### PR TITLE
refactor(gui): close the parallel user-defaults write surface (434)

### DIFF
--- a/doc/gui-state-governance.md
+++ b/doc/gui-state-governance.md
@@ -169,4 +169,8 @@
 
 ### 8.8 与 `ConfigSnapshot` / Revert baseline 的边界
 
-`GuiState::ConfigSnapshot`（`gui_state.hpp:1101`）只覆盖七个配置字段（晶体 / filter / layer / `sun` / `sim` / `renderer` / 染色规则），不含任何 `kView` 字段——而本层的默认值候选恰恰以 `kView` 为主力。默认值层复用的是 `ConfigSnapshot` 背后"两份状态结构化 diff、按需派生效果"的**模式**，但不能复用其 struct：两者覆盖的字段集合不同，把默认值的 diff 引擎强行套进 `ConfigSnapshot` 会连带改动 Revert 语义。
+`GuiState::ConfigSnapshot`（`gui_state.hpp:1101`）只覆盖七个配置字段（晶体 / filter / layer / `sun` / `sim` / `renderer` / 染色规则），其中没有任何一个**顶层字段**登记为 `FieldTier::kView`——而本层的默认值候选恰恰以 `kView` 为主力（`bg_*` / `show_*` / 各类颜色与 alpha / 面板折叠态）。
+
+⚠️ 但"没有 `kView` 顶层字段"不等于"没有视图性的设置"：档位登记在**顶层字段**这一粒度上（`renderer` 整体登记为 `kStructSoft`，`gui_state_tiers.hpp`），而 `ConfigSnapshot::renderer` 拷贝的是整份 `RenderConfig`，所以镜头 / fov / elevation / azimuth / roll / visible / front 这些纯显示侧的控制项是以**结构体成员**的形式被包含在快照里的，只是不作为独立字段出现在上面那份七项清单中。读这一段时不要把它读成"这些控制项不在 Revert 的作用域内"——它们在。Revert **应当**覆盖哪些字段是一个独立的语义问题，不在本节范围内。
+
+默认值层复用的是 `ConfigSnapshot` 背后"两份状态结构化 diff、按需派生效果"的**模式**，但不能复用其 struct：两者覆盖的字段集合不同，把默认值的 diff 引擎强行套进 `ConfigSnapshot` 会连带改动 Revert 语义。

--- a/scripts/check_policies.py
+++ b/scripts/check_policies.py
@@ -1233,7 +1233,10 @@ USER_DEFAULTS_STORE_CPP = SRC / "gui" / "user_defaults.cpp"
 USER_DEFAULTS_FILENAME_OWNERS = frozenset({USER_DEFAULTS_STORE_HPP, USER_DEFAULTS_STORE_CPP})
 USER_DEFAULTS_WRITE_CALL = re.compile(r"\bWriteUserDefaultsFile\s*\(")
 # The declaration in the header and the definition in the .cpp, told apart from a
-# call by the leading return type.
+# call by the leading return type. This assumes both stay on one line and start with
+# a bare `bool`: adding `[[nodiscard]]`/`static`, or breaking the return type onto its
+# own line, makes the signature look like a call and the check fire on a clean tree.
+# Change the signature, change this regex — and re-run the red probe both ways.
 USER_DEFAULTS_WRITE_SIGNATURE = re.compile(r"^\s*bool\s+WriteUserDefaultsFile\s*\(")
 USER_DEFAULTS_FILENAME_SYMBOL = re.compile(r"\bkUserDefaultsFileName\b")
 
@@ -1278,12 +1281,23 @@ def check_user_defaults_single_write_path() -> list[Violation]:
             call_sites.append((path, lineno))
 
     if len(call_sites) != 1:
-        message = (
-            f"WriteUserDefaultsFile() must have exactly ONE caller under src/ "
-            f"(defaults_diff.cpp's WriteActiveOverlayDoc); found {len(call_sites)}. "
-            "A second writer is a second answer to 'what did the user save' — commit "
-            "the whole document through WriteActiveOverlayDoc instead. See AGENTS.md."
-        )
+        if call_sites:
+            message = (
+                f"WriteUserDefaultsFile() must have exactly ONE caller under src/ "
+                f"(defaults_diff.cpp's WriteActiveOverlayDoc); found {len(call_sites)}. "
+                "A second writer is a second answer to 'what did the user save' — commit "
+                "the whole document through WriteActiveOverlayDoc instead. See AGENTS.md."
+            )
+        else:
+            # Anchored on the signature, so say so: the line being pointed at is the
+            # declaration/definition, not an offending call. Without this wording the
+            # message reads as "this signature is the violation".
+            message = (
+                "WriteUserDefaultsFile() has NO caller under src/ — the one write path "
+                "(defaults_diff.cpp's WriteActiveOverlayDoc) is gone, so nothing commits "
+                "the user's defaults any more. This line is the signature the check "
+                "anchored on, not the fault. See AGENTS.md."
+            )
         # Nothing to point at when the count is zero, so anchor on the definition
         # rather than dropping the diagnostic.
         anchors = call_sites or signature_sites

--- a/scripts/check_policies.py
+++ b/scripts/check_policies.py
@@ -82,7 +82,17 @@ Checks:
      (single owner of the pre-abort trap — call lumice::FatalAbort instead of
      hand-rolling print-then-abort). Scans .cu/.metal too, so a GPU backend
      cannot reopen the side channel; test/ is deliberately out of scope.
-  13. pytest-invocation-marker — a pytest call site (test/CMakeLists.txt's
+  13. user-defaults-single-write-path — the personal-defaults override file has
+     ONE writer under src/: WriteUserDefaultsFile is called from exactly one
+     place (defaults_diff.cpp's WriteActiveOverlayDoc), and kUserDefaultsFileName
+     is named only by the store that owns it (src/gui/user_defaults.*). The rule
+     exists because the file once had two write paths: the defaults panel's move
+     to the copy model changed the callers and copied the implementation, leaving
+     the superseded read-mutate-write wrappers in place — unreachable, and still
+     asserting in a comment that they were the only place a key gets written.
+     Both halves are regex, so neither proves a second path does not exist; the
+     limits are enumerated at the check's own docstring.
+  14. pytest-invocation-marker — a pytest call site (test/CMakeLists.txt's
      add_test, scripts/*.sh, doc/**/*.md and AGENTS.md fenced recipes) that
      names a `.py` target must pass its own `-m`. Without one it inherits
      pyproject.toml's `addopts = ["-m", "not slow"]`, and a slow-only target
@@ -1206,6 +1216,99 @@ def check_no_bare_print() -> list[Violation]:
     return out
 
 
+# --- user-defaults-single-write-path ---------------------------------------
+#
+# The personal-defaults override file has exactly one writer, and the rule exists
+# because it once had two. Moving the defaults panel to the copy model changed the
+# callers and copied the implementation; the superseded read-mutate-write wrappers
+# stayed behind, unreachable from production and still carrying their own "this is
+# the only place that turns a … into a written key" comment. Nothing failed, so
+# nothing surfaced it — the contracts they claimed to protect were simply no longer
+# being asserted about the code that runs.
+USER_DEFAULTS_STORE_HPP = SRC / "gui" / "user_defaults.hpp"
+USER_DEFAULTS_STORE_CPP = SRC / "gui" / "user_defaults.cpp"
+# Both files, not just the .cpp: the constant is DEFINED in the header
+# (user_defaults.hpp's kUserDefaultsFileName), so exempting only the .cpp would make
+# the rule fail on a clean tree.
+USER_DEFAULTS_FILENAME_OWNERS = frozenset({USER_DEFAULTS_STORE_HPP, USER_DEFAULTS_STORE_CPP})
+USER_DEFAULTS_WRITE_CALL = re.compile(r"\bWriteUserDefaultsFile\s*\(")
+# The declaration in the header and the definition in the .cpp, told apart from a
+# call by the leading return type.
+USER_DEFAULTS_WRITE_SIGNATURE = re.compile(r"^\s*bool\s+WriteUserDefaultsFile\s*\(")
+USER_DEFAULTS_FILENAME_SYMBOL = re.compile(r"\bkUserDefaultsFileName\b")
+
+
+def check_user_defaults_single_write_path() -> list[Violation]:
+    """The override file has ONE writer under src/, reached through ONE wrapper.
+
+    Two sub-checks, deliberately one registered rule because they are two faces of
+    the same policy ("there is one write path"), each emitting its own wording so a
+    violation is still attributable:
+
+      A  — WriteUserDefaultsFile() is called from exactly one place in src/
+           (defaults_diff.cpp's WriteActiveOverlayDoc). Signature lines are not
+           calls and are excluded.
+      A' — kUserDefaultsFileName is referenced only by the store itself
+           (user_defaults.hpp defines it, user_defaults.cpp reads and writes
+           through it). Composing that filename anywhere else is how a second
+           writer would be opened WITHOUT going through the wrapper, which A alone
+           cannot see.
+
+    WHAT THIS RULE DOES NOT CLAIM. Both halves are plain regex over comment-stripped
+    lines, the same instrument as no-bare-print, so neither can see: a call reached
+    through a function pointer or std::function; a path built from a hand-written
+    "user_defaults.json" literal or an assembled/macro-pasted one that never names
+    the constant; or a writer opened outside src/ (test/ deliberately has several —
+    the harness seeds override files directly). The rule stops someone from casually
+    adding a second writer. It is NOT evidence that no second write path exists, and
+    reading a green run as that would be the same mistake the deleted wrappers were:
+    a claim of uniqueness that nothing checked.
+    """
+    out: list[Violation] = []
+
+    call_sites: list[tuple[Path, int]] = []
+    signature_sites: list[tuple[Path, int]] = []
+    for path in cxx_sources(SRC):
+        for lineno, _orig, code in code_lines(path):
+            if not USER_DEFAULTS_WRITE_CALL.search(code):
+                continue
+            if USER_DEFAULTS_WRITE_SIGNATURE.match(code):
+                signature_sites.append((path, lineno))
+                continue
+            call_sites.append((path, lineno))
+
+    if len(call_sites) != 1:
+        message = (
+            f"WriteUserDefaultsFile() must have exactly ONE caller under src/ "
+            f"(defaults_diff.cpp's WriteActiveOverlayDoc); found {len(call_sites)}. "
+            "A second writer is a second answer to 'what did the user save' — commit "
+            "the whole document through WriteActiveOverlayDoc instead. See AGENTS.md."
+        )
+        # Nothing to point at when the count is zero, so anchor on the definition
+        # rather than dropping the diagnostic.
+        anchors = call_sites or signature_sites
+        for path, lineno in anchors:
+            out.append(Violation(path, lineno, "user-defaults-single-write-path", message))
+
+    for path in cxx_sources(SRC):
+        if path in USER_DEFAULTS_FILENAME_OWNERS:
+            continue
+        for lineno, _orig, code in code_lines(path):
+            if USER_DEFAULTS_FILENAME_SYMBOL.search(code):
+                out.append(
+                    Violation(
+                        path,
+                        lineno,
+                        "user-defaults-single-write-path",
+                        "kUserDefaultsFileName belongs to the store (src/gui/user_defaults.*). "
+                        "Naming it elsewhere means composing the override file's path outside the "
+                        "one function that owns reading and writing it — route through "
+                        "ReadActiveOverlayDoc / WriteActiveOverlayDoc. See AGENTS.md.",
+                    )
+                )
+    return out
+
+
 # --- pytest-invocation-marker ----------------------------------------------
 #
 # `pyproject.toml`'s `addopts = ["-m", "not slow"]` pins a bare `pytest` to the
@@ -1532,6 +1635,7 @@ CHECKS = [
     check_no_default_constructed_crystal_slots,
     check_gui_test_suite_args_sync,
     check_no_bare_print,
+    check_user_defaults_single_write_path,
     check_pytest_invocation_marker,
 ]
 
@@ -1557,7 +1661,7 @@ def main() -> int:
         "reconciler-widget-include, using-namespace, struct-layout parity, no-config-by-value-copy, "
         "gui-state-field-tier-registration, no-msvc-unsafe-builtin, "
         "no-default-constructed-crystal-slots, gui-test-suite-args-sync, no-bare-print, "
-        "pytest-invocation-marker)."
+        "user-defaults-single-write-path, pytest-invocation-marker)."
     )
     return 0
 

--- a/src/gui/defaults_diff.cpp
+++ b/src/gui/defaults_diff.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cstdio>
-#include <functional>
 #include <optional>
 #include <string_view>
 #include <utility>
@@ -176,61 +175,10 @@ bool SerializeCurrentState(const GuiState& current, json& out) {
   return true;
 }
 
-// The accepted-key copy itself, given an ALREADY serialized current document. Split out so
-// SaveAcceptedDefaults can fail before it opens the file: a serialization failure must leave the
-// override file untouched, not rewrite it unchanged.
-void ApplyAcceptedKeys(json& doc, const std::vector<std::string>& accepted_key_paths, const json& current_json) {
-  for (const auto& key_path : accepted_key_paths) {
-    const auto tokens = SplitKeyPath(key_path);
-    if (tokens.empty() || IsExcludedRootKey(tokens.front())) {
-      // Defense in depth: the panel never offers an excluded key, but this is the only place
-      // that turns a string into a written key, and a namespace-4 key path in the file would
-      // be read back by MakeNewDocumentState.
-      continue;
-    }
-    if (const json* value = FindByPath(current_json, tokens)) {
-      SetByPath(doc, tokens, *value);
-    } else {
-      ErasePath(doc, tokens);
-    }
-  }
-}
-
 // Drop one key path from `doc`, so it falls back to the factory value. Empty parent objects left
 // behind are pruned, keeping the file readable by hand.
 void EraseKeyPath(json& doc, const std::string& key_path) {
   ErasePath(doc, SplitKeyPath(key_path));
-}
-
-// Drop every GuiState key from `doc`. "presets" survives untouched — it belongs to namespace 2 and
-// is not what this panel edits.
-void EraseEveryGuiStateKey(json& doc) {
-  json preserved = json::object();
-  // Namespace 2 (the preset library) is a sibling section this panel does not edit. Keeping it
-  // by name — rather than deleting the GuiState keys one by one — means a future GuiState key
-  // is reset without anyone having to remember to add it here.
-  const auto presets = doc.find("presets");
-  if (presets != doc.end()) {
-    preserved["presets"] = *presets;
-  }
-  doc = std::move(preserved);
-}
-
-// Shared read-modify-write for all three disk-side wrappers. `mutate` receives the EXISTING document
-// (never a fresh one), so a subtree this panel does not own — "presets" above all — survives every
-// write by construction rather than by three call sites each remembering to preserve it.
-bool UpdateOverlayDocument(const std::function<void(json&)>& mutate) {
-  const auto dir = GetActiveUserConfigDir();
-  if (!dir) {
-    GUI_LOG_WARNING("[GUI] User defaults: no user-config directory available; nothing was saved");
-    return false;
-  }
-  json doc = ReadOverlayJsonIfPresent(*dir);
-  if (!doc.is_object()) {
-    doc = json::object();
-  }
-  mutate(doc);
-  return WriteUserDefaultsFile(*dir, doc);
 }
 
 }  // namespace
@@ -383,24 +331,6 @@ bool ApplyCheckedRowsToDoc(nlohmann::json& doc, const std::vector<DefaultDiffRow
     }
   }
   return true;
-}
-
-bool SaveAcceptedDefaults(const std::vector<std::string>& accepted_key_paths, const GuiState& current) {
-  json current_json;
-  if (!SerializeCurrentState(current, current_json)) {
-    // Deliberately before UpdateOverlayDocument: a failure here must leave the file untouched
-    // rather than rewrite it without the keys it was asked to adopt.
-    return false;
-  }
-  return UpdateOverlayDocument([&](json& doc) { ApplyAcceptedKeys(doc, accepted_key_paths, current_json); });
-}
-
-bool RevertOneDefault(const std::string& key_path) {
-  return UpdateOverlayDocument([&](json& doc) { EraseKeyPath(doc, key_path); });
-}
-
-bool ResetAllDefaults() {
-  return UpdateOverlayDocument([](json& doc) { EraseEveryGuiStateKey(doc); });
 }
 
 }  // namespace lumice::gui

--- a/src/gui/defaults_diff.hpp
+++ b/src/gui/defaults_diff.hpp
@@ -91,10 +91,15 @@ nlohmann::json ReadActiveOverlayDoc();
 
 // Writes `doc` verbatim to the active user-config directory's override file. Public for the same
 // reason ReadActiveOverlayDoc is: the panel's Save is a whole-document commit (it builds the next
-// document in memory, then writes it), not a read-mutate-write of one key, so it needs the write
-// half of UpdateOverlayDocument's directory resolution without the read/mutate half. A second
-// inline GetActiveUserConfigDir() + WriteUserDefaultsFile() at the call site would be the same
-// drift risk ReadActiveOverlayDoc's comment already flags for the read side.
+// document in memory, then writes it), so it needs that directory resolution once, in one place.
+// A second inline GetActiveUserConfigDir() + WriteUserDefaultsFile() at the call site would be the
+// same drift risk ReadActiveOverlayDoc's comment already flags for the read side.
+//
+// THE ONLY WRITER of the override file outside user_defaults.cpp's own WriteUserDefaultsFile, and
+// meant to stay that way: a second write path is a second answer to "what did the user save", and
+// this file has already carried one (an unreachable set of read-mutate-write wrappers left behind
+// by the panel's move to the copy model, complete with its own "this is the only place…" comment).
+// scripts/check_policies.py enforces the call-site count.
 bool WriteActiveOverlayDoc(const nlohmann::json& doc);
 
 // The whole row set for `current`, against the currently effective defaults (factory + whatever is
@@ -177,22 +182,6 @@ bool RowWouldChangeOnSave(const DefaultDiffRow& row, bool checked);
 // first mutation, which is what makes the whole call all-or-nothing.
 bool ApplyCheckedRowsToDoc(nlohmann::json& doc, const std::vector<DefaultDiffRow>& rows,
                            const std::set<std::string>& checked_key_paths, const GuiState& current);
-
-// ------------------------------------------------------------------------------------------------
-// Disk-side wrappers: read the override file, apply one surgical edit, write it back.
-//
-// The panel does NOT use these — it is a pure editor and commits once, through its own copy (see
-// defaults_panel.cpp). They are the one-shot committed-edit API, and today their only callers are
-// test_defaults_diff.cpp: they are the entry point through which the surgical-write contract
-// (untouched keys survive, the "presets" subtree survives, a missing config directory reports
-// failure, a clobbered non-object path node files a downgrade notice) is exercised.
-// ------------------------------------------------------------------------------------------------
-
-bool SaveAcceptedDefaults(const std::vector<std::string>& accepted_key_paths, const GuiState& current);
-
-bool RevertOneDefault(const std::string& key_path);
-
-bool ResetAllDefaults();
 
 }  // namespace lumice::gui
 

--- a/src/gui/user_defaults.cpp
+++ b/src/gui/user_defaults.cpp
@@ -447,29 +447,6 @@ void AdoptAxisPresetZenithStdOverrideInMemory(AxisPreset preset, std::optional<f
   g_axis_overrides.slots[slot] = stored_value ? AxisPresetOverride{ true, *stored_value } : AxisPresetOverride{};
 }
 
-bool RevertOneAxisPresetOverride(AxisPreset preset) {
-  const AxisPresetEntry& entry = AxisPresetEntryFor(preset);
-  if (!entry.has_adjustable_zenith_std || entry.override_json_name == nullptr) {
-    return false;  // nothing can be stored for it, so there is nothing to restore
-  }
-
-  const auto dir = GetActiveUserConfigDir();
-  if (!dir) {
-    GUI_LOG_WARNING("[GUI] User defaults: no user-config directory available; nothing was changed");
-    return false;
-  }
-  nlohmann::json doc = ReadOverlayJsonIfPresent(*dir);
-  EraseAxisPresetZenithStdFromDoc(doc, preset);
-
-  if (!WriteUserDefaultsFile(*dir, doc)) {
-    return false;
-  }
-  // Disk first, memory second (see the header): a failed write above returns with the in-memory
-  // override still in place, which is what the next launch would read back anyway.
-  AdoptAxisPresetZenithStdOverrideInMemory(preset, std::nullopt);
-  return true;
-}
-
 AxisDist EffectiveAxisPresetZenith(const AxisPresetEntry& entry) {
   AxisDist zenith = entry.zenith;
   if (const auto stored = GetUserAxisPresetZenithStdOverride(entry.id)) {

--- a/src/gui/user_defaults.hpp
+++ b/src/gui/user_defaults.hpp
@@ -330,6 +330,14 @@ void ApplyUserDefaultsOverlay(GuiState& state, const nlohmann::json& doc);
 // The user's zenith-std override for a built-in axis preset, if any. nullopt means "use the
 // factory value". Prefer EffectiveAxisPresetZenith() below at consumption sites — this raw
 // accessor exists for the tests and for the panel's "is anything saved for this preset" cell.
+//
+// IT CANNOT BE FOLDED INTO EffectiveAxisPresetZenith, and has been mistaken for dead code twice
+// on the assumption that it can. That function returns the COMPOSED AxisDist, in which "nothing
+// stored" and "stored a number that happens to equal the factory value" are indistinguishable —
+// the two produce the same struct. Only this accessor answers the question the panel and the
+// tests actually ask, which is about the OVERRIDE's existence and not about the resulting
+// distribution: the same presence-vs-value distinction DefaultDiffRow::has_saved_override draws
+// for the settings half of the file.
 std::optional<float> GetUserAxisPresetZenithStdOverride(AxisPreset preset);
 
 // --------------------------------------------------------------------------------------------------

--- a/src/gui/user_defaults.hpp
+++ b/src/gui/user_defaults.hpp
@@ -399,13 +399,11 @@ void EraseAxisPresetZenithStdFromDoc(nlohmann::json& doc, AxisPreset preset);
 // For a caller that has ALREADY committed the document itself — the defaults panel writes its
 // whole working copy in one go, so by the time it calls this the value is on disk. Nothing else
 // should: memory that leads disk is exactly how "what this session resolves" and "what the next
-// launch reads" drift apart, which is why RevertOneAxisPresetOverride below does the file first.
+// launch reads" drift apart. That ordering is the panel's own to keep, and it says so at the call
+// site (defaults_panel.cpp's CommitCopy, "ORDER IS PART OF THE CONTRACT"); there is deliberately
+// no store-side revert wrapper composing the two here, because a second writer of this file is a
+// second answer to "what did the user save".
 void AdoptAxisPresetZenithStdOverrideInMemory(AxisPreset preset, std::optional<float> stored_value);
-
-// Drop the user's override for one preset, returning it to the factory value. Disk first, memory
-// second — the reverse order would leave a failed write reporting success in this session and
-// resurrecting the old value on the next launch. Other presets and the GuiState half are untouched.
-bool RevertOneAxisPresetOverride(AxisPreset preset);
 
 // The zenith distribution a preset button actually writes: the factory row, with the user's std
 // substituted when one is stored. Single source for that resolution — the axis modal's preset

--- a/test/gui/functional/test_gui_defaults_panel.cpp
+++ b/test/gui/functional/test_gui_defaults_panel.cpp
@@ -1094,6 +1094,72 @@ void RegisterDefaultsPanelTests(ImGuiTestEngine* engine) {
     };
   }
 
+  {
+    // A Save that could not write must leave the process-wide preset cache exactly as it was.
+    // Otherwise this session resolves one value for the Column button while the next launch reads
+    // the older one off disk, and the user watches their setting "come back" with no event to
+    // attribute it to.
+    //
+    // WHY THIS IS A gui_test AND NOT A PURE UNIT TEST. The contract is not a property of any
+    // single function: it is the ORDER in which CommitCopy composes two of them — write the
+    // document, and only if that succeeded push the changed presets into the cache
+    // (defaults_panel.cpp, the "ORDER IS PART OF THE CONTRACT" comment, which is the only one of
+    // its kind in the repo). Extracting the decision into a pure `ShouldAdopt(bool
+    // write_succeeded, ...)` is perfectly possible, and that is exactly the problem: the unit test
+    // would then assert that `write_succeeded == false` yields no adoptions, i.e. restate the `if`
+    // it was extracted from, while the side that can actually break — does the production call
+    // site really write first, and does it really leave before the adopt loop — moves out of view
+    // and reports as covered. So the case drives the real Save button, twice: once where the write
+    // fails and once where it lands.
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "defaults_panel", "save_failure_leaves_the_preset_cache_untouched");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      const auto dir = FreshOverlayDir("panel_save_fail");
+      std::optional<std::string> before_bytes;
+      {
+        ScopedUserConfigSource guard(gui::UserConfigSource::kExplicitDir, dir);
+        ResetTestState();
+        ResetUserDefaultsChannels();
+
+        json doc;
+        doc["presets"]["axis"]["column"]["zenith_std"] = 0.3f;
+        IM_CHECK(gui::WriteUserDefaultsFile(dir, doc));
+        gui::g_state = gui::MakeNewDocumentState();
+
+        OpenPanelOn(ctx, gui::DefaultsPanelSection::kPresets);
+        ctx->ItemOpen("**/###preset_Column");
+        ctx->Yield(2);
+        ctx->ItemInputValue("**/###preset_std_column", 0.7f);
+        ctx->Yield(3);
+        before_bytes = ReadOverlayBytes(dir);
+      }
+      IM_CHECK(before_bytes.has_value());
+      const auto before_cache = gui::GetUserAxisPresetZenithStdOverride(gui::AxisPreset::kColumn);
+      IM_CHECK(before_cache.has_value());
+      IM_CHECK_EQ(*before_cache, 0.3f);
+
+      // No writable directory at all — the same shape as a config directory that has become
+      // read-only between opening the panel and pressing Save.
+      {
+        ScopedUserConfigSource disabled(gui::UserConfigSource::kDisabled);
+        SaveDefaultsPanel(ctx);
+        IM_CHECK_EQ(gui::GetUserAxisPresetZenithStdOverride(gui::AxisPreset::kColumn), before_cache);
+        IM_CHECK_EQ(ReadOverlayBytes(dir), before_bytes);
+      }
+
+      // The same button, with somewhere to write again: the edit lands, in the file AND in the
+      // cache. This is what makes the assertions above a claim about the FAILED write rather than
+      // about a click that never reached CommitCopy at all — and it is the half that turns red if
+      // the adopt loop is moved ahead of the write instead of behind it.
+      {
+        ScopedUserConfigSource writable(gui::UserConfigSource::kExplicitDir, dir);
+        SaveDefaultsPanel(ctx);
+        IM_CHECK_EQ(gui::GetUserAxisPresetZenithStdOverride(gui::AxisPreset::kColumn).value_or(-1.0f), 0.7f);
+        IM_CHECK_EQ(ReadPresetStd(ReadOverlayFile(dir), "column").value_or(-1.0f), 0.7f);
+        CloseDefaultsPanel(ctx);
+      }
+    };
+  }
+
   // RETIRED: copy_ac4_source_follows_copy_section_follows_snapshot.
   //
   // It asserted that a row's Source cell and Revert button tracked the WORKING COPY while its

--- a/test/unit-correctness/gui/test_defaults_diff.cpp
+++ b/test/unit-correctness/gui/test_defaults_diff.cpp
@@ -645,7 +645,11 @@ TEST(DefaultsDiff, replacing_a_non_object_path_node_is_not_silent) {
 
   EXPECT_EQ(gui::TakeUserDefaultsDowngradeCount(), 1);
   const auto notices = gui::TakeUserDefaultsDowngradeNotices();
-  EXPECT_EQ(notices.size(), static_cast<size_t>(1));
+  // ASSERT, not EXPECT: the very regression this case exists to catch is "no notice was filed",
+  // and indexing an empty vector on the next line would take this single-process binary down with
+  // a SIGSEGV — hiding every case after it behind a crash instead of a diagnosis. Measured while
+  // red-probing this assertion.
+  ASSERT_EQ(notices.size(), static_cast<size_t>(1));
   EXPECT_TRUE(notices[0].find("renderer") != std::string::npos);
 
   // The write still landed — the notice reports the loss, it does not refuse the edit.

--- a/test/unit-correctness/gui/test_defaults_diff.cpp
+++ b/test/unit-correctness/gui/test_defaults_diff.cpp
@@ -492,60 +492,76 @@ TEST(DefaultsDiff, apply_checked_rows_removes_an_absent_optional_key) {
 }
 
 // ================================================================================
-// Write-back contract (the disk-side wrappers)
+// Write-back contract, asserted on the pair the panel's Save actually calls
+// (ApplyCheckedRowsToDoc -> WriteActiveOverlayDoc)
 // ================================================================================
-TEST(DefaultsDiff, write_back_is_surgical_and_keeps_presets) {
+
+// Surgical writes, asserted FILE-side: what the panel commits must edit the keys its rows name
+// and leave every other key of the document exactly where it was.
+//
+// The sibling "presets" subtree is the first-order case (it belongs to the preset library, and a
+// wholesale rewrite here would delete a user's preset overrides), but it is not the only one: a
+// key written by an OLDER version, whose GuiState field has since been removed, produces no row
+// either. Both survive for the same structural reason — the rule only ever touches keys a row
+// names — so both are asserted here, the second one because it is the case no other test covers
+// and the one that would silently start disappearing if the rule were ever rewritten as
+// "keep the keys we know about".
+//
+// Runs the pair together, through the file, rather than asserting on the in-memory document
+// alone: apply_checked_rows_adopts_and_removes_in_one_pass already pins the pure rule, and what
+// is added here is that the document survives the trip to disk unchanged.
+TEST(DefaultsDiff, live_write_back_is_surgical_and_keeps_keys_no_row_names) {
   ResetUserDefaultsChannels();
-  const auto dir = FreshOverlayDir("diff_write");
+  const auto dir = FreshOverlayDir("diff_live_write");
   ScopedUserConfigSource guard(gui::UserConfigSource::kExplicitDir, dir);
 
-  // A pre-existing document with a preset-library subtree this panel does not own.
+  // A pre-existing document with a preset-library subtree this panel does not own, plus a
+  // GuiState key that IS in today's schema (so it produces a row) and one that is not.
   json existing;
   existing["presets"]["axis"]["column"]["zenith_std"] = 0.3f;
   existing["bg_show"] = true;
+  existing["a_key_no_current_field_serializes"] = 7;
   EXPECT_TRUE(gui::WriteUserDefaultsFile(dir, existing));
 
-  gui::GuiState state = MakeEditedState();
-  EXPECT_TRUE(gui::SaveAcceptedDefaults({ "renderer.lens_type", "bg_alpha" }, state));
+  const gui::GuiState state = MakeEditedState();
+  const auto rows = gui::BuildDefaultDiffRows(state, existing);
+  // The premise both halves of this case rest on, asserted rather than assumed: one of the two
+  // extra keys is named by a row and the other is not.
+  ASSERT_TRUE(FindRow(rows, "bg_show") != nullptr);
+  ASSERT_TRUE(FindRow(rows, "a_key_no_current_field_serializes") == nullptr);
 
-  json saved = ReadOverlayFile(dir);
+  json next = existing;
+  EXPECT_TRUE(gui::ApplyCheckedRowsToDoc(next, rows, { "renderer.lens_type", "bg_alpha" }, state));
+  EXPECT_TRUE(gui::WriteActiveOverlayDoc(next));
+
+  const json saved = ReadOverlayFile(dir);
   EXPECT_STREQ(saved["renderer"]["lens_type"].get<std::string>().c_str(), "fisheye_equal_area");
   EXPECT_EQ(saved["bg_alpha"].get<float>(), 0.42f);
-  // Untouched keys of both kinds survive: the sibling namespace-2 subtree AND a namespace-1
-  // key this call did not mention.
+  // Untouched keys of both kinds survive: the sibling namespace-2 subtree AND the key no row
+  // names.
   EXPECT_TRUE(saved.contains("presets"));
   EXPECT_EQ(saved["presets"]["axis"]["column"]["zenith_std"].get<float>(), 0.3f);
-  EXPECT_EQ(saved["bg_show"].get<bool>(), true);
-  // A key that was never adopted must not be written just because it was serialized.
-  EXPECT_TRUE(!saved.contains("sun"));
-
-  // Revert removes exactly one key and prunes the object it emptied.
-  EXPECT_TRUE(gui::RevertOneDefault("renderer.lens_type"));
-  saved = ReadOverlayFile(dir);
-  EXPECT_TRUE(!saved.contains("renderer"));
-  EXPECT_TRUE(saved.contains("bg_alpha"));
-  EXPECT_TRUE(saved.contains("presets"));
-
-  // Reset all drops every GuiState key and keeps the preset library.
-  EXPECT_TRUE(gui::ResetAllDefaults());
-  saved = ReadOverlayFile(dir);
-  EXPECT_TRUE(!saved.contains("bg_alpha"));
+  EXPECT_EQ(saved.value("a_key_no_current_field_serializes", 0), 7);
+  // bg_show, by contrast, HAS a row and was left un-checked, so the same pass removes it. That
+  // is the line separating "not mentioned" from "mentioned and declined".
   EXPECT_TRUE(!saved.contains("bg_show"));
-  EXPECT_TRUE(saved.contains("presets"));
-  EXPECT_EQ(saved["presets"]["axis"]["column"]["zenith_std"].get<float>(), 0.3f);
-  EXPECT_EQ(saved.size(), static_cast<size_t>(1));
+  // A key that was never checked must not be written just because it was serialized.
+  EXPECT_TRUE(!saved.contains("sun"));
 }
 
 // No writable config directory (--no-user-config, or an OS that gave us nowhere to write):
-// every write reports failure instead of silently claiming success, and nothing is created.
-TEST(DefaultsDiff, write_back_reports_failure_without_a_directory) {
+// the write reports failure instead of silently claiming success, and nothing is created.
+TEST(DefaultsDiff, live_write_back_reports_failure_without_a_directory) {
   ResetUserDefaultsChannels();
   ScopedUserConfigSource guard(gui::UserConfigSource::kDisabled);
 
   const gui::GuiState state = MakeEditedState();
-  EXPECT_TRUE(!gui::SaveAcceptedDefaults({ "bg_alpha" }, state));
-  EXPECT_TRUE(!gui::RevertOneDefault("bg_alpha"));
-  EXPECT_TRUE(!gui::ResetAllDefaults());
+  json doc;
+  doc["bg_alpha"] = state.bg_alpha;
+  EXPECT_TRUE(!gui::WriteActiveOverlayDoc(doc));
+  // Nothing was created to write into, so the read side still answers "nothing saved" rather
+  // than reporting a document this call invented.
+  EXPECT_TRUE(gui::ReadActiveOverlayDoc().empty());
 
   // And the row set still builds — the panel must remain usable (read-only) in this state.
   EXPECT_TRUE(!gui::BuildDefaultDiffRows(state).empty());
@@ -613,12 +629,19 @@ TEST(DefaultsDiff, replacing_a_non_object_path_node_is_not_silent) {
   json doc;
   doc["renderer"] = 3;  // a scalar where an object belongs
   EXPECT_TRUE(gui::WriteUserDefaultsFile(dir, doc));
-  // Draining first: reading that file back is itself fine (it is valid JSON), but this keeps
-  // the assertion below about the WRITE and nothing else.
+
+  const gui::GuiState state = MakeEditedState();
+  // Built BEFORE the drain below, deliberately: this is the panel's opening snapshot, and
+  // overlaying a document whose "renderer" is a scalar is itself a degradation the loader is
+  // entitled to report. Draining after it keeps the assertions below about the WRITE and
+  // nothing else.
+  const auto rows = gui::BuildDefaultDiffRows(state, doc);
   gui::TakeUserDefaultsDowngradeCount();
   gui::TakeUserDefaultsDowngradeNotices();
 
-  EXPECT_TRUE(gui::SaveAcceptedDefaults({ "renderer.fov" }, MakeEditedState()));
+  json next = doc;
+  EXPECT_TRUE(gui::ApplyCheckedRowsToDoc(next, rows, { "renderer.fov" }, state));
+  EXPECT_TRUE(gui::WriteActiveOverlayDoc(next));
 
   EXPECT_EQ(gui::TakeUserDefaultsDowngradeCount(), 1);
   const auto notices = gui::TakeUserDefaultsDowngradeNotices();
@@ -645,7 +668,17 @@ TEST(DefaultsDiff, an_ordinary_write_reports_no_downgrade) {
   const auto dir = FreshOverlayDir("setbypath_quiet");
   ScopedUserConfigSource guard(gui::UserConfigSource::kExplicitDir, dir);
 
-  EXPECT_TRUE(gui::SaveAcceptedDefaults({ "renderer.fov", "bg_alpha" }, MakeEditedState()));
+  const gui::GuiState state = MakeEditedState();
+  const auto rows = gui::BuildDefaultDiffRows(state, json::object());
+  gui::TakeUserDefaultsDowngradeCount();
+  gui::TakeUserDefaultsDowngradeNotices();
+
+  json next = json::object();
+  EXPECT_TRUE(gui::ApplyCheckedRowsToDoc(next, rows, { "renderer.fov", "bg_alpha" }, state));
+  EXPECT_TRUE(gui::WriteActiveOverlayDoc(next));
+  // The premise: the write really did create the nested object the notice would have described,
+  // so a silent zero here is "no loss to report" rather than "no write happened".
+  EXPECT_TRUE(next["renderer"].is_object());
   EXPECT_EQ(gui::TakeUserDefaultsDowngradeCount(), 0);
   EXPECT_TRUE(gui::TakeUserDefaultsDowngradeNotices().empty());
 }

--- a/test/unit-correctness/gui/test_user_defaults.cpp
+++ b/test/unit-correctness/gui/test_user_defaults.cpp
@@ -117,6 +117,26 @@ bool SeedPresetOverrideOnDisk(const std::filesystem::path& dir, gui::AxisPreset 
   return gui::WriteUserDefaultsFile(dir, doc);
 }
 
+// Drop one preset override the way the panel's Restore button and Save do: erase the key from the
+// working document through its production owner, write the whole document, and only THEN let the
+// process-wide cache follow — disk first, memory second, the order defaults_panel.cpp's CommitCopy
+// calls out as part of the contract.
+//
+// Spelled out here rather than called through one store-side function because there is no longer
+// one: the disk-side revert wrapper this file used to call was a second write path that the panel
+// itself never went through, and the live path composes these three primitives at its own call
+// site. The assertions below are about the DOCUMENT shape the erase leaves behind, which is
+// EraseAxisPresetZenithStdFromDoc's own contract and the half a wholesale rewrite would break.
+bool RestoreOnePresetOnDisk(const std::filesystem::path& dir, gui::AxisPreset preset) {
+  json doc = ReadOverlayDoc(dir);
+  gui::EraseAxisPresetZenithStdFromDoc(doc, preset);
+  if (!gui::WriteUserDefaultsFile(dir, doc)) {
+    return false;
+  }
+  gui::AdoptAxisPresetZenithStdOverrideInMemory(preset, std::nullopt);
+  return true;
+}
+
 }  // namespace
 
 // ================================================================================
@@ -853,7 +873,7 @@ TEST(UserDefaults, preset_restore_to_factory_is_surgical) {
     EXPECT_EQ(after_two_writes.value("bg_alpha", 0.0f), 0.42f);
   }
 
-  EXPECT_TRUE(gui::RevertOneAxisPresetOverride(gui::AxisPreset::kColumn));
+  EXPECT_TRUE(RestoreOnePresetOnDisk(dir, gui::AxisPreset::kColumn));
 
   // Factory again, field by field against the table itself.
   const auto& column = gui::AxisPresetEntryFor(gui::AxisPreset::kColumn);
@@ -873,7 +893,7 @@ TEST(UserDefaults, preset_restore_to_factory_is_surgical) {
 
   // Reverting the last preset prunes the now-empty parents, so a hand-opened file does not
   // accumulate `"presets": {"axis": {}}` skeletons.
-  EXPECT_TRUE(gui::RevertOneAxisPresetOverride(gui::AxisPreset::kPlate));
+  EXPECT_TRUE(RestoreOnePresetOnDisk(dir, gui::AxisPreset::kPlate));
   const json pruned = ReadOverlayDoc(dir);
   EXPECT_TRUE(!pruned.contains("presets"));
   EXPECT_EQ(pruned.value("bg_alpha", 0.0f), 0.42f);
@@ -887,16 +907,23 @@ TEST(UserDefaults, preset_without_adjustable_face_is_never_written) {
   const auto dir = FreshOverlayDir("preset_random");
   ScopedUserConfigSource guard(gui::UserConfigSource::kExplicitDir, dir);
 
+  json working = json::object();
   for (const auto preset : { gui::AxisPreset::kRandom, gui::AxisPreset::kCustom }) {
     const auto result = gui::ClampAxisPresetZenithStdForSave(preset, 3.0f);
     EXPECT_TRUE(!result.accepted);         // refused before any caller could commit it
     EXPECT_TRUE(!result.message.empty());  // refused out loud, not silently dropped
     EXPECT_TRUE(!gui::GetUserAxisPresetZenithStdOverride(preset).has_value());
-    EXPECT_TRUE(!gui::RevertOneAxisPresetOverride(preset));
+    // Both document mutators are no-ops for these presets, asserted in both directions: a write
+    // must not invent a key, and an erase must not leave a `presets`/`axis` skeleton behind. They
+    // are the primitives the panel's §1 controls call, so this is the store-level defense in the
+    // place the panel would actually hit it.
+    gui::WriteAxisPresetZenithStdToDoc(working, preset, 3.0f);
+    gui::EraseAxisPresetZenithStdFromDoc(working, preset);
+    EXPECT_TRUE(working.empty());
   }
 
-  // Nothing reached the file — RevertOneAxisPresetOverride is a real writer, and it must bail
-  // out for these presets rather than leave an empty `presets` skeleton behind.
+  // Nothing reached the file either.
+  EXPECT_TRUE(gui::WriteUserDefaultsFile(dir, working));
   const json doc = ReadOverlayDoc(dir);
   EXPECT_TRUE(!doc.contains("presets"));
 
@@ -914,31 +941,15 @@ TEST(UserDefaults, preset_without_adjustable_face_is_never_written) {
   EXPECT_EQ(adjustable, 4);  // Column / Plate / Parry / Lowitz
 }
 
-// A failed write must leave the in-memory value alone. Otherwise this session resolves one
-// value while the next launch reads the older one off disk, and the user sees their setting
-// "come back" with no event to attribute it to.
+// MOVED, not retired: "a failed write leaves the in-memory preset value alone" now lives in
+// test/gui/functional/test_gui_defaults_panel.cpp as
+// save_failure_leaves_the_preset_cache_untouched.
 //
-// The write under test is the revert — dropping an override is a file write like any other, and
-// this is the repo's only coverage of what it does when that write cannot happen.
-TEST(UserDefaults, preset_write_failure_leaves_memory_untouched) {
-  ResetUserDefaultsChannels();
-  const auto dir = FreshOverlayDir("preset_write_fail");
-  {
-    ScopedUserConfigSource guard(gui::UserConfigSource::kExplicitDir, dir);
-    EXPECT_TRUE(SeedPresetOverrideOnDisk(dir, gui::AxisPreset::kColumn, 0.3f));
-    gui::MakeNewDocumentState(dir);
-  }
-  const auto seeded = gui::GetUserAxisPresetZenithStdOverride(gui::AxisPreset::kColumn);
-  ASSERT_TRUE(seeded.has_value());
-  EXPECT_EQ(*seeded, 0.3f);
-
-  // No writable directory at all — the same shape as a read-only config dir.
-  ScopedUserConfigSource disabled(gui::UserConfigSource::kDisabled);
-  EXPECT_TRUE(!gui::RevertOneAxisPresetOverride(gui::AxisPreset::kColumn));
-  const auto after_failed_revert = gui::GetUserAxisPresetZenithStdOverride(gui::AxisPreset::kColumn);
-  ASSERT_TRUE(after_failed_revert.has_value());
-  EXPECT_EQ(*after_failed_revert, 0.3f);  // a failed revert must not report success in memory
-}
+// It used to be asserted here against a disk-side revert wrapper the panel never called. The
+// contract is not a property of any one function — it is the ORDER in which the panel's Save
+// composes two of them (write the document, and only if that succeeded push the values into the
+// process-wide cache), so the only place it can be observed is the composition itself. See the
+// comment on that case for why it is driven through the real Save button.
 
 // AC4 — a load-time clamp must REACH the user, not merely be counted. 405.2 built the
 // counters; until this task nothing consumed them, so a value silently adjusted at startup
@@ -1046,8 +1057,10 @@ TEST(UserDefaults, json_import_does_not_leak_downgrades_into_the_next_new) {
   EXPECT_EQ(gui::TakeUserDefaultsDowngradeCount(), 0);
   EXPECT_TRUE(gui::TakeUserDefaultsDowngradeNotices().empty());
 
-  // The decisive part: the NEXT New reports its own load, and the file is clean by then.
-  EXPECT_TRUE(gui::RevertOneAxisPresetOverride(gui::AxisPreset::kColumn));
+  // The decisive part: the NEXT New reports its own load, and the file is clean by then. HOW the
+  // file gets cleaned is not the subject here, so it is emptied directly rather than through a
+  // preset-shaped edit.
+  EXPECT_TRUE(gui::WriteUserDefaultsFile(dir, json::object()));
   gui::ClearImportComplexFilterWarning();
   gui::DoNew();
   EXPECT_TRUE(gui::PeekImportComplexFilterWarning().empty());

--- a/test/unit-correctness/gui/test_user_defaults.cpp
+++ b/test/unit-correctness/gui/test_user_defaults.cpp
@@ -127,6 +127,12 @@ bool SeedPresetOverrideOnDisk(const std::filesystem::path& dir, gui::AxisPreset 
 // itself never went through, and the live path composes these three primitives at its own call
 // site. The assertions below are about the DOCUMENT shape the erase leaves behind, which is
 // EraseAxisPresetZenithStdFromDoc's own contract and the half a wholesale rewrite would break.
+//
+// ⛔ Do NOT reuse this helper to assert the disk-first ORDER itself. It reproduces that order to
+// build a starting state, so an assertion about ordering made through it would be checking this
+// file's copy of the sequence, not the panel's. The order contract belongs to CommitCopy and is
+// pinned in gui_test (save_failure_leaves_the_preset_cache_untouched) — a second place asserting
+// it here is exactly the parallel-implementation shape this task deleted.
 bool RestoreOnePresetOnDisk(const std::filesystem::path& dir, gui::AxisPreset preset) {
   json doc = ReadOverlayDoc(dir);
   gui::EraseAxisPresetZenithStdFromDoc(doc, preset);
@@ -917,9 +923,12 @@ TEST(UserDefaults, preset_without_adjustable_face_is_never_written) {
     // must not invent a key, and an erase must not leave a `presets`/`axis` skeleton behind. They
     // are the primitives the panel's §1 controls call, so this is the store-level defense in the
     // place the panel would actually hit it.
+    // One assertion per direction, not one after both: checking only the net effect of write+erase
+    // would still pass if a future write DID invent a key, so long as the erase removed it again.
     gui::WriteAxisPresetZenithStdToDoc(working, preset, 3.0f);
+    EXPECT_TRUE(working.empty());  // a write must not invent a key
     gui::EraseAxisPresetZenithStdFromDoc(working, preset);
-    EXPECT_TRUE(working.empty());
+    EXPECT_TRUE(working.empty());  // an erase must not leave a skeleton behind
   }
 
   // Nothing reached the file either.


### PR DESCRIPTION
收口 405.x → 408.2 副本模型迁移遗留的**平行写入面**（explore-433 交付 T1/T2/T3/T5）。408.2 换掉了调用方、把实现复制了一份，旧的那份连同它的自我声明一起留下 —— 同一句 "this is the only place…" 的 defense-in-depth 注释在活/死两处各出现一遍。

## 做了什么（严格按 A → B → C 顺序）

**A. 先把五条活契约移植到活路径并逐条证红**（顺序不可反：直接删 = 一次性失掉全部覆盖）

| 契约 | 移植到 |
|---|---|
| 写入保全自己不拥有的子树（`presets` 首当其冲） | `ApplyCheckedRowsToDoc`（gui_unit_test） |
| 无可写目录 ⇒ 报失败、不静默声称成功 | `WriteActiveOverlayDoc`（gui_unit_test） |
| I3 降级留痕 + 其负例 | `ApplyCheckedRowsToDoc` → `SetByPath`（gui_unit_test） |
| 写盘失败 ⇒ 内存不动 | `CommitCopy`，驱动真实 Save 按钮（gui_test） |

这五条此前在活路径上**零覆盖**——移植不是搬运，是给活路径补第一次覆盖。每条都附了一次红态探针（破坏活路径保护 → 对应用例变红并记下失败断言原文 → 还原 → `git status --porcelain` 判空 → 重建复绿），偿还 433 明确移交的"全程零探针"欠账。

**B. 再删死写入面**：`SaveAcceptedDefaults` / `RevertOneDefault` / `ResetAllDefaults` / `UpdateOverlayDocument` / `ApplyAcceptedKeys` / `RevertOneAxisPresetOverride`（前三个还从头文件导出）。`ResetUserAxisPresetOverrides` 不是死代码（test fixture 复位钩子），未动。

**C. 加门禁** `user-defaults-single-write-path`（`scripts/check_policies.py`，与 `no-bare-print` 同款形态）：`WriteUserDefaultsFile` 调用方数 == 1，且 `kUserDefaultsFileName` 只许被 store 自身引用（堵住绕过 wrapper 另开写入这条 A 拦不住的路）。两个子检查各自在红态下自证有效。门禁的已知盲区写进了 docstring —— 它挡的是"顺手加第二个写入者"，不是"证明第二写入路径不存在"。

**D. 文档/注释**：`GetUserAxisPresetZenithStdOverride` 补上它为何不能被内联（已被误判为死代码两次）。

## 一处与 issue 不同的判断

issue 称 `doc/gui-state-governance.md` §8.8「`ConfigSnapshot` 不含任何 `kView` 字段」与代码不符、要求改对。一手核验后**这个前提不成立**：档位登记的粒度是 `GuiState` 顶层字段，`renderer` 整体登记为 `kStructSoft`，`ConfigSnapshot` 七个成员确无一登记为 `kView`。真实问题是**易被误读**——`renderer` 拷的是整份 `RenderConfig`，lens/fov/elevation 等显示侧控制项以结构体成员形式随之进快照。故保留原句、补一段拆开两个粒度的说明，并显式声明 Revert **应当**覆盖哪些字段是独立语义问题（task-435 的范围）。

## 验证

- `./scripts/test.sh quick` → RESULT: PASS（gui 320/320）
- 全量 `gui_test`（非 headless，含 real-timing 池）→ 326/326
- `check_policies.py`（14 条 policy）/ `check_new_refs.py` / `check_new_gui_tests.py` / `format.sh --check` 均 exit 0
- plan-review 3 轮 → APPROVE；code-review 2 轮 → APPROVE

⚠️ 实施期间出现过**一次未能取证的 `fast-e2e` 失败**（首跑 `test.sh quick` exit 1，失败行被 `tail` 截掉，test.sh 不持久化分层日志）。随后 `pytest -q` / `pytest -n auto` / `test.sh quick` 共四次独立复跑全绿，未复现。**未按 flake 结案**，如实记录在 SUMMARY 的已知问题里。

🤖 Generated with [Claude Code](https://claude.com/claude-code)