### PR TITLE
fix(gui): align Revert's field scope with the predicate that decides what counts as a change

### DIFF
--- a/doc/gui-state-governance.md
+++ b/doc/gui-state-governance.md
@@ -170,8 +170,8 @@
 
 ### 8.8 与 `ConfigSnapshot` / Revert baseline 的边界
 
-`GuiState::ConfigSnapshot`（`gui_state.hpp:1101`）只覆盖七个配置字段（晶体 / filter / layer / `sun` / `sim` / `renderer` / 染色规则），其中没有任何一个**顶层字段**登记为 `FieldTier::kView`——而本层的默认值候选恰恰以 `kView` 为主力（`bg_*` / `show_*` / 各类颜色与 alpha / 面板折叠态）。
+`GuiState::ConfigSnapshot`（`gui_state.hpp:1101`）只覆盖七个配置字段（晶体 / filter / layer / `sun` / `sim` / `renderer_resim` / 染色规则），其中没有任何一个**顶层字段**登记为 `FieldTier::kView`——而本层的默认值候选恰恰以 `kView` 为主力（`bg_*` / `show_*` / 各类颜色与 alpha / 面板折叠态）。
 
-⚠️ 但"没有 `kView` 顶层字段"不等于"没有视图性的设置"：档位登记在**顶层字段**这一粒度上（`renderer` 整体登记为 `kStructSoft`，`gui_state_tiers.hpp`），而 `ConfigSnapshot::renderer` 拷贝的是整份 `RenderConfig`，所以镜头 / fov / elevation / azimuth / roll / visible / front 这些纯显示侧的控制项是以**结构体成员**的形式被包含在快照里的，只是不作为独立字段出现在上面那份七项清单中。读这一段时不要把它读成"这些控制项不在 Revert 的作用域内"——它们在。Revert **应当**覆盖哪些字段是一个独立的语义问题，不在本节范围内。
+⚠️ "没有 `kView` 顶层字段"本身不等于"没有视图性的设置"，因为档位登记在**顶层字段**这一粒度上（`renderer` 整体登记为 `kStructSoft`，`gui_state_tiers.hpp`），一个顶层字段内部的成员不会单独出现在那份七项清单里。但对 `renderer` 这一项，答案现在是明确的：快照存的是 `RenderConfigResimFields renderer_resim` 而**不是**整份 `RenderConfig`，镜头 / fov / elevation / azimuth / roll / visible / front 与 `exposure_offset` 结构性地不在快照里，Revert 不覆盖它们。「Revert 应当覆盖哪些字段」这个语义问题已有答案且只有一个真源——`RenderConfigResimFields`，见 §3 偏离 F。
 
 默认值层复用的是 `ConfigSnapshot` 背后"两份状态结构化 diff、按需派生效果"的**模式**，但不能复用其 struct：两者覆盖的字段集合不同，把默认值的 diff 引擎强行套进 `ConfigSnapshot` 会连带改动 Revert 语义。

--- a/doc/gui-state-governance.md
+++ b/doc/gui-state-governance.md
@@ -57,6 +57,7 @@
 - **S4** ~~`MarkFilterDirty` 名不副实~~ **已由 scrum-353.5 落地正名为 `MarkStructHardDirty`**（gui_state.hpp:782），与档位表 T-struct·hard 对齐。
 - **S5** ~~signal 缓存无 server/epoch 键控~~ **已由 scrum-353.5 落地**：`RefreshColorClassSignals`（color_window.cpp）在入口比较 `(server, committed_epoch)`，任一 mismatch 即清 `signal_flags` + `last_poll_time=-1000` 强制立即重 poll，后端切换/epoch 递增不再展示旧信号。
 - **偏离 E（Save 裁定，已落地）**：owner 裁定 = kModified 态 Save 前弹提示（"Run first / Save anyway / Cancel"）——scrum-353.5 落地。Save anyway 保留"存所见"能力，但由用户显式确认；同时**不清 kModified**（保留视觉线索）。
+- **偏离 F（Revert 字段范围，已落地）**：~~Revert 恢复的 `renderer` 字段集宽于「什么才算改动」判定集——`ConfigSnapshot::From`/`ApplyTo` 整体拷贝 `RenderConfig`，于是改视角/换镜头/调 FOV 这些**从未点亮过 Revert 按钮**的操作会被 Revert 连带回滚（入不算改动、出算回滚）~~ **已修复**：这组字段的清单现在只声明在 `RenderConfigResimFields`（`gui_state.hpp`）一处，**「什么才算改动」与「Revert 恢复什么」读的是同一个真源**——该类型自己拥有三个方向：`From`（捕获）/ `Matches`（判定，`gui_state_reconcile.cpp::DiffAgainstCommitBaseline` 与 `app.cpp::DoRun` 的 `expect_rebuild` 都调它）/ `ApplyTo`（恢复）。`ConfigSnapshot` 的 Revert 基线字段随之从整份 `RenderConfig` 收窄为 `RenderConfigResimFields renderer_resim`，T-view 字段（lens_type / fov / elevation / azimuth / roll / visible / front）与 `exposure_offset` **结构性地不在基线里**（不是"捕获了但恢复时跳过"，那会让 `From`/`ApplyTo` 不对称），Revert 后保持用户当前实时值。
 - **已证伪**：sim_resolution 改动**确实** MarkDirty（app_panels.cpp:726）——非偏离。
 
 ## 4. 目标模型：三支柱 + 文档重置 owner

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -973,15 +973,16 @@ bool DoRun(bool user_initiated) {
   // NeedsRebuild comparison: RenderConfig::id was removed during the renderer copy-model
   // migration; since `id` was always 1 pre-migration, operator== behavior is strictly looser
   // and cannot produce new false-positive reuse paths.
-  // Renderer comparison uses RenderConfigResimEqual (gui_state.hpp) — same helper used by
-  // gui_state_reconcile.cpp::DiffAgainstCommitBaseline, so this predicate and the reconciler's
-  // resim/dirty verdict stay in lock-step (single source of truth; see T2 plan §3 design 1).
+  // Renderer comparison uses RenderConfigResimFields::Matches (gui_state.hpp) — the same
+  // projection gui_state_reconcile.cpp::DiffAgainstCommitBaseline compares against, so this
+  // predicate and the reconciler's resim/dirty verdict stay in lock-step (single source of
+  // truth; see T2 plan §3 design 1).
   // Excludes all T-view fields (lens_type / fov / elevation / azimuth / roll / visible / front /
   // exposure_offset) because they are client-side reprojection only — the sim renders a fixed
   // full-sky dual-fisheye and the GUI reprojects it (see gui_state.hpp comment). Dragging the
   // view / switching the lens / toggling the hemisphere clip must not cause a poller Stop here.
   bool expect_rebuild = backend_reconstructed || !g_state.last_committed_state.has_value() ||
-                        !RenderConfigResimEqual(g_state.renderer, g_state.last_committed_state->renderer);
+                        !g_state.last_committed_state->renderer_resim.Matches(g_state.renderer);
 
   // Single handle commit path (327.4 / 399.5): all filter types — including multi-segment
   // raypath / multi-value EE (expanded to N simple + 1 complex) — go through LUMICE_Scene, so

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -417,10 +417,6 @@ struct RenderConfigResimFields {
   friend bool operator!=(const RenderConfigResimFields& a, const RenderConfigResimFields& b) { return !(a == b); }
 };
 
-inline bool RenderConfigResimEqual(const RenderConfig& a, const RenderConfig& b) {
-  return RenderConfigResimFields::From(a) == RenderConfigResimFields::From(b);
-}
-
 // Apple Silicon + libc++ only. Layout pins, mirroring the EntryCard pattern (see below).
 // Linux/Windows CI still compiles both structs; this only pins the Apple main-dev platform.
 #if defined(__APPLE__) && defined(__aarch64__)
@@ -1159,7 +1155,12 @@ struct GuiState {
     std::vector<Layer> layers;
     SunConfig sun;
     SimConfig sim;
-    RenderConfig renderer;
+    // Deliberately NOT a whole RenderConfig: only the fields RenderConfigResimFields judges are
+    // captured, so Revert restores exactly the set that counts as a change. The T-view fields
+    // (lens_type / fov / elevation / azimuth / roll / visible / front) and exposure_offset are
+    // absent *structurally* — not captured-then-skipped-on-restore, which would leave From and
+    // ApplyTo asymmetric and the omission easy to lose track of.
+    RenderConfigResimFields renderer_resim;
     std::vector<ColorClassConfig> raypath_color;
 
     // Build a snapshot from the configuration fields of `state`. Implementation is
@@ -1225,7 +1226,9 @@ struct GuiState {
 // Size bumped from 192 → 216 by task-349.2: added `raypath_color` field
 // (std::vector<ColorClassConfig>) so Revert restores color-class edits that
 // go through MarkStructHardDirty (Revert-completeness fix, plan §3.4).
-static_assert(sizeof(GuiState::ConfigSnapshot) == 216,
+// Size then shrank when the Revert baseline narrowed from a full RenderConfig to
+// RenderConfigResimFields: it now holds exactly the fields that count as a change.
+static_assert(sizeof(GuiState::ConfigSnapshot) == 184,
               "GuiState::ConfigSnapshot size changed; audit From()/ApplyTo() implementations below");
 #endif
 
@@ -1239,7 +1242,7 @@ inline GuiState::ConfigSnapshot GuiState::ConfigSnapshot::From(const GuiState& s
   s.layers = state.layers;
   s.sun = state.sun;
   s.sim = state.sim;
-  s.renderer = state.renderer;
+  s.renderer_resim = RenderConfigResimFields::From(state.renderer);
   s.raypath_color = state.raypath_color;
   return s;
 }
@@ -1250,7 +1253,7 @@ inline void GuiState::ConfigSnapshot::ApplyTo(GuiState& state) const {
   state.layers = layers;
   state.sun = sun;
   state.sim = sim;
-  state.renderer = renderer;
+  renderer_resim.ApplyTo(state.renderer);
   state.raypath_color = raypath_color;
 }
 

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -409,6 +409,9 @@ struct RenderConfigResimFields {
   // Does `live` still agree with this captured baseline on the resim-eligible fields?
   bool Matches(const RenderConfig& live) const { return From(live) == *this; }
 
+  // Value-type equality, kept as free friends so two captured projections can be compared
+  // directly (tests and debugging do this); `Matches` above is the live-vs-baseline shorthand
+  // built on top of it, not the only intended consumer.
   friend bool operator==(const RenderConfigResimFields& a, const RenderConfigResimFields& b) {
     return a.sim_resolution_index == b.sim_resolution_index &&
            std::equal(a.background, a.background + 3, b.background) &&

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -350,8 +350,19 @@ struct RenderConfig {
   bool operator!=(const RenderConfig& o) const { return !(*this == o); }
 };
 
-// resim-eligibility comparator for RenderConfig. Compares ONLY fields whose change genuinely
-// requires re-running / rebuilding the simulation. Everything else is client-side display state.
+// The resim-eligible projection of RenderConfig: ONLY the fields whose change genuinely requires
+// re-running / rebuilding the simulation. Everything else is client-side display state.
+//
+// This type is the single place that field list is written down. Three questions read it, and all
+// three are its own members so they cannot drift apart:
+//   From(live)      — capture the projection (what a commit records).
+//   Matches(live)   — has the live config changed in a resim-relevant way? (the "is it dirty"
+//                     predicate: gui_state_reconcile.cpp::DiffAgainstCommitBaseline and
+//                     app.cpp::DoRun's expect_rebuild).
+//   ApplyTo(live)   — restore the projection (what Revert puts back).
+// Capture and restore covering exactly the compared field set is the point, not a coincidence:
+// a Revert baseline wider than the predicate would discard edits the UI never counted as changes
+// (a view drag never lights the Revert button, so Revert must not undo it).
 //
 // EXCLUDED — T-view fields (doc/gui-state-governance.md §2 row "T-view"): the simulation always
 // renders a fixed full-sky dual-fisheye and the GUI reprojects it in the preview GL shader, so
@@ -372,20 +383,57 @@ struct RenderConfig {
 // the server only through the commit payload (background / ray_color / opacity); leave them in so
 // they still get applied on Run until they gain a display-time push path.
 //
-// Callers: gui_state_reconcile.cpp::DiffAgainstCommitBaseline and app.cpp::DoRun expect_rebuild
-// (single source of truth — do not fork).
+// Consumers: gui_state_reconcile.cpp::DiffAgainstCommitBaseline, app.cpp::DoRun expect_rebuild,
+// and GuiState::ConfigSnapshot's Revert baseline (single source of truth — do not fork).
+struct RenderConfigResimFields {
+  int sim_resolution_index;
+  float background[3];
+  float ray_color[3];
+  float opacity;
+
+  static RenderConfigResimFields From(const RenderConfig& r) {
+    return { r.sim_resolution_index,
+             { r.background[0], r.background[1], r.background[2] },
+             { r.ray_color[0], r.ray_color[1], r.ray_color[2] },
+             r.opacity };
+  }
+
+  // Write back onto a live RenderConfig, touching nothing outside this projection.
+  void ApplyTo(RenderConfig& r) const {
+    r.sim_resolution_index = sim_resolution_index;
+    std::copy(std::begin(background), std::end(background), r.background);
+    std::copy(std::begin(ray_color), std::end(ray_color), r.ray_color);
+    r.opacity = opacity;
+  }
+
+  // Does `live` still agree with this captured baseline on the resim-eligible fields?
+  bool Matches(const RenderConfig& live) const { return From(live) == *this; }
+
+  friend bool operator==(const RenderConfigResimFields& a, const RenderConfigResimFields& b) {
+    return a.sim_resolution_index == b.sim_resolution_index &&
+           std::equal(a.background, a.background + 3, b.background) &&
+           std::equal(a.ray_color, a.ray_color + 3, b.ray_color) && a.opacity == b.opacity;
+  }
+  friend bool operator!=(const RenderConfigResimFields& a, const RenderConfigResimFields& b) { return !(a == b); }
+};
+
 inline bool RenderConfigResimEqual(const RenderConfig& a, const RenderConfig& b) {
-  return a.sim_resolution_index == b.sim_resolution_index && std::equal(a.background, a.background + 3, b.background) &&
-         std::equal(a.ray_color, a.ray_color + 3, b.ray_color) && a.opacity == b.opacity;
+  return RenderConfigResimFields::From(a) == RenderConfigResimFields::From(b);
 }
 
-// Apple Silicon + libc++ only. RenderConfig layout pin: mirrors the EntryCard pattern
-// (see below). If this size assertion fires, a field was added/removed from RenderConfig —
-// the author must inspect `RenderConfigResimEqual` above and either include the new field
-// (if it participates in resim eligibility) or explicitly exclude it (like exposure_offset).
-// Linux/Windows CI still compiles the struct; this only pins the Apple main-dev platform.
+// Apple Silicon + libc++ only. Layout pins, mirroring the EntryCard pattern (see below).
+// Linux/Windows CI still compiles both structs; this only pins the Apple main-dev platform.
 #if defined(__APPLE__) && defined(__aarch64__)
-static_assert(sizeof(RenderConfig) == 64, "RenderConfig size changed — check RenderConfigResimEqual for new fields");
+// RenderConfig: if this fires, a field was added/removed — the author must decide whether it
+// belongs in RenderConfigResimFields above (participates in resim eligibility) or is explicitly
+// excluded (like exposure_offset).
+static_assert(sizeof(RenderConfig) == 64, "RenderConfig size changed — check RenderConfigResimFields for new fields");
+// RenderConfigResimFields: naming the field list once does NOT by itself keep the three
+// directions in step. From() aggregate-initializes, so a newly added field is silently
+// value-initialized rather than rejected, and ApplyTo()/operator== would quietly keep working on
+// the old subset. Pinning the size is what turns that omission into a compile error.
+static_assert(sizeof(RenderConfigResimFields) == 32,
+              "RenderConfigResimFields size changed — update From/ApplyTo/operator== together");
 #endif
 
 // Resettable subset of RenderConfig (the View `Reset` button targets these

--- a/src/gui/gui_state_reconcile.cpp
+++ b/src/gui/gui_state_reconcile.cpp
@@ -105,14 +105,15 @@ void DiffAgainstCommitBaseline(const GuiState& state, GuiEffects& effects) {
   }
   const auto& baseline = *state.last_committed_state;
 
-  // T-struct·soft: re-sim carry-forward. Renderer comparison uses RenderConfigResimEqual
+  // T-struct·soft: re-sim carry-forward. Renderer comparison uses RenderConfigResimFields
   // (defined in gui_state.hpp): it excludes `exposure_offset`, which is a pure display-time
   // field pushed every frame via LUMICE_SetCompositeExposure and never baked into the sim
   // (doc/ev-pipeline-architecture.md §6.4/§6.5). Excluding EV here is what makes dragging the
   // EV slider not falsely flip a finished sim into kModified. app.cpp::DoRun's expect_rebuild
-  // predicate consumes the same helper — single source of truth (see T2 plan §3 design point 1).
+  // predicate compares the same projection, and the baseline stores nothing else — single
+  // source of truth (see T2 plan §3 design point 1).
   if (state.crystals != baseline.crystals || state.layers != baseline.layers || state.sun != baseline.sun ||
-      state.sim != baseline.sim || !RenderConfigResimEqual(state.renderer, baseline.renderer)) {
+      state.sim != baseline.sim || !baseline.renderer_resim.Matches(state.renderer)) {
     effects.need_resim = true;
   }
 

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -3628,6 +3628,67 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // The user-visible loop behind Revert's field scope, driven end to end through the real
+  // widgets rather than through DoRevert(): change the view, watch Revert stay inert, change a
+  // crystal, watch it arm, click it. What the unit-correctness pair on DoRevert cannot show is
+  // exactly what makes the old behavior surprising — the Revert affordance never offers itself
+  // for a view change, so a Revert that discarded the view was undoing something the UI had
+  // never offered to undo. Both halves are asserted here in one run, off one live top bar.
+  //
+  // The affordance is probed by its disabled flag, not by ItemExists: the top bar always renders
+  // the ⚠ + Revert pair so the toolbar's layout does not shift, and hides it with alpha=0 inside
+  // BeginDisabled (app_panels.cpp). The item therefore exists in every state, and "the user
+  // cannot revert" is expressed by the flag.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "revert_keeps_view_discards_crystal_edit");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+      gui::g_state.modal_immediate_mode = true;
+      // Linear lens: the view angle inputs are enabled here (see registry_view_applicability).
+      gui::g_state.renderer.lens_type = gui::kLensTypeLinear;
+
+      // Stand in for "Run just finished": a commit baseline plus a reconcile base of kDone, so a
+      // later dirty edit surfaces as kModified. run_intent is what makes kDone stick — the
+      // harness main loop re-derives sim_state every frame.
+      gui::g_state.run_intent = gui::RunIntent::kLoaded;
+      gui::g_state.sim_state = gui::GuiState::SimState::kDone;
+      gui::g_state.committed_epoch = 5;
+      gui::g_state.display_epoch_floor = 0;
+      gui::g_state.dirty = false;
+      gui::g_state.last_committed_state = gui::GuiState::ConfigSnapshot::From(gui::g_state);
+      ctx->Yield(4);
+
+      const int cid = gui::g_state.layers[0].entries[0].crystal_id;
+      const float committed_h = gui::g_state.crystals[cid].height.center;
+
+      // (1) Change the view through its real input. Revert must NOT arm.
+      ctx->ItemInputValue("**/##Elevation##view_input", 30.0f);
+      ctx->Yield(4);
+      IM_CHECK_EQ(gui::g_state.renderer.elevation, 30.0f);  // premise: the edit landed
+      IM_CHECK_NE(static_cast<int>(gui::g_state.sim_state), static_cast<int>(gui::GuiState::SimState::kModified));
+      IM_CHECK((ctx->ItemInfo("##TopBar/Revert").ItemFlags & ImGuiItemFlags_Disabled) != 0);
+
+      // (2) Change a crystal through the real edit modal. Revert must arm.
+      gui::EditRequest req{ gui::EditTarget::kCrystal, /*layer_idx=*/0, /*entry_idx=*/0 };
+      gui::OpenEditModal(req, gui::g_state);
+      ctx->Yield(4);
+      ctx->ItemInputValue("**/##Height##modal_cr_input", committed_h + 1.0f);
+      ctx->Yield(2);
+      ctx->ItemClick("**/Close##edit_modal");  // Immediate mode: single Close button
+      ctx->Yield(4);
+      IM_CHECK_EQ(gui::g_state.crystals[cid].height.center, committed_h + 1.0f);  // premise
+      IM_CHECK_EQ(static_cast<int>(gui::g_state.sim_state), static_cast<int>(gui::GuiState::SimState::kModified));
+      IM_CHECK((ctx->ItemInfo("##TopBar/Revert").ItemFlags & ImGuiItemFlags_Disabled) == 0);
+
+      // (3) Click the real Revert button: the crystal edit goes, the view stays.
+      ctx->ItemClick("##TopBar/Revert");
+      ctx->Yield(4);
+      IM_CHECK_EQ(gui::g_state.crystals[cid].height.center, committed_h);
+      IM_CHECK_EQ(gui::g_state.renderer.elevation, 30.0f);
+    };
+  }
+
   // p2_render/registry_display_overlay_domains — the six remaining unconditional sliders.
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "registry_display_overlay_domains");

--- a/test/unit-correctness/config/test_config_snapshot.cpp
+++ b/test/unit-correctness/config/test_config_snapshot.cpp
@@ -61,11 +61,22 @@ GuiState MakeModifiedState() {
   s.sun = SunConfig{ 35.0f, 0.6f, 4 };
   s.sim = SimConfig{ 7.5f, 12, true };
 
-  s.renderer.lens_type = 3;
+  // Renderer, both sides of the ConfigSnapshot boundary. The snapshot stores a
+  // RenderConfigResimFields projection, so only the second group can survive a round trip; the
+  // first is here precisely so the cases below can show it does not.
+  s.renderer.lens_type = 3;  // T-view: client-side reprojection, outside the projection
   s.renderer.fov = 110.0f;
   s.renderer.elevation = 15.0f;
   s.renderer.azimuth = -20.0f;
   s.renderer.exposure_offset = 0.5f;
+  s.renderer.sim_resolution_index = 3;  // resim-eligible: inside the projection
+  s.renderer.background[0] = 0.1f;
+  s.renderer.background[1] = 0.2f;
+  s.renderer.background[2] = 0.3f;
+  s.renderer.ray_color[0] = 0.4f;
+  s.renderer.ray_color[1] = 0.5f;
+  s.renderer.ray_color[2] = 0.6f;
+  s.renderer.opacity = 0.65f;
 
   // task-349.2 Step 2: raypath_color is a configuration field (structural
   // edits go through MarkStructHardDirty); ConfigSnapshot must round-trip it so
@@ -114,11 +125,15 @@ TEST(ConfigSnapshot, FromCapturesAllConfigFields) {
   EXPECT_EQ(snap.sim.max_hits, 12);
   EXPECT_TRUE(snap.sim.infinite);
 
-  EXPECT_EQ(snap.renderer.lens_type, 3);
-  EXPECT_FLOAT_EQ(snap.renderer.fov, 110.0f);
-  EXPECT_FLOAT_EQ(snap.renderer.elevation, 15.0f);
-  EXPECT_FLOAT_EQ(snap.renderer.azimuth, -20.0f);
-  EXPECT_FLOAT_EQ(snap.renderer.exposure_offset, 0.5f);
+  // The renderer is captured as a RenderConfigResimFields projection: the resim-eligible fields
+  // and nothing else. The T-view fields MakeModifiedState also set (lens_type / fov / elevation /
+  // azimuth / exposure_offset) have no slot here at all — the type does not declare them, so the
+  // omission is structural rather than something From() has to remember to skip.
+  EXPECT_EQ(snap.renderer_resim.sim_resolution_index, 3);
+  EXPECT_FLOAT_EQ(snap.renderer_resim.background[0], 0.1f);
+  EXPECT_FLOAT_EQ(snap.renderer_resim.background[2], 0.3f);
+  EXPECT_FLOAT_EQ(snap.renderer_resim.ray_color[1], 0.5f);
+  EXPECT_FLOAT_EQ(snap.renderer_resim.opacity, 0.65f);
 
   // task-349.2 Step 2: raypath_color mirror.
   ASSERT_EQ(snap.raypath_color.size(), s.raypath_color.size());
@@ -154,6 +169,13 @@ TEST(ConfigSnapshot, ApplyToRestoresConfigFieldsAndPreservesRuntimeState) {
   target.raypath_color.push_back(junk);
 
   // Runtime / view-preference fields: these must NOT be touched by ApplyTo.
+  // The renderer's T-view fields belong to this group: changing them never counts as a
+  // configuration change (the Revert button does not light up for a view drag), so Revert must
+  // not discard them either.
+  target.renderer.lens_type = 2;
+  target.renderer.fov = 77.0f;
+  target.renderer.elevation = -8.0f;
+  target.renderer.exposure_offset = -1.5f;
   target.dirty = true;
   target.sim_state = GuiState::SimState::kSimulating;
   target.stats_ray_seg_num = 123456;
@@ -181,9 +203,10 @@ TEST(ConfigSnapshot, ApplyToRestoresConfigFieldsAndPreservesRuntimeState) {
   ASSERT_EQ(target.layers.size(), source.layers.size());
   EXPECT_FLOAT_EQ(target.sun.altitude, source.sun.altitude);
   EXPECT_FLOAT_EQ(target.sim.ray_num_millions, source.sim.ray_num_millions);
-  EXPECT_EQ(target.renderer.lens_type, source.renderer.lens_type);
-  EXPECT_FLOAT_EQ(target.renderer.fov, source.renderer.fov);
-  EXPECT_FLOAT_EQ(target.renderer.exposure_offset, source.renderer.exposure_offset);
+  EXPECT_EQ(target.renderer.sim_resolution_index, source.renderer.sim_resolution_index);
+  EXPECT_FLOAT_EQ(target.renderer.background[1], source.renderer.background[1]);
+  EXPECT_FLOAT_EQ(target.renderer.ray_color[2], source.renderer.ray_color[2]);
+  EXPECT_FLOAT_EQ(target.renderer.opacity, source.renderer.opacity);
   // task-349.2 Step 2: raypath_color is CONFIG, ApplyTo replaces it (junk
   // classes seeded above are gone, source content restored 1:1).
   ASSERT_EQ(target.raypath_color.size(), source.raypath_color.size());
@@ -192,7 +215,13 @@ TEST(ConfigSnapshot, ApplyToRestoresConfigFieldsAndPreservesRuntimeState) {
   ASSERT_EQ(target.raypath_color[0].match.size(), source.raypath_color[0].match.size());
   EXPECT_EQ(target.raypath_color[0].match[0].predicate_text, source.raypath_color[0].match[0].predicate_text);
 
-  // Runtime / view fields: unchanged.
+  // Runtime / view fields: unchanged. The renderer's T-view values are the target's own, NOT
+  // the source's — this is the assertion that fails if the Revert baseline ever widens back to
+  // a whole RenderConfig.
+  EXPECT_EQ(target.renderer.lens_type, 2);
+  EXPECT_FLOAT_EQ(target.renderer.fov, 77.0f);
+  EXPECT_FLOAT_EQ(target.renderer.elevation, -8.0f);
+  EXPECT_FLOAT_EQ(target.renderer.exposure_offset, -1.5f);
   EXPECT_TRUE(target.dirty);
   EXPECT_EQ(target.sim_state, GuiState::SimState::kSimulating);
   EXPECT_EQ(target.stats_ray_seg_num, 123456u);
@@ -254,8 +283,15 @@ TEST(ConfigSnapshot, RoundTripFromThenApplyRestoresConfig) {
   EXPECT_FALSE(restored.filters[*restored_e1.filter_id].sym_p);
   EXPECT_FLOAT_EQ(restored.sun.altitude, original.sun.altitude);
   EXPECT_EQ(restored.sim.infinite, original.sim.infinite);
-  EXPECT_EQ(restored.renderer.lens_type, original.renderer.lens_type);
-  EXPECT_FLOAT_EQ(restored.renderer.fov, original.renderer.fov);
+  EXPECT_EQ(restored.renderer.sim_resolution_index, original.renderer.sim_resolution_index);
+  EXPECT_FLOAT_EQ(restored.renderer.opacity, original.renderer.opacity);
+  // T-view fields do not make the round trip: `restored` keeps the ones it started with.
+  // Compared against a second pristine state rather than literals so this stays true if the
+  // RenderConfig defaults ever move.
+  const GuiState pristine = InitDefaultState();
+  ASSERT_NE(original.renderer.lens_type, pristine.renderer.lens_type);  // premise of the next line
+  EXPECT_EQ(restored.renderer.lens_type, pristine.renderer.lens_type);
+  EXPECT_FLOAT_EQ(restored.renderer.fov, pristine.renderer.fov);
   // Nested crystal/axis fields also survive the From → ApplyTo cycle.
   const auto& restored_e0 = restored.layers[0].entries[0];
   EXPECT_FLOAT_EQ(restored.crystals[restored_e0.crystal_id].face_distance[0].center, 1.3f);
@@ -304,7 +340,7 @@ TEST(ConfigSnapshot, RoundTripPoolAndEntries) {
 // Mirror the production sizeof() guard at test scope as an extra reminder on the
 // baseline platform. Platform-gated because std::vector size varies across stdlibs.
 #if defined(__APPLE__) && defined(__aarch64__)
-static_assert(sizeof(GuiState::ConfigSnapshot) == 216,
+static_assert(sizeof(GuiState::ConfigSnapshot) == 184,
               "Test mirror: ConfigSnapshot size changed; update From/ApplyTo in gui_state.hpp");
 #endif
 

--- a/test/unit-correctness/config/test_config_snapshot.cpp
+++ b/test/unit-correctness/config/test_config_snapshot.cpp
@@ -132,6 +132,7 @@ TEST(ConfigSnapshot, FromCapturesAllConfigFields) {
   EXPECT_EQ(snap.renderer_resim.sim_resolution_index, 3);
   EXPECT_FLOAT_EQ(snap.renderer_resim.background[0], 0.1f);
   EXPECT_FLOAT_EQ(snap.renderer_resim.background[2], 0.3f);
+  EXPECT_FLOAT_EQ(snap.renderer_resim.ray_color[0], 0.4f);
   EXPECT_FLOAT_EQ(snap.renderer_resim.ray_color[1], 0.5f);
   EXPECT_FLOAT_EQ(snap.renderer_resim.opacity, 0.65f);
 

--- a/test/unit-correctness/gui/test_import_export_logic.cpp
+++ b/test/unit-correctness/gui/test_import_export_logic.cpp
@@ -2766,7 +2766,7 @@ TEST(ImportExport, document_switch_leaves_no_stale_status_bar_stats) {
 }
 
 // Revert's field scope must equal the scope of the "did the configuration change" predicate,
-// `RenderConfigResimEqual` (gui_state.hpp) — the repo's declared single source of truth for that
+// `RenderConfigResimFields` (gui_state.hpp) — the repo's declared single source of truth for that
 // question. The two directions are pinned here as a pair because either one alone is satisfiable
 // by a wrong fix:
 //

--- a/test/unit-correctness/gui/test_import_export_logic.cpp
+++ b/test/unit-correctness/gui/test_import_export_logic.cpp
@@ -2797,7 +2797,7 @@ TEST(ImportExport, dorevert_preserves_view_fields_but_reverts_crystal_via_owner)
   // The user drags the view (never counted as a change) and edits a crystal (counted).
   ASSERT_FLOAT_EQ(gui::g_state.renderer.elevation, 0.0f);  // premise: the edit below is a change
   gui::g_state.renderer.elevation = 30.0f;
-  gui::g_state.crystals[0].height = committed_height + 1.0f;
+  gui::g_state.crystals[0].height.center = committed_height + 1.0f;
 
   gui::DoRevert();
 

--- a/test/unit-correctness/gui/test_import_export_logic.cpp
+++ b/test/unit-correctness/gui/test_import_export_logic.cpp
@@ -2764,3 +2764,56 @@ TEST(ImportExport, document_switch_leaves_no_stale_status_bar_stats) {
   EXPECT_EQ(gui::g_state.stats_crystal_num, 77u);
   EXPECT_EQ(gui::g_state.stats_orientation_num, 88u);
 }
+
+// Revert's field scope must equal the scope of the "did the configuration change" predicate,
+// `RenderConfigResimEqual` (gui_state.hpp) — the repo's declared single source of truth for that
+// question. The two directions are pinned here as a pair because either one alone is satisfiable
+// by a wrong fix:
+//
+//   (A) A T-view field the predicate deliberately excludes (elevation — camera orbit, a pure
+//       client-side reprojection uniform) must SURVIVE a Revert. Changing it never counts as a
+//       change, so the Revert button never lights up for it; discarding it anyway is Revert
+//       undoing something the UI never claimed was pending. The crystal assertion in the same
+//       case is what stops "just stop restoring renderer at all" from passing.
+//   (B) A field the predicate DOES judge (sim_resolution_index — it changes the sim render grid)
+//       must still be restored. Without this, narrowing the Revert baseline too far reads as a
+//       pass.
+//
+// Both drive the production `gui::DoRevert()` rather than `ConfigSnapshot::ApplyTo` directly, so
+// a future change that restores renderer fields somewhere else along that path is still caught.
+TEST(ImportExport, dorevert_preserves_view_fields_but_reverts_crystal_via_owner) {
+  gui::DoNew();
+
+  // Do not depend on the default document happening to contain a crystal: a later change to the
+  // seeded contents would silently turn this case's premise into a no-op rather than fail it.
+  if (gui::g_state.crystals.empty()) {
+    gui::g_state.crystals.emplace_back();
+  }
+
+  // Commit baseline, as DoRun writes it on a successful run.
+  gui::g_state.last_committed_state = gui::GuiState::ConfigSnapshot::From(gui::g_state);
+  const float committed_height = gui::g_state.crystals[0].height.center;
+
+  // The user drags the view (never counted as a change) and edits a crystal (counted).
+  ASSERT_FLOAT_EQ(gui::g_state.renderer.elevation, 0.0f);  // premise: the edit below is a change
+  gui::g_state.renderer.elevation = 30.0f;
+  gui::g_state.crystals[0].height = committed_height + 1.0f;
+
+  gui::DoRevert();
+
+  EXPECT_FLOAT_EQ(gui::g_state.renderer.elevation, 30.0f);
+  EXPECT_FLOAT_EQ(gui::g_state.crystals[0].height.center, committed_height);
+}
+
+TEST(ImportExport, dorevert_reverts_sim_resolution_index_via_owner) {
+  gui::DoNew();
+
+  gui::g_state.last_committed_state = gui::GuiState::ConfigSnapshot::From(gui::g_state);
+  const int committed_resolution = gui::g_state.renderer.sim_resolution_index;
+
+  gui::g_state.renderer.sim_resolution_index = committed_resolution + 1;
+
+  gui::DoRevert();
+
+  EXPECT_EQ(gui::g_state.renderer.sim_resolution_index, committed_resolution);
+}

--- a/test/unit-correctness/gui/test_state_reconcile.cpp
+++ b/test/unit-correctness/gui/test_state_reconcile.cpp
@@ -190,7 +190,7 @@ TEST(GuiStateReconcile, effects_truth_table) {
   }
 
   // renderer.exposure_offset is display-time only
-  // (RenderConfigResimEqual excludes it). Mutating EV alone MUST NOT drive re-sim /
+  // (RenderConfigResimFields excludes it). Mutating EV alone MUST NOT drive re-sim /
   // hard-reset / display-push. This is the pin that dragging the EV slider never falsely
   // demotes a finished sim to kModified.
   {
@@ -207,7 +207,7 @@ TEST(GuiStateReconcile, effects_truth_table) {
   // preview shader). Mutating any of them alone MUST NOT drive re-sim / hard-reset / display-push.
   // Before the fix, dragging the view or switching the lens falsely re-triggered the sim
   // (auto-restart in infinite-rays mode; "Configuration changed" in finite mode) because
-  // RenderConfigResimEqual compared these fields. This pin prevents a silent re-add.
+  // the resim projection compared these fields. This pin prevents a silent re-add.
   {
     struct ViewMutator {
       const char* field;
@@ -434,7 +434,7 @@ TEST(GuiStateReconcile, meta_anti_drift) {
   }
 
   // Mutating exposure_offset alone MUST NOT change
-  // GuiEffects — this pins the RenderConfigResimEqual exclusion so a future refactor
+  // GuiEffects — this pins the RenderConfigResimFields exclusion so a future refactor
   // cannot silently re-add EV to the resim diff. Pair to the truth-table pin above.
   {
     GuiState s = MakeBaselineState();


### PR DESCRIPTION
## What

The repo declares one source of truth for "did the configuration change": a predicate over exactly four `RenderConfig` fields (`sim_resolution_index`, `background`, `ray_color`, `opacity`). Revert did not consume it — `ConfigSnapshot::From`/`ApplyTo` copied the whole `RenderConfig`.

The asymmetry that falls out: dragging the view, switching the lens or changing FOV never counts as a change, so the Revert button never lights up for it — but once some *other* edit lights it up, Revert discards the view too. The button's tooltip says "discard the changes"; the behavior was wider than that.

## How

`RenderConfigResimFields` — the resim-eligible projection of `RenderConfig`, written down exactly once. Three questions read that field list, and all three are its own members so they cannot drift apart:

- `From(live)` — capture (what a commit records)
- `Matches(live)` — has it changed in a resim-relevant way? (`DoRun`'s `expect_rebuild`, `DiffAgainstCommitBaseline`)
- `ApplyTo(live)` — restore (what Revert puts back)

`ConfigSnapshot` stores that projection instead of a full `RenderConfig`, so the T-view fields and `exposure_offset` are absent **structurally** — not captured-then-skipped-on-restore, which would leave `From` and `ApplyTo` asymmetric.

Naming the field list once does not by itself keep the three directions in step: `From` aggregate-initializes, so a newly added field would be silently value-initialized rather than rejected. `static_assert(sizeof(RenderConfigResimFields) == 32)` is what turns that omission into a compile error. `sizeof(ConfigSnapshot)` moves 216 → 184.

## Verification

- New pair of nails, pinned together because either alone is satisfiable by a wrong fix: a T-view field (`elevation`) must **survive** Revert, and a judged field (`sim_resolution_index`) must still be **restored**. The first was confirmed red before the fix and green after, on the same build.
- Both drive the production `gui::DoRevert()`, and a third case drives the real top bar, so a future change that restores renderer fields elsewhere on that path is still caught.
- Re-verified after rebasing onto current `main`: build exit 0, `./scripts/test.sh quick` `RESULT: PASS`, full `gui_test` 327/327, `check_policies.py` 14/14, `check_new_refs.py` clean.

## Notes for review

- The free `RenderConfigResimEqual` helper is gone: after both call sites moved to `Matches`, it had zero callers.
- The rename forced a fifth consumer into the open at compile time (`test_config_snapshot.cpp`), which is the mechanism working as intended rather than a surprise.
- `doc/gui-state-governance.md` §8.8 described the old wide baseline in detail — including an explicit warning that the view controls *are* inside Revert's scope. Corrected here, since leaving it would contradict §3 in the same file.
- Manual on-screen confirmation is covered programmatically (real window, real widgets); a human-eye pass over the preview framing is the one thing not automated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)