### PR TITLE
fix(gui): scale preview drag by the lens's angular resolution

### DIFF
--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -1181,16 +1181,22 @@ void RenderPreviewPanel(GLFWwindow* window, float window_width, float window_hei
       ImGuiIO& io = ImGui::GetIO();
       if (is_active && ImGui::IsMouseDragging(ImGuiMouseButton_Left)) {
         ImVec2 delta = io.MouseDelta;
+        // Sensitivity is the lens's angular resolution at the frame center, so one pixel of
+        // drag moves the content one pixel whatever the FOV and viewport are. A fixed deg/px
+        // was ~180x too fast at fov=1° and ~70x too slow at fov=179°. vp_w/vp_h are
+        // framebuffer pixels (set above from the DPI scale), the same units
+        // ProjectWorldDirToScreen works in, which is what makes this DPI-correct for free.
+        float gain = ComputeDragGainDegPerPixel(rc.lens_type, rc.fov, g_preview_vp.vp_w, g_preview_vp.vp_h);
         // Globe is outside-in: u_view_matrix * (0,0,D) yields camera world
         // position, so +az/+el move the camera and the sphere drifts in the
         // opposite direction. Flip both signs so a right/down drag moves the
         // sphere right/down, matching the inside-out lenses' feel.
         if (rc.lens_type == kLensTypeGlobe) {
-          rc.azimuth += delta.x * 0.3f;
-          rc.elevation -= delta.y * 0.3f;
+          rc.azimuth += delta.x * gain;
+          rc.elevation -= delta.y * gain;
         } else {
-          rc.azimuth -= delta.x * 0.3f;
-          rc.elevation += delta.y * 0.3f;
+          rc.azimuth -= delta.x * gain;
+          rc.elevation += delta.y * gain;
         }
         // Wrap azimuth into [-180, 180] so dragging past the slider's clamp
         // boundary continues seamlessly instead of getting pinned at ±180.

--- a/src/gui/preview_renderer.cpp
+++ b/src/gui/preview_renderer.cpp
@@ -1100,8 +1100,18 @@ float ComputeDragGainDegPerPixel(int lens_type, float fov_deg, int vp_w, int vp_
     // bare assert: assert compiles out, and a new lens type that is draggable but
     // missing from this switch would otherwise silently fall back to the old,
     // fov-blind feel with nothing to notice it by.
-    GUI_LOG_WARNING("ComputeDragGainDegPerPixel: no drag-gain law for lens_type {}; falling back to {} deg/px",
-                    lens_type, kLegacyGainDegPerPixel);
+    // Warn once per lens type, not once per frame: this is called from the drag handler, so an
+    // unthrottled warning would emit tens of lines per second and bury the very signal it exists
+    // to raise. The latch is per type rather than a single global flag so a second unknown type
+    // still gets its own line instead of being swallowed by the first one.
+    static thread_local unsigned int warned_lens_types = 0u;
+    const bool latchable = lens_type >= 0 && lens_type < static_cast<int>(sizeof(warned_lens_types) * 8);
+    const unsigned int bit = latchable ? (1u << lens_type) : 0u;
+    if (!latchable || (warned_lens_types & bit) == 0u) {
+      warned_lens_types |= bit;
+      GUI_LOG_WARNING("ComputeDragGainDegPerPixel: no drag-gain law for lens_type {}; falling back to {} deg/px",
+                      lens_type, kLegacyGainDegPerPixel);
+    }
     return kLegacyGainDegPerPixel;
   }
   return rad_per_px * 180.0f / kPi;

--- a/src/gui/preview_renderer.cpp
+++ b/src/gui/preview_renderer.cpp
@@ -839,6 +839,8 @@ static void WorldToView(const ViewProjection& vp, const float world_dir[3], floa
 constexpr float kBehindCameraEps = 1e-5f;
 
 // Linear pinhole: behind-camera ⇒ sentinel; otherwise standard perspective divide.
+// SYNC: ComputeDragGainDegPerPixel's kLensTypeLinear branch is this formula's
+// hand-derived d(theta)/d(r) at theta=0 — changing r(theta) here needs that branch rechecked.
 static std::array<float, 2> ProjectLinear(const float view_dir[3], float half_fov, float img_radius) {
   if (view_dir[2] >= -kBehindCameraEps) {
     return kProjectSentinel;
@@ -852,6 +854,9 @@ static std::array<float, 2> ProjectLinear(const float view_dir[3], float half_fo
 // Forward equation for the single-hemisphere fisheye family (lens=1..3, 8).
 // fisheye_type matches the shader's `fisheyeInverse(... int type)` switch:
 // 0=equal_area, 1=equidistant, 2=stereographic, 3=orthographic.
+// SYNC: ComputeDragGainDegPerPixel's four single-fisheye branches are these
+// r_norm(theta) laws' hand-derived d(theta)/d(r) at theta=0 — changing any of them
+// here needs the matching branch rechecked.
 static std::array<float, 2> ProjectFisheye(const float view_dir[3], float half_fov, float img_radius,
                                            int fisheye_type) {
   if (view_dir[2] > kBehindCameraEps) {
@@ -959,6 +964,9 @@ static std::array<float, 2> ProjectRectangular(const float world_dir[3], float s
 // hemisphere visible to the camera satisfies eye_dir.z > 1/kGlobeCameraD.
 // Math is line-for-line equivalent to overlay_labels.cpp::WorldDirToPixel's
 // globe branch — kGlobeCameraD is the single source of truth (gui_constants.hpp).
+// SYNC: ComputeDragGainDegPerPixel's kLensTypeGlobe branch is this formula's
+// hand-derived d(theta)/d(r) at theta=0 — changing the camera model here needs that
+// branch rechecked.
 static std::array<float, 2> ProjectGlobe(const float eye_dir[3], float half_fov, float img_radius) {
   if (eye_dir[2] <= 1.0f / kGlobeCameraD) {
     return kProjectSentinel;
@@ -1032,6 +1040,71 @@ std::array<float, 2> ProjectWorldDirToScreen(const ViewProjection& vp, const flo
     return kProjectSentinel;
   }
   return out;
+}
+
+// See declaration in preview_renderer.hpp for contract.
+//
+// Each branch is the reciprocal of the corresponding forward projection's radial
+// derivative dr/dtheta evaluated at theta = 0 (the frame center), i.e. it answers
+// "one pixel of screen radius is how many radians of view angle?". img_radius is
+// min(vp_w, vp_h)/2 — the same definition ProjectWorldDirToScreen uses, so the gain
+// and the projection that consumes it share one pixel/DPI convention and window
+// resize needs no extra handling.
+//
+//   lens                        forward r(theta)                       dtheta/dr at 0
+//   --------------------------  -------------------------------------  ---------------------------
+//   kLensTypeLinear             r = focal*tan(theta),                   tan(hf) / R
+//                               focal = R/tan(hf)          (ProjectLinear)
+//   kLensTypeFisheyeEqualArea   r/R = sin(theta/2)/sin(hf/2)   (ProjectFisheye, type 0)
+//                                                                       2*sin(hf/2) / R
+//   kLensTypeFisheyeEquidist    r/R = theta/hf                 (ProjectFisheye, type 1)
+//                                                                       hf / R   (exact for all theta)
+//   kLensTypeFisheyeStereogr.   r/R = tan(theta/2)/tan(hf/2)   (ProjectFisheye, type 2)
+//                                                                       2*tan(hf/2) / R
+//   kLensTypeFisheyeOrthogr.    r/R = sin(theta)/sin(hf)       (ProjectFisheye, type 3)
+//                                                                       sin(hf) / R
+//   kLensTypeGlobe              r = focal*x_eye/(D - z_eye)    (ProjectGlobe)
+//                                                                       (D-1)*tan(hf) / R
+//   (hf = half_fov in radians, R = img_radius, D = kGlobeCameraD)
+//
+// LUMICE_MaxFov() keeps every expression finite over each lens's legal FOV range
+// (linear caps at 179°, short of tan's pole at 180°; globe at 90°), so no extra
+// numerical guard is needed beyond the degenerate-viewport check.
+float ComputeDragGainDegPerPixel(int lens_type, float fov_deg, int vp_w, int vp_h) {
+  constexpr float kPi = 3.14159265358979323846f;
+  // Pre-fov-aware sensitivity. Only reachable via the default branch below, which
+  // no caller should hit — app_panels.cpp only drags when !LensIsFullSky.
+  constexpr float kLegacyGainDegPerPixel = 0.3f;
+
+  if (vp_w <= 0 || vp_h <= 0) {
+    return 0.0f;  // degenerate viewport: produce no rotation this frame
+  }
+  float img_radius = std::min(static_cast<float>(vp_w), static_cast<float>(vp_h)) * 0.5f;
+  float half_fov = fov_deg * 0.5f * kPi / 180.0f;
+
+  float rad_per_px = 0.0f;
+  if (lens_type == kLensTypeLinear) {
+    rad_per_px = std::tan(half_fov) / img_radius;
+  } else if (lens_type == kLensTypeFisheyeEqualArea) {
+    rad_per_px = 2.0f * std::sin(half_fov * 0.5f) / img_radius;
+  } else if (lens_type == kLensTypeFisheyeEquidist) {
+    rad_per_px = half_fov / img_radius;
+  } else if (lens_type == kLensTypeFisheyeStereographic) {
+    rad_per_px = 2.0f * std::tan(half_fov * 0.5f) / img_radius;
+  } else if (lens_type == kLensTypeFisheyeOrthographic) {
+    rad_per_px = std::sin(half_fov) / img_radius;
+  } else if (lens_type == kLensTypeGlobe) {
+    rad_per_px = (kGlobeCameraD - 1.0f) * std::tan(half_fov) / img_radius;
+  } else {
+    // Full-sky (or a newly added) lens type. A release-visible warning rather than a
+    // bare assert: assert compiles out, and a new lens type that is draggable but
+    // missing from this switch would otherwise silently fall back to the old,
+    // fov-blind feel with nothing to notice it by.
+    GUI_LOG_WARNING("ComputeDragGainDegPerPixel: no drag-gain law for lens_type {}; falling back to {} deg/px",
+                    lens_type, kLegacyGainDegPerPixel);
+    return kLegacyGainDegPerPixel;
+  }
+  return rad_per_px * 180.0f / kPi;
 }
 
 void PreviewRenderer::Render(int vp_x, int vp_y, int vp_w, int vp_h, const PreviewParams& params) {

--- a/src/gui/preview_renderer.cpp
+++ b/src/gui/preview_renderer.cpp
@@ -1049,7 +1049,8 @@ std::array<float, 2> ProjectWorldDirToScreen(const ViewProjection& vp, const flo
 // "one pixel of screen radius is how many radians of view angle?". img_radius is
 // min(vp_w, vp_h)/2 — the same definition ProjectWorldDirToScreen uses, so the gain
 // and the projection that consumes it share one pixel/DPI convention and window
-// resize needs no extra handling.
+// resize needs no extra handling. The table below is that 1:1 law; the returned
+// value is it scaled by kDragSensitivity (see the constant for why).
 //
 //   lens                        forward r(theta)                       dtheta/dr at 0
 //   --------------------------  -------------------------------------  ---------------------------
@@ -1073,8 +1074,25 @@ std::array<float, 2> ProjectWorldDirToScreen(const ViewProjection& vp, const flo
 float ComputeDragGainDegPerPixel(int lens_type, float fov_deg, int vp_w, int vp_h) {
   constexpr float kPi = 3.14159265358979323846f;
   // Pre-fov-aware sensitivity. Only reachable via the default branch below, which
-  // no caller should hit — app_panels.cpp only drags when !LensIsFullSky.
+  // no caller should hit — app_panels.cpp only drags when !LensIsFullSky. It is the
+  // historical feel value itself, so kDragSensitivity is deliberately NOT applied to it.
   constexpr float kLegacyGainDegPerPixel = 0.3f;
+
+  // How many screen pixels the content moves per dragged pixel. The closed forms below
+  // are the 1:1 law (one pixel of mouse motion, one pixel of content motion at the frame
+  // center); this multiplier re-anchors that law without touching its shape.
+  //
+  // 1:1 is a hard constraint on a touchscreen — the finger is physically on the content —
+  // but on a mouse it is only one candidate anchor, and it lost the owner's drag test:
+  // measured against the historical 0.3 deg/px on a 900 px short side, the 1:1 law is 2.4x
+  // slower at fov=90°, 4.1x at 60°, 8.8x at 30°, and only overtakes it above fov=134° —
+  // i.e. slower everywhere in daily use. 2.5 puts linear at fov=90°/900 px at 0.318 deg/px,
+  // within 6% of the constant people are already used to.
+  //
+  // What this does NOT change is the property the fov-aware law exists for: the screen
+  // displacement per dragged pixel stays constant across each lens's whole FOV range. Only
+  // the value of that constant moves, from 1 to k.
+  constexpr float kDragSensitivity = 2.5f;
 
   if (vp_w <= 0 || vp_h <= 0) {
     return 0.0f;  // degenerate viewport: produce no rotation this frame
@@ -1104,6 +1122,13 @@ float ComputeDragGainDegPerPixel(int lens_type, float fov_deg, int vp_w, int vp_
     // unthrottled warning would emit tens of lines per second and bury the very signal it exists
     // to raise. The latch is per type rather than a single global flag so a second unknown type
     // still gets its own line instead of being swallowed by the first one.
+    //
+    // thread_local rather than a bare static, even though every caller today is the ImGui
+    // main loop and a bare static would do: the promise this latch makes is "one line per
+    // lens type per thread", which degrades gracefully (an extra line) if someone ever
+    // calls this off the UI thread, whereas a bare static would be an unsynchronized
+    // read-modify-write and thus a data race. The cost of the choice is that promise's
+    // "per thread" qualifier, stated here rather than left for a reader to infer.
     static thread_local unsigned int warned_lens_types = 0u;
     const bool latchable = lens_type >= 0 && lens_type < static_cast<int>(sizeof(warned_lens_types) * 8);
     const unsigned int bit = latchable ? (1u << lens_type) : 0u;
@@ -1114,7 +1139,7 @@ float ComputeDragGainDegPerPixel(int lens_type, float fov_deg, int vp_w, int vp_
     }
     return kLegacyGainDegPerPixel;
   }
-  return rad_per_px * 180.0f / kPi;
+  return rad_per_px * kDragSensitivity * 180.0f / kPi;
 }
 
 void PreviewRenderer::Render(int vp_x, int vp_y, int vp_w, int vp_h, const PreviewParams& params) {

--- a/src/gui/preview_renderer.hpp
+++ b/src/gui/preview_renderer.hpp
@@ -187,11 +187,15 @@ void BuildViewMatrix(float elevation_deg, float azimuth_deg, float roll_deg, flo
 std::array<float, 2> ProjectWorldDirToScreen(const ViewProjection& vp, const float world_dir[3], int vp_w, int vp_h);
 
 // Preview drag sensitivity: how many degrees of azimuth/elevation one pixel of
-// mouse motion should produce, so that content under the cursor moves roughly
-// 1:1 with the cursor at the center of the frame, for any lens/FOV/viewport.
+// mouse motion should produce, so that content at the center of the frame moves
+// a CONSTANT number of screen pixels per dragged pixel, for any lens/FOV/viewport.
+// That constant is kDragSensitivity, calibrated with the implementation; the
+// invariant this function exists for is that the ratio does not depend on FOV or
+// viewport size, not the particular value it holds.
 //
 // This is the analytic inverse of the forward projections' angular resolution at
-// theta=0 — see the derivation table in the definition (preview_renderer.cpp).
+// theta=0, times kDragSensitivity — see the derivation table in the definition
+// (preview_renderer.cpp).
 // Returns 0 for a degenerate viewport (vp_w <= 0 || vp_h <= 0), and the historical
 // constant 0.3 deg/px for a lens type that has no drag interaction (full-sky).
 // Isotropic by construction: azimuth and elevation share one scalar, because the

--- a/src/gui/preview_renderer.hpp
+++ b/src/gui/preview_renderer.hpp
@@ -186,6 +186,18 @@ void BuildViewMatrix(float elevation_deg, float azimuth_deg, float roll_deg, flo
 // / rectangularInverse) in preview_renderer.cpp.
 std::array<float, 2> ProjectWorldDirToScreen(const ViewProjection& vp, const float world_dir[3], int vp_w, int vp_h);
 
+// Preview drag sensitivity: how many degrees of azimuth/elevation one pixel of
+// mouse motion should produce, so that content under the cursor moves roughly
+// 1:1 with the cursor at the center of the frame, for any lens/FOV/viewport.
+//
+// This is the analytic inverse of the forward projections' angular resolution at
+// theta=0 — see the derivation table in the definition (preview_renderer.cpp).
+// Returns 0 for a degenerate viewport (vp_w <= 0 || vp_h <= 0), and the historical
+// constant 0.3 deg/px for a lens type that has no drag interaction (full-sky).
+// Isotropic by construction: azimuth and elevation share one scalar, because the
+// radial projection laws are rotationally symmetric about the optical axis.
+float ComputeDragGainDegPerPixel(int lens_type, float fov_deg, int vp_w, int vp_h);
+
 // Build a ViewProjection from the renderer sub-state of GuiState.
 // roll is wrapped through EffectiveRollForLens so that lens types that ignore
 // roll (e.g. dual-fisheye) always see 0° — mirrors app_panels.cpp:742-747.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -231,6 +231,7 @@ if(BUILD_GUI)
     "${PROJ_TEST_DIR}/unit-correctness/gui/test_crystal_renderer.cpp"
     "${PROJ_TEST_DIR}/unit-correctness/gui/test_state_reconcile.cpp"
     "${PROJ_TEST_DIR}/unit-correctness/gui/test_project_world_dir.cpp"
+    "${PROJ_TEST_DIR}/unit-correctness/gui/test_drag_gain.cpp"
     "${PROJ_TEST_DIR}/unit-correctness/gui/test_render_handedness_guard.cpp"
     "${PROJ_TEST_DIR}/unit-correctness/gui/test_axis_absent_alignment.cpp"
     "${PROJ_TEST_DIR}/unit-correctness/gui/test_user_defaults.cpp"

--- a/test/gui/functional/test_gui_interaction.cpp
+++ b/test/gui/functional/test_gui_interaction.cpp
@@ -2952,7 +2952,21 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
     }
   };
 
-  // T1: Globe drag direction. dx=+60 px @ 0.3 sensitivity → az ≈ +18°.
+  // Degrees the handler should produce for a given pixel delta, read off the live viewport.
+  //
+  // These five cases own the WIRING — sign, wrap, clamp — not the sensitivity law; that law
+  // is ComputeDragGainDegPerPixel's, and it is covered against the projection pipeline in
+  // gui_unit_test (test/unit-correctness/gui/test_drag_gain.cpp). So the expected magnitude
+  // is sourced from the same function the handler calls rather than restated as a literal.
+  // The literals these cases used to carry (±18° for a 60 px drag) were the old fixed
+  // 0.3 deg/px in disguise, which is why making the gain FOV-aware turned four of them red:
+  // they were pinning a constant none of them was about.
+  // static so the captureless TestFunc lambdas below can reach it, same as s_trackball_upload_done.
+  static const auto trackball_expected_deg = [](int lens_type, float fov, float pixels) {
+    return pixels * gui::ComputeDragGainDegPerPixel(lens_type, fov, gui::g_preview_vp.vp_w, gui::g_preview_vp.vp_h);
+  };
+
+  // T1: Globe drag direction — a rightward drag must raise azimuth.
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "lens_globe_trackball");
     t->GuiFunc = trackball_gui_func;
@@ -2969,18 +2983,20 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
       gui::g_state.renderer.roll = 0.0f;
       ctx->Yield(2);
 
+      float expected = trackball_expected_deg(gui::kLensTypeGlobe, 60.0f, 60.0f);
+      IM_CHECK_GT(expected, 1.0f);  // guard: a degenerate viewport would make the check vacuous
       ctx->ItemDragWithDelta("**/##preview_interact", ImVec2(60.0f, 0.0f));
       ctx->Yield(2);
 
-      IM_CHECK_GT(gui::g_state.renderer.azimuth, 17.0f);
-      IM_CHECK_LT(gui::g_state.renderer.azimuth, 19.0f);
+      IM_CHECK_GT(gui::g_state.renderer.azimuth, expected - 1.0f);
+      IM_CHECK_LT(gui::g_state.renderer.azimuth, expected + 1.0f);
       IM_CHECK_LT(std::fabs(gui::g_state.renderer.elevation), 0.5f);
       IM_CHECK_LT(std::fabs(gui::g_state.renderer.roll), 0.001f);
     };
   }
 
-  // T2: non-Globe drag direction is opposite (sign flip in app_panels.cpp:780).
-  // dx=+60 px → az ≈ -18° on FisheyeEquidist.
+  // T2: non-Globe drag direction is opposite (sign flip in app_panels.cpp's else branch):
+  // the same rightward drag must LOWER azimuth on FisheyeEquidist.
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "lens_fisheye_trackball");
     t->GuiFunc = trackball_gui_func;
@@ -2997,18 +3013,24 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
       gui::g_state.renderer.roll = 0.0f;
       ctx->Yield(2);
 
+      float expected = -trackball_expected_deg(gui::kLensTypeFisheyeEquidist, 60.0f, 60.0f);
+      IM_CHECK_LT(expected, -1.0f);  // guard: a degenerate viewport would make the check vacuous
       ctx->ItemDragWithDelta("**/##preview_interact", ImVec2(60.0f, 0.0f));
       ctx->Yield(2);
 
-      IM_CHECK_GT(gui::g_state.renderer.azimuth, -19.0f);
-      IM_CHECK_LT(gui::g_state.renderer.azimuth, -17.0f);
+      IM_CHECK_GT(gui::g_state.renderer.azimuth, expected - 1.0f);
+      IM_CHECK_LT(gui::g_state.renderer.azimuth, expected + 1.0f);
       IM_CHECK_LT(std::fabs(gui::g_state.renderer.elevation), 0.5f);
       IM_CHECK_LT(std::fabs(gui::g_state.renderer.roll), 0.001f);
     };
   }
 
-  // T3: az wrap across +180°. Start az=170, drag dx=+200 → 170 + 60 = 230 →
-  // wrap by -360 → -130. Validates app_panels.cpp:783-789.
+  // T3: az wrap across +180°. Start az=170 and drag right far enough to overshoot 180, which
+  // must wrap by -360 into the negative half rather than pin at +180.
+  //
+  // The overshoot is asserted as a precondition, not assumed: if the gain ever shrinks enough
+  // that 200 px no longer clears the remaining 10°, this case would stop exercising the wrap
+  // and quietly keep passing on an unwrapped value.
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "lens_globe_trackball_az_wrap");
     t->GuiFunc = trackball_gui_func;
@@ -3025,17 +3047,21 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
       gui::g_state.renderer.roll = 0.0f;
       ctx->Yield(2);
 
+      float expected_raw = 170.0f + trackball_expected_deg(gui::kLensTypeGlobe, 60.0f, 200.0f);
+      IM_CHECK_GT(expected_raw, 180.0f);  // precondition: the drag really does cross the seam
       ctx->ItemDragWithDelta("**/##preview_interact", ImVec2(200.0f, 0.0f));
       ctx->Yield(2);
 
-      IM_CHECK_GT(gui::g_state.renderer.azimuth, -131.0f);
-      IM_CHECK_LT(gui::g_state.renderer.azimuth, -129.0f);
+      IM_CHECK_LT(gui::g_state.renderer.azimuth, 0.0f);  // wrapped, not pinned at +180
+      IM_CHECK_GT(gui::g_state.renderer.azimuth, expected_raw - 360.0f - 1.0f);
+      IM_CHECK_LT(gui::g_state.renderer.azimuth, expected_raw - 360.0f + 1.0f);
     };
   }
 
-  // T4: Globe el clamps at ±89° (tighter than non-Globe ±90°). Globe formula
-  // is `el -= dy * 0.3` (app_panels.cpp:778), so dy=-1000 drives +300 toward
-  // the upper limit — far past +89, which std::min collapses to exactly 89.
+  // T4: Globe el clamps at ±89° (tighter than non-Globe ±90°). Globe's elevation update is
+  // `el -= dy * gain`, so an upward drag drives elevation positive; the delta below is sized
+  // to overshoot +89 by a wide margin, and the overshoot is asserted rather than assumed so
+  // the case cannot decay into "never reached the limit, therefore never violated it".
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "lens_globe_trackball_el_clamp");
     t->GuiFunc = trackball_gui_func;
@@ -3052,6 +3078,7 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
       gui::g_state.renderer.roll = 0.0f;
       ctx->Yield(2);
 
+      IM_CHECK_GT(trackball_expected_deg(gui::kLensTypeGlobe, 60.0f, 1000.0f), 89.0f);
       ctx->ItemDragWithDelta("**/##preview_interact", ImVec2(0.0f, -1000.0f));
       ctx->Yield(2);
 
@@ -3060,9 +3087,13 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
     };
   }
 
-  // T5: non-Globe el clamps at ±90° (looser limit branch in app_panels.cpp:792).
-  // Non-Globe formula is `el += dy * 0.3` (app_panels.cpp:781), so dy=+1000
-  // drives +300 toward +90.
+  // T5: non-Globe el clamps at ±90° (the looser limit branch). Non-Globe's update is
+  // `el += dy * gain`, so a downward drag drives elevation positive.
+  //
+  // FOV is 360° (FisheyeEquidist's MaxFov) rather than 60°: the gain is now proportional to
+  // half_fov, and at 60° a 1000 px drag only reaches ~75°, which never touches the clamp.
+  // Same overshoot precondition as T4 — the assertion that this case is still exercising a
+  // clamp at all, rather than passing because the value stayed in range on its own.
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "p2_render", "lens_fisheye_trackball_el_clamp");
     t->GuiFunc = trackball_gui_func;
@@ -3073,12 +3104,13 @@ void RegisterP2InteractionRenderTests(ImGuiTestEngine* engine) {
       IM_CHECK(gui::g_preview.HasTexture());
 
       gui::g_state.renderer.lens_type = gui::kLensTypeFisheyeEquidist;
-      gui::g_state.renderer.fov = 60.0f;
+      gui::g_state.renderer.fov = 360.0f;
       gui::g_state.renderer.azimuth = 0.0f;
       gui::g_state.renderer.elevation = 0.0f;
       gui::g_state.renderer.roll = 0.0f;
       ctx->Yield(2);
 
+      IM_CHECK_GT(trackball_expected_deg(gui::kLensTypeFisheyeEquidist, 360.0f, 1000.0f), 90.0f);
       ctx->ItemDragWithDelta("**/##preview_interact", ImVec2(0.0f, 1000.0f));
       ctx->Yield(2);
 

--- a/test/unit-correctness/gui/test_drag_gain.cpp
+++ b/test/unit-correctness/gui/test_drag_gain.cpp
@@ -11,12 +11,12 @@
 //
 // A note on step size, which is the honest boundary of this design: the gain is a DERIVATIVE
 // (exact at the frame center only, to first order). At the top of a lens's FOV range the
-// angular resolution at the center is enormous — linear at fov=179° is ~21.9 deg per pixel —
-// so a "20 px drag" there is a 438° rotation and no linearization survives it. The probe tests
-// therefore normalize the step to a fixed small ANGLE and assert the ratio is 1; the
-// realistic-drag tests use whole-pixel deltas only where the second-order term is genuinely
-// negligible. Widening either one's tolerance to make an extreme-FOV whole-pixel case pass
-// would be measuring the linearization error, not the gain.
+// angular resolution at the center is enormous — linear at fov=179° is ~54.7 deg per pixel —
+// so a "20 px drag" there is a full revolution and no linearization survives it. The probe
+// tests therefore normalize the step to a fixed small ANGLE; the realistic-drag test uses
+// whole-pixel deltas and states its tolerance as the analytic second-order bound for the
+// angle each case actually sweeps, so the budget follows the sensitivity instead of being a
+// hand-tuned number that silently goes stale when the sensitivity changes.
 
 #include <gtest/gtest.h>
 
@@ -37,6 +37,15 @@ using lumice::gui::ViewProjection;
 
 constexpr float kSentinelLimit = -9000.f;  // any helper output <= this is the sentinel
 constexpr float kPi = 3.14159265358979323846f;
+
+// Screen pixels the content must travel per dragged pixel — the owner-calibrated sensitivity
+// (AC1's revised anchor). Restated here as a literal rather than imported from the production
+// side on purpose: this value is a product decision, so the test's job is to hold it, not to
+// agree with whatever the implementation currently says. Changing kDragSensitivity in
+// preview_renderer.cpp without changing this turns every round trip below red, which is the
+// intended signal. The FOV-independence of the ratio — the actual defect this task fixes — is
+// asserted separately and does not depend on the value.
+constexpr float kExpectedSensitivity = 2.5f;
 
 bool IsSentinel(const std::array<float, 2>& p) {
   return p[0] <= kSentinelLimit && p[1] <= kSentinelLimit;
@@ -153,9 +162,10 @@ const std::vector<Viewport>& Viewports() {
 // between them with roughly an order of magnitude of headroom on each side.
 //
 // The pixel cap is the one place the frame gets a say: at narrow FOV, 0.02 rad is a large
-// fraction of the whole field, so the probe is also held to 40% of img_radius, keeping the
-// projected point comfortably inside the viewport (and inside the fisheye imaging circle)
-// rather than clipping to the sentinel.
+// fraction of the whole field, so the probe is also held to a drag whose RESULTING content
+// displacement is 40% of img_radius, keeping the projected point comfortably inside the
+// viewport (and inside the fisheye imaging circle) rather than clipping to the sentinel.
+// The displacement is kExpectedSensitivity times the drag, hence the division.
 constexpr float kProbeAngleRad = 0.02f;
 constexpr float kProbeFrameFraction = 0.4f;
 
@@ -167,7 +177,7 @@ constexpr float kRoundTripTol = 2e-3f;
 float ProbePixels(float gain_deg_per_px, int vp_w, int vp_h) {
   float gain_rad_per_px = gain_deg_per_px * kPi / 180.0f;
   float img_radius = std::min(static_cast<float>(vp_w), static_cast<float>(vp_h)) * 0.5f;
-  return std::min(kProbeFrameFraction * img_radius, kProbeAngleRad / gain_rad_per_px);
+  return std::min(kProbeFrameFraction * img_radius / kExpectedSensitivity, kProbeAngleRad / gain_rad_per_px);
 }
 
 std::string Label(const LensCase& lc, float fov, const Viewport& vp, float dx, float dy) {
@@ -231,10 +241,11 @@ TEST(DragGain, GlobeReferenceIsMirroredVersusInsideOutLenses) {
 // ---------------------------------------------------------------------------------------
 // AC1 / AC2 / AC3 — the main event. For every draggable lens, across its own full FOV range,
 // on square / landscape / portrait / HiDPI viewports, in both directions on both axes: one
-// pixel of drag moves the content one pixel. Constant across the FOV range is the whole
-// point — the same assertion with the same tolerance holds at fov=1° and at fov=MaxFov.
+// pixel of drag moves the content kExpectedSensitivity pixels. Constant across the FOV range
+// is the whole point — the same assertion with the same tolerance holds at fov=1° and at
+// fov=MaxFov.
 // ---------------------------------------------------------------------------------------
-TEST(DragGain, HorizontalDragMovesContentOnePixelPerPixel) {
+TEST(DragGain, HorizontalDragMovesContentAtFixedPixelRatio) {
   for (const auto& lc : DraggableLenses()) {
     for (float fov : FovLadder(lc)) {
       for (const auto& vp : Viewports()) {
@@ -244,16 +255,19 @@ TEST(DragGain, HorizontalDragMovesContentOnePixelPerPixel) {
         for (float dx : { step, -step }) {
           auto p = RoundTrip(lc, fov, vp, dx, 0.0f);
           ASSERT_FALSE(IsSentinel(p)) << Label(lc, fov, vp, dx, 0.0f);
-          // Content follows the cursor: +dx of mouse motion => +dx of screen-x motion.
-          EXPECT_NEAR(p[0] / dx, 1.0f, kRoundTripTol) << Label(lc, fov, vp, dx, 0.0f);
-          EXPECT_NEAR(p[1], 0.0f, std::abs(dx) * kRoundTripTol) << Label(lc, fov, vp, dx, 0.0f);
+          // Content follows the cursor: +dx of mouse motion => +k*dx of screen-x motion.
+          // Written as a ratio against the expectation so kRoundTripTol stays a RELATIVE
+          // budget; comparing p[0]/dx against k directly would silently hand it k times
+          // the slack.
+          EXPECT_NEAR(p[0] / (dx * kExpectedSensitivity), 1.0f, kRoundTripTol) << Label(lc, fov, vp, dx, 0.0f);
+          EXPECT_NEAR(p[1], 0.0f, std::abs(dx) * kExpectedSensitivity * kRoundTripTol) << Label(lc, fov, vp, dx, 0.0f);
         }
       }
     }
   }
 }
 
-TEST(DragGain, VerticalDragMovesContentOnePixelPerPixel) {
+TEST(DragGain, VerticalDragMovesContentAtFixedPixelRatio) {
   for (const auto& lc : DraggableLenses()) {
     for (float fov : FovLadder(lc)) {
       for (const auto& vp : Viewports()) {
@@ -264,10 +278,10 @@ TEST(DragGain, VerticalDragMovesContentOnePixelPerPixel) {
           auto p = RoundTrip(lc, fov, vp, 0.0f, dy);
           ASSERT_FALSE(IsSentinel(p)) << Label(lc, fov, vp, 0.0f, dy);
           // ImGui's mouse y is DOWN-positive, the projection's py is UP-positive, so
-          // content following the cursor means py = -dy. This is also where a globe sign
+          // content following the cursor means py = -k*dy. This is also where a globe sign
           // regression would surface: its elevation update is -= where the others are +=.
-          EXPECT_NEAR(p[1] / dy, -1.0f, kRoundTripTol) << Label(lc, fov, vp, 0.0f, dy);
-          EXPECT_NEAR(p[0], 0.0f, std::abs(dy) * kRoundTripTol) << Label(lc, fov, vp, 0.0f, dy);
+          EXPECT_NEAR(p[1] / (dy * kExpectedSensitivity), -1.0f, kRoundTripTol) << Label(lc, fov, vp, 0.0f, dy);
+          EXPECT_NEAR(p[0], 0.0f, std::abs(dy) * kExpectedSensitivity * kRoundTripTol) << Label(lc, fov, vp, 0.0f, dy);
         }
       }
     }
@@ -300,21 +314,40 @@ TEST(DragGain, RealisticDragStepsAtModerateFov) {
     { lumice::gui::kLensTypeGlobe, "globe", 90.0f },
   };
   const Viewport vp = { 1280, 720, "1280x720" };
-  // 3% absorbs the second-order term of the widest combo here (linear at fov=150°, where a
-  // 20 px step is 0.25 rad and tan(theta)/theta = 1.021). Every other combo lands well
-  // inside it; this is a linearization budget, not a fudge factor.
-  constexpr float kRelTol = 0.03f;
+
+  // The tolerance is DERIVED per case, not tuned: the gain is a first derivative, so the
+  // round trip is off by each law's second-order term in the swept angle theta. Over the six
+  // laws those terms are theta^2/3 (linear, globe), theta^2/12 (stereographic), theta^2/6
+  // (orthographic), theta^2/24 (equal-area) and exactly 0 (equidistant), so theta^2/3 bounds
+  // them all; 1.5x covers the theta^4 remainder, and a 0.5% floor keeps the near-zero cases
+  // from being pinned tighter than float noise.
+  //
+  // A single hand-tuned constant was what this test used to have, and raising the sensitivity
+  // to k=2.5 multiplied every swept angle by 2.5 and quadrupled these terms — linear at
+  // fov=150° went from 1.5% to 10.3%. A fixed budget would have had to be widened by hand,
+  // which reads identically to widening it to hide a defect. Deriving it removes the choice.
+  auto tolerance_for = [](float gain_deg_per_px, float pixels) {
+    float theta = std::abs(pixels) * gain_deg_per_px * kPi / 180.0f;
+    return std::max(0.005f, 1.5f * theta * theta / 3.0f);
+  };
 
   for (const auto& c : kCombos) {
     LensCase lc = { c.lens_type, c.name, 0.0f };
+    float gain = ComputeDragGainDegPerPixel(c.lens_type, c.fov, vp.w, vp.h);
+    ASSERT_GT(gain, 0.0f) << c.name;
     for (float d : { 5.0f, 20.0f, -5.0f, -20.0f }) {
+      float tol = tolerance_for(gain, d);
+      // The budget must stay well under the effects it has to separate: the smallest defect
+      // this suite is built to catch is a missing factor (>=2x, i.e. 100%).
+      ASSERT_LT(tol, 0.2f) << Label(lc, c.fov, vp, d, 0.0f);
+
       auto px = RoundTrip(lc, c.fov, vp, d, 0.0f);
       ASSERT_FALSE(IsSentinel(px)) << Label(lc, c.fov, vp, d, 0.0f);
-      EXPECT_NEAR(px[0] / d, 1.0f, kRelTol) << Label(lc, c.fov, vp, d, 0.0f);
+      EXPECT_NEAR(px[0] / (d * kExpectedSensitivity), 1.0f, tol) << Label(lc, c.fov, vp, d, 0.0f);
 
       auto py = RoundTrip(lc, c.fov, vp, 0.0f, d);
       ASSERT_FALSE(IsSentinel(py)) << Label(lc, c.fov, vp, 0.0f, d);
-      EXPECT_NEAR(py[1] / d, -1.0f, kRelTol) << Label(lc, c.fov, vp, 0.0f, d);
+      EXPECT_NEAR(py[1] / (d * kExpectedSensitivity), -1.0f, tol) << Label(lc, c.fov, vp, 0.0f, d);
     }
   }
 }
@@ -355,29 +388,32 @@ TEST(DragGain, GovernedByShorterViewportSide) {
 // ---------------------------------------------------------------------------------------
 TEST(DragGain, ClosedFormAnchors) {
   constexpr float kRad2Deg = 180.0f / kPi;
+  // Every anchor is the 1:1 closed form times the sensitivity, so a k that stopped being
+  // applied — or got applied to the legacy fallback too — shows up here as well.
+  constexpr float kK = kExpectedSensitivity;
 
   // linear, fov=90 => half_fov=45°, tan(45°)=1 => 1/img_radius rad/px. img_radius = 400.
-  EXPECT_NEAR(ComputeDragGainDegPerPixel(lumice::gui::kLensTypeLinear, 90.0f, 800, 800), kRad2Deg / 400.0f, 1e-5f);
+  EXPECT_NEAR(ComputeDragGainDegPerPixel(lumice::gui::kLensTypeLinear, 90.0f, 800, 800), kK * kRad2Deg / 400.0f, 1e-5f);
 
   // fisheye equidistant, fov=180 => half_fov=pi/2 => (pi/2)/img_radius rad/px, i.e. the
   // whole 90° half-field spans exactly img_radius pixels. img_radius = 300.
-  EXPECT_NEAR(ComputeDragGainDegPerPixel(lumice::gui::kLensTypeFisheyeEquidist, 180.0f, 800, 600), 90.0f / 300.0f,
+  EXPECT_NEAR(ComputeDragGainDegPerPixel(lumice::gui::kLensTypeFisheyeEquidist, 180.0f, 800, 600), kK * 90.0f / 300.0f,
               1e-5f);
 
   // fisheye orthographic, fov=180 => sin(90°)=1 => 1/img_radius rad/px. img_radius = 300.
   EXPECT_NEAR(ComputeDragGainDegPerPixel(lumice::gui::kLensTypeFisheyeOrthographic, 180.0f, 800, 600),
-              kRad2Deg / 300.0f, 1e-5f);
+              kK * kRad2Deg / 300.0f, 1e-5f);
 
   // fisheye equal area, fov=180 => 2*sin(45°)=sqrt(2) => sqrt(2)/img_radius rad/px.
   EXPECT_NEAR(ComputeDragGainDegPerPixel(lumice::gui::kLensTypeFisheyeEqualArea, 180.0f, 800, 600),
-              std::sqrt(2.0f) * kRad2Deg / 300.0f, 1e-5f);
+              kK * std::sqrt(2.0f) * kRad2Deg / 300.0f, 1e-5f);
 
   // fisheye stereographic, fov=180 => 2*tan(45°)=2 => 2/img_radius rad/px.
   EXPECT_NEAR(ComputeDragGainDegPerPixel(lumice::gui::kLensTypeFisheyeStereographic, 180.0f, 800, 600),
-              2.0f * kRad2Deg / 300.0f, 1e-5f);
+              kK * 2.0f * kRad2Deg / 300.0f, 1e-5f);
 
   // globe, fov=90 => (D-1)*tan(45°) = 3 => 3/img_radius rad/px. img_radius = 300.
-  EXPECT_NEAR(ComputeDragGainDegPerPixel(lumice::gui::kLensTypeGlobe, 90.0f, 800, 600), 3.0f * kRad2Deg / 300.0f,
+  EXPECT_NEAR(ComputeDragGainDegPerPixel(lumice::gui::kLensTypeGlobe, 90.0f, 800, 600), kK * 3.0f * kRad2Deg / 300.0f,
               1e-4f);
 }
 
@@ -404,8 +440,10 @@ TEST(DragGain, SmallFovLawsConvergeToEquidistant) {
     float reference = ComputeDragGainDegPerPixel(lumice::gui::kLensTypeFisheyeEquidist, fov, kW, kH);
     ASSERT_GT(reference, 0.0f);
     // The equidistant law IS half_fov / img_radius, exactly and at every FOV — it is the
-    // limit itself, so it is the natural yardstick for the other five.
-    EXPECT_NEAR(reference, (fov * 0.5f) / 300.0f, 1e-6f) << "fov=" << fov;
+    // limit itself, so it is the natural yardstick for the other five. (Scaled by the
+    // sensitivity, like every branch; the five ratios below are unaffected by that scale,
+    // which is why this one line is where k enters this test.)
+    EXPECT_NEAR(reference, kExpectedSensitivity * (fov * 0.5f) / 300.0f, 1e-6f) << "fov=" << fov;
 
     // Every law's departure from the shared limit is second order in half_fov, with 1/3 the
     // largest coefficient among the six (tan(hf)/hf - 1 = hf^2/3, hit by both linear and
@@ -423,14 +461,16 @@ TEST(DragGain, SmallFovLawsConvergeToEquidistant) {
   }
 }
 
-// The 0.3 deg/px the drag used before this became FOV-aware, quantified: at the default
-// 30° linear preview it was ~2.3x too slow, and at fov=1° it was ~180x too fast. That
-// spread is the defect AC1 names, recorded here so a regression to a constant is visible.
+// The 0.3 deg/px the drag used before this became FOV-aware, quantified on this 800x600
+// viewport: at fov=1° the constant was ~72x too fast (0.3 vs 0.0042 deg/px) and at fov=179°
+// ~180x too slow (0.3 vs 54.7). The sensitivity calibration deliberately keeps the two laws
+// close in the mid band — 2.3x apart at the 30° default here — so the SPREAD is what this
+// pins, and it is the defect AC1 names: a regression to any single constant fails one end.
 TEST(DragGain, FovAwareGainSpansTheRangeTheConstantMissed) {
   float narrow = ComputeDragGainDegPerPixel(lumice::gui::kLensTypeLinear, 1.0f, 800, 600);
   float wide = ComputeDragGainDegPerPixel(lumice::gui::kLensTypeLinear, 179.0f, 800, 600);
-  EXPECT_LT(narrow, 0.3f / 100.0f);
-  EXPECT_GT(wide, 0.3f * 50.0f);
+  EXPECT_LT(narrow, 0.3f / 50.0f);
+  EXPECT_GT(wide, 0.3f * 100.0f);
 }
 
 // ---------------------------------------------------------------------------------------
@@ -445,6 +485,11 @@ TEST(DragGain, DegenerateViewportProducesNoRotation) {
 // Full-sky lenses never reach the drag branch (app_panels.cpp guards on !LensIsFullSky), so
 // this is the defensive fallback, not a live path: it must stay finite and match the legacy
 // constant rather than return 0 or NaN.
+//
+// Exactly 0.3, NOT 0.3 * kExpectedSensitivity: the fallback IS the historical feel value, and
+// the sensitivity constant exists to bring the closed forms up to it, not to be stacked on top
+// of it. Applying k to this branch too would be a silent 2.5x on the one path that is supposed
+// to change nothing, so the exact compare here is the guard against that.
 TEST(DragGain, FullSkyLensesFallBackToLegacyConstant) {
   for (int lt : lumice::gui::kFullSkyLensTypes) {
     EXPECT_FLOAT_EQ(ComputeDragGainDegPerPixel(lt, 180.0f, 800, 600), 0.3f) << "lens_type " << lt;

--- a/test/unit-correctness/gui/test_drag_gain.cpp
+++ b/test/unit-correctness/gui/test_drag_gain.cpp
@@ -1,0 +1,452 @@
+// Pure-CPU unit tests for ComputeDragGainDegPerPixel — the preview drag sensitivity law.
+// No GL context and no ImGui, which is why they live in gui_unit_test rather than gui_test.
+//
+// The contract under test is not "the closed form matches the closed form" (that would be a
+// tautology): it is the end-to-end statement the drag interaction actually owes the user —
+// feed the gain through the SAME azimuth/elevation update rule app_panels.cpp uses, then let
+// the UNMODIFIED production projection (ProjectWorldDirToScreen / BuildViewMatrix) say where
+// the reference sky point landed. If the hand-derived derivative in preview_renderer.cpp is
+// off by a factor, a sign, or disagrees with the projection's img_radius / theta conventions,
+// the round trip misses and no amount of "the formula looks right" hides it.
+//
+// A note on step size, which is the honest boundary of this design: the gain is a DERIVATIVE
+// (exact at the frame center only, to first order). At the top of a lens's FOV range the
+// angular resolution at the center is enormous — linear at fov=179° is ~21.9 deg per pixel —
+// so a "20 px drag" there is a 438° rotation and no linearization survives it. The probe tests
+// therefore normalize the step to a fixed small ANGLE and assert the ratio is 1; the
+// realistic-drag tests use whole-pixel deltas only where the second-order term is genuinely
+// negligible. Widening either one's tolerance to make an extreme-FOV whole-pixel case pass
+// would be measuring the linearization error, not the gain.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <string>
+#include <vector>
+
+#include "gui/gui_constants.hpp"
+#include "gui/preview_renderer.hpp"
+
+namespace {
+
+using lumice::gui::ComputeDragGainDegPerPixel;
+using lumice::gui::ProjectWorldDirToScreen;
+using lumice::gui::ViewProjection;
+
+constexpr float kSentinelLimit = -9000.f;  // any helper output <= this is the sentinel
+constexpr float kPi = 3.14159265358979323846f;
+
+bool IsSentinel(const std::array<float, 2>& p) {
+  return p[0] <= kSentinelLimit && p[1] <= kSentinelLimit;
+}
+
+ViewProjection MakeVp(int lens_type, float fov, float elev, float az) {
+  ViewProjection vp;
+  vp.lens_type = lens_type;
+  vp.fov = fov;
+  vp.elevation = elev;
+  vp.azimuth = az;
+  vp.roll = 0.0f;
+  vp.visible = lumice::gui::kVisibleFull;
+  return vp;
+}
+
+// The world point that sits exactly at the frame center when azimuth = elevation = roll = 0.
+//
+// BuildViewMatrix documents the camera as looking at world (-1,0,0) in that pose, and that is
+// the reference used by the five inside-out lenses. Globe is the exception: ProjectGlobe
+// reinterprets the WorldToView output as a POSITION in eye space rather than a view direction,
+// so (-1,0,0) becomes eye_dir.z = -1, which fails its eye_dir.z > 1/kGlobeCameraD visibility
+// test and returns the sentinel; (+1,0,0) is the one that lands at the center. GlobeReference
+// (below) is a standing check on that asymmetry, so the choice here is measured, not assumed.
+const float* ReferenceWorldDir(int lens_type) {
+  static const float kFront[3] = { -1.0f, 0.0f, 0.0f };
+  static const float kBack[3] = { 1.0f, 0.0f, 0.0f };
+  return lens_type == lumice::gui::kLensTypeGlobe ? kBack : kFront;
+}
+
+// Verbatim mirror of the update rule in app_panels.cpp's drag branch — including the globe
+// sign flip, which exists so a right/down drag moves the sphere right/down like the inside-out
+// lenses. Copied rather than re-derived: a test that invents its own sign convention would
+// pass while the app drags backwards.
+//
+//   if (rc.lens_type == kLensTypeGlobe) { rc.azimuth += delta.x * g; rc.elevation -= delta.y * g; }
+//   else                                { rc.azimuth -= delta.x * g; rc.elevation += delta.y * g; }
+//
+// The azimuth wrap and the elevation clamp are carried over too, so the mirror is the whole
+// branch rather than the convenient half of it. Neither fires for the step sizes used here —
+// every case stays well inside ±180° / ±89° — but leaving them out would make the helper a
+// selective copy, and the next person to grow the step sizes would not find out.
+ViewProjection ApplyDrag(int lens_type, float fov, float gain_deg_per_px, float delta_x, float delta_y) {
+  float az = 0.0f;
+  float el = 0.0f;
+  if (lens_type == lumice::gui::kLensTypeGlobe) {
+    az += delta_x * gain_deg_per_px;
+    el -= delta_y * gain_deg_per_px;
+  } else {
+    az -= delta_x * gain_deg_per_px;
+    el += delta_y * gain_deg_per_px;
+  }
+  if (az > 180.0f) {
+    az -= 360.0f;
+  } else if (az < -180.0f) {
+    az += 360.0f;
+  }
+  float el_lim = (lens_type == lumice::gui::kLensTypeGlobe) ? 89.0f : 90.0f;
+  el = std::max(-el_lim, std::min(el_lim, el));
+  return MakeVp(lens_type, fov, el, az);
+}
+
+struct LensCase {
+  int lens_type;
+  const char* name;
+  float max_fov;  // LUMICE_MaxFov for this lens, per src/config/render_config.cpp MaxFov()
+  float min_fov;  // lowest FOV at which ProjectWorldDirToScreen is usable as an oracle — see below
+};
+
+// The six lens types that currently enable dragging, i.e. exactly !LensIsFullSky.
+// AC2's "all lens types with drag enabled" is this list.
+//
+// min_fov is a property of the ORACLE, not of the gain. ProjectFisheye recovers the view angle
+// with acos(-view_dir.z), and 1 - cos(theta) ~ theta^2/2 falls under the float ulp at 1.0
+// (5.96e-8) once theta drops below ~3.5e-4 rad — cos returns exactly 1.0f and the angle is
+// gone. Measured: at fisheye fov=1° a 10 px probe is theta = 2.18e-4 rad and the oracle reports
+// theta = 0, i.e. 100% of the angle lost. ProjectLinear and ProjectGlobe divide instead of
+// taking an acos, so they hold their precision all the way down and keep min_fov = 1.
+// The fisheye band below 8° is instead covered by SmallFovLawsConvergeToEquidistant, which
+// checks the four fisheye laws against an independent analytic limit rather than a projection.
+const std::vector<LensCase>& DraggableLenses() {
+  static const std::vector<LensCase> kCases = {
+    { lumice::gui::kLensTypeLinear, "linear", 179.0f, 1.0f },
+    { lumice::gui::kLensTypeFisheyeEqualArea, "fisheye_equal_area", 360.0f, 8.0f },
+    { lumice::gui::kLensTypeFisheyeEquidist, "fisheye_equidistant", 360.0f, 8.0f },
+    { lumice::gui::kLensTypeFisheyeStereographic, "fisheye_stereographic", 359.0f, 8.0f },
+    { lumice::gui::kLensTypeFisheyeOrthographic, "fisheye_orthographic", 180.0f, 8.0f },
+    { lumice::gui::kLensTypeGlobe, "globe", 90.0f, 1.0f },
+  };
+  return kCases;
+}
+
+struct Viewport {
+  int w;
+  int h;
+  const char* name;
+};
+
+// Square, landscape, portrait, and a 2x-DPI landscape (AC3: the gain must be expressed in
+// framebuffer pixels, so the 2x viewport is the same physical feel at twice the pixel delta).
+const std::vector<Viewport>& Viewports() {
+  static const std::vector<Viewport> kVps = {
+    { 800, 800, "800x800" },
+    { 1280, 720, "1280x720" },
+    { 600, 900, "600x900" },
+    { 2560, 1440, "2560x1440_hidpi" },
+  };
+  return kVps;
+}
+
+// The probe is sized by ANGLE, not by pixels, because both error sources that bound it are
+// angular: the linearization error above (worst case tan(theta)/theta - 1 = theta^2/3, so
+// 1.3e-4 at 0.02 rad) and the oracle's float floor below (see DraggableLenses). 0.02 rad sits
+// between them with roughly an order of magnitude of headroom on each side.
+//
+// The pixel cap is the one place the frame gets a say: at narrow FOV, 0.02 rad is a large
+// fraction of the whole field, so the probe is also held to 40% of img_radius, keeping the
+// projected point comfortably inside the viewport (and inside the fisheye imaging circle)
+// rather than clipping to the sentinel.
+constexpr float kProbeAngleRad = 0.02f;
+constexpr float kProbeFrameFraction = 0.4f;
+
+// 2e-3 is ~15x the worst linearization term in play and ~25x the worst oracle float noise,
+// while any real defect in a gain branch (a missing factor of 2, a sin/tan swap, a wrong
+// img_radius) is a several-percent-to-several-hundred-percent effect. It separates the two.
+constexpr float kRoundTripTol = 2e-3f;
+
+float ProbePixels(float gain_deg_per_px, int vp_w, int vp_h) {
+  float gain_rad_per_px = gain_deg_per_px * kPi / 180.0f;
+  float img_radius = std::min(static_cast<float>(vp_w), static_cast<float>(vp_h)) * 0.5f;
+  return std::min(kProbeFrameFraction * img_radius, kProbeAngleRad / gain_rad_per_px);
+}
+
+std::string Label(const LensCase& lc, float fov, const Viewport& vp, float dx, float dy) {
+  return std::string(lc.name) + " fov=" + std::to_string(fov) + " vp=" + vp.name + " delta=(" + std::to_string(dx) +
+         "," + std::to_string(dy) + ")";
+}
+
+// One round trip: drag by (dx, dy) screen pixels, reproject the reference sky point, and
+// report where it landed. Screen coords are the projection's own y-up pixel frame, so a
+// mouse delta of +dy (ImGui y is DOWN-positive) must move the content to py = -dy.
+std::array<float, 2> RoundTrip(const LensCase& lc, float fov, const Viewport& vp, float dx, float dy) {
+  float gain = ComputeDragGainDegPerPixel(lc.lens_type, fov, vp.w, vp.h);
+  ViewProjection dragged = ApplyDrag(lc.lens_type, fov, gain, dx, dy);
+  return ProjectWorldDirToScreen(dragged, ReferenceWorldDir(lc.lens_type), vp.w, vp.h);
+}
+
+// FOV ladder for a lens: its oracle-usable floor, a narrow value, mid-range, and two rungs up
+// against its own MaxFov. The near-max rungs are the ones that matter — that is where a
+// uniform fov/height approximation would have been wrong by ~70x for linear and stereographic,
+// which is the whole reason this task took the per-lens closed form.
+std::vector<float> FovLadder(const LensCase& lc) {
+  std::vector<float> ladder = { lc.min_fov, 15.0f, lc.max_fov * 0.5f, lc.max_fov * 0.9f, lc.max_fov - 0.5f };
+  ladder.erase(
+      std::remove_if(ladder.begin(), ladder.end(), [&lc](float f) { return f < lc.min_fov || f > lc.max_fov; }),
+      ladder.end());
+  return ladder;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------------------
+// Precondition for every round trip below: the reference world point really is the frame
+// center at the identity pose, and globe really is the one that needs (+1,0,0). If this
+// flips, the round-trip assertions are measuring the wrong thing.
+// ---------------------------------------------------------------------------------------
+TEST(DragGain, ReferencePointIsFrameCenter) {
+  for (const auto& lc : DraggableLenses()) {
+    auto vp = MakeVp(lc.lens_type, 60.0f, 0.0f, 0.0f);
+    auto p = ProjectWorldDirToScreen(vp, ReferenceWorldDir(lc.lens_type), 800, 600);
+    ASSERT_FALSE(IsSentinel(p)) << lc.name;
+    EXPECT_NEAR(p[0], 0.0f, 1e-3f) << lc.name;
+    EXPECT_NEAR(p[1], 0.0f, 1e-3f) << lc.name;
+  }
+}
+
+TEST(DragGain, GlobeReferenceIsMirroredVersusInsideOutLenses) {
+  const float front[3] = { -1.0f, 0.0f, 0.0f };
+  const float back[3] = { 1.0f, 0.0f, 0.0f };
+
+  // Globe: the inside-out lenses' front direction is NOT visible (eye_dir.z = -1).
+  auto globe = MakeVp(lumice::gui::kLensTypeGlobe, 60.0f, 0.0f, 0.0f);
+  EXPECT_TRUE(IsSentinel(ProjectWorldDirToScreen(globe, front, 800, 600)));
+  EXPECT_FALSE(IsSentinel(ProjectWorldDirToScreen(globe, back, 800, 600)));
+
+  // Linear: the mirror image of the above.
+  auto linear = MakeVp(lumice::gui::kLensTypeLinear, 60.0f, 0.0f, 0.0f);
+  EXPECT_FALSE(IsSentinel(ProjectWorldDirToScreen(linear, front, 800, 600)));
+  EXPECT_TRUE(IsSentinel(ProjectWorldDirToScreen(linear, back, 800, 600)));
+}
+
+// ---------------------------------------------------------------------------------------
+// AC1 / AC2 / AC3 — the main event. For every draggable lens, across its own full FOV range,
+// on square / landscape / portrait / HiDPI viewports, in both directions on both axes: one
+// pixel of drag moves the content one pixel. Constant across the FOV range is the whole
+// point — the same assertion with the same tolerance holds at fov=1° and at fov=MaxFov.
+// ---------------------------------------------------------------------------------------
+TEST(DragGain, HorizontalDragMovesContentOnePixelPerPixel) {
+  for (const auto& lc : DraggableLenses()) {
+    for (float fov : FovLadder(lc)) {
+      for (const auto& vp : Viewports()) {
+        float gain = ComputeDragGainDegPerPixel(lc.lens_type, fov, vp.w, vp.h);
+        ASSERT_GT(gain, 0.0f) << Label(lc, fov, vp, 0, 0);
+        float step = ProbePixels(gain, vp.w, vp.h);
+        for (float dx : { step, -step }) {
+          auto p = RoundTrip(lc, fov, vp, dx, 0.0f);
+          ASSERT_FALSE(IsSentinel(p)) << Label(lc, fov, vp, dx, 0.0f);
+          // Content follows the cursor: +dx of mouse motion => +dx of screen-x motion.
+          EXPECT_NEAR(p[0] / dx, 1.0f, kRoundTripTol) << Label(lc, fov, vp, dx, 0.0f);
+          EXPECT_NEAR(p[1], 0.0f, std::abs(dx) * kRoundTripTol) << Label(lc, fov, vp, dx, 0.0f);
+        }
+      }
+    }
+  }
+}
+
+TEST(DragGain, VerticalDragMovesContentOnePixelPerPixel) {
+  for (const auto& lc : DraggableLenses()) {
+    for (float fov : FovLadder(lc)) {
+      for (const auto& vp : Viewports()) {
+        float gain = ComputeDragGainDegPerPixel(lc.lens_type, fov, vp.w, vp.h);
+        ASSERT_GT(gain, 0.0f) << Label(lc, fov, vp, 0, 0);
+        float step = ProbePixels(gain, vp.w, vp.h);
+        for (float dy : { step, -step }) {
+          auto p = RoundTrip(lc, fov, vp, 0.0f, dy);
+          ASSERT_FALSE(IsSentinel(p)) << Label(lc, fov, vp, 0.0f, dy);
+          // ImGui's mouse y is DOWN-positive, the projection's py is UP-positive, so
+          // content following the cursor means py = -dy. This is also where a globe sign
+          // regression would surface: its elevation update is -= where the others are +=.
+          EXPECT_NEAR(p[1] / dy, -1.0f, kRoundTripTol) << Label(lc, fov, vp, 0.0f, dy);
+          EXPECT_NEAR(p[0], 0.0f, std::abs(dy) * kRoundTripTol) << Label(lc, fov, vp, 0.0f, dy);
+        }
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------------------
+// The same contract stated in whole mouse pixels, for the FOV band where a real drag is
+// small enough that the first-order gain is a good description of a 20 px motion. This is
+// the reading of AC1 closest to the user's hand; the probe tests above are what cover the
+// extreme ends of the FOV range, where no whole-pixel step can be linear.
+// ---------------------------------------------------------------------------------------
+TEST(DragGain, RealisticDragStepsAtModerateFov) {
+  struct Combo {
+    int lens_type;
+    const char* name;
+    float fov;
+  };
+  const Combo kCombos[] = {
+    { lumice::gui::kLensTypeLinear, "linear", 30.0f },
+    { lumice::gui::kLensTypeLinear, "linear", 90.0f },
+    { lumice::gui::kLensTypeLinear, "linear", 150.0f },
+    { lumice::gui::kLensTypeFisheyeEqualArea, "fisheye_equal_area", 120.0f },
+    { lumice::gui::kLensTypeFisheyeEqualArea, "fisheye_equal_area", 360.0f },
+    { lumice::gui::kLensTypeFisheyeEquidist, "fisheye_equidistant", 180.0f },
+    { lumice::gui::kLensTypeFisheyeEquidist, "fisheye_equidistant", 360.0f },
+    { lumice::gui::kLensTypeFisheyeStereographic, "fisheye_stereographic", 120.0f },
+    { lumice::gui::kLensTypeFisheyeOrthographic, "fisheye_orthographic", 180.0f },
+    { lumice::gui::kLensTypeGlobe, "globe", 30.0f },
+    { lumice::gui::kLensTypeGlobe, "globe", 90.0f },
+  };
+  const Viewport vp = { 1280, 720, "1280x720" };
+  // 3% absorbs the second-order term of the widest combo here (linear at fov=150°, where a
+  // 20 px step is 0.25 rad and tan(theta)/theta = 1.021). Every other combo lands well
+  // inside it; this is a linearization budget, not a fudge factor.
+  constexpr float kRelTol = 0.03f;
+
+  for (const auto& c : kCombos) {
+    LensCase lc = { c.lens_type, c.name, 0.0f };
+    for (float d : { 5.0f, 20.0f, -5.0f, -20.0f }) {
+      auto px = RoundTrip(lc, c.fov, vp, d, 0.0f);
+      ASSERT_FALSE(IsSentinel(px)) << Label(lc, c.fov, vp, d, 0.0f);
+      EXPECT_NEAR(px[0] / d, 1.0f, kRelTol) << Label(lc, c.fov, vp, d, 0.0f);
+
+      auto py = RoundTrip(lc, c.fov, vp, 0.0f, d);
+      ASSERT_FALSE(IsSentinel(py)) << Label(lc, c.fov, vp, 0.0f, d);
+      EXPECT_NEAR(py[1] / d, -1.0f, kRelTol) << Label(lc, c.fov, vp, 0.0f, d);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------------------
+// AC3, stated structurally rather than through the round trip: the gain is inversely
+// proportional to framebuffer pixels. Doubling the DPI doubles the pixel delta of the same
+// physical hand motion and halves the gain, so the rotation — the feel — is unchanged.
+// ---------------------------------------------------------------------------------------
+TEST(DragGain, ScalesInverselyWithFramebufferPixels) {
+  for (const auto& lc : DraggableLenses()) {
+    for (float fov : FovLadder(lc)) {
+      float g1 = ComputeDragGainDegPerPixel(lc.lens_type, fov, 1280, 720);
+      float g2 = ComputeDragGainDegPerPixel(lc.lens_type, fov, 2560, 1440);
+      ASSERT_GT(g1, 0.0f) << lc.name;
+      EXPECT_NEAR(g2 * 2.0f / g1, 1.0f, 1e-5f) << lc.name << " fov=" << fov;
+    }
+  }
+}
+
+// img_radius is min(w, h)/2 — the same definition ProjectWorldDirToScreen uses — so a
+// viewport that is wide but the same height gives the same gain, and the short side is what
+// governs. Pinning this keeps the two from drifting apart into a non-square mismatch.
+TEST(DragGain, GovernedByShorterViewportSide) {
+  for (const auto& lc : DraggableLenses()) {
+    float wide = ComputeDragGainDegPerPixel(lc.lens_type, 60.0f, 2000, 720);
+    float square = ComputeDragGainDegPerPixel(lc.lens_type, 60.0f, 720, 720);
+    float tall = ComputeDragGainDegPerPixel(lc.lens_type, 60.0f, 720, 2000);
+    EXPECT_FLOAT_EQ(wide, square) << lc.name;
+    EXPECT_FLOAT_EQ(tall, square) << lc.name;
+  }
+}
+
+// ---------------------------------------------------------------------------------------
+// Closed-form anchors. These separate "the derivative is wrong" from "the projection is
+// consuming it wrongly" when a round trip above goes red: pick combinations whose value is
+// exact by hand, so a failure here indicts the formula alone.
+// ---------------------------------------------------------------------------------------
+TEST(DragGain, ClosedFormAnchors) {
+  constexpr float kRad2Deg = 180.0f / kPi;
+
+  // linear, fov=90 => half_fov=45°, tan(45°)=1 => 1/img_radius rad/px. img_radius = 400.
+  EXPECT_NEAR(ComputeDragGainDegPerPixel(lumice::gui::kLensTypeLinear, 90.0f, 800, 800), kRad2Deg / 400.0f, 1e-5f);
+
+  // fisheye equidistant, fov=180 => half_fov=pi/2 => (pi/2)/img_radius rad/px, i.e. the
+  // whole 90° half-field spans exactly img_radius pixels. img_radius = 300.
+  EXPECT_NEAR(ComputeDragGainDegPerPixel(lumice::gui::kLensTypeFisheyeEquidist, 180.0f, 800, 600), 90.0f / 300.0f,
+              1e-5f);
+
+  // fisheye orthographic, fov=180 => sin(90°)=1 => 1/img_radius rad/px. img_radius = 300.
+  EXPECT_NEAR(ComputeDragGainDegPerPixel(lumice::gui::kLensTypeFisheyeOrthographic, 180.0f, 800, 600),
+              kRad2Deg / 300.0f, 1e-5f);
+
+  // fisheye equal area, fov=180 => 2*sin(45°)=sqrt(2) => sqrt(2)/img_radius rad/px.
+  EXPECT_NEAR(ComputeDragGainDegPerPixel(lumice::gui::kLensTypeFisheyeEqualArea, 180.0f, 800, 600),
+              std::sqrt(2.0f) * kRad2Deg / 300.0f, 1e-5f);
+
+  // fisheye stereographic, fov=180 => 2*tan(45°)=2 => 2/img_radius rad/px.
+  EXPECT_NEAR(ComputeDragGainDegPerPixel(lumice::gui::kLensTypeFisheyeStereographic, 180.0f, 800, 600),
+              2.0f * kRad2Deg / 300.0f, 1e-5f);
+
+  // globe, fov=90 => (D-1)*tan(45°) = 3 => 3/img_radius rad/px. img_radius = 300.
+  EXPECT_NEAR(ComputeDragGainDegPerPixel(lumice::gui::kLensTypeGlobe, 90.0f, 800, 600), 3.0f * kRad2Deg / 300.0f,
+              1e-4f);
+}
+
+// ---------------------------------------------------------------------------------------
+// Narrow-FOV coverage for the fisheye family, which the round trip above cannot reach (the
+// oracle's acos loses the angle — see DraggableLenses).
+//
+// The check is against an independent physical fact rather than against the implementation:
+// every projection is locally equidistant near its optical axis, so as fov -> 0 all five
+// inside-out laws must converge to the SAME angular resolution, half_fov / img_radius. This
+// is not a restatement of any branch — it is the property that pins each branch's constant
+// factor. Drop the 2 from the equal-area law, or write sin where tan belongs, and the ratio
+// leaves 1 immediately, at exactly the FOV band nothing else covers.
+//
+// Globe is the meaningful exception and is asserted at its own factor: its camera sits at
+// D = kGlobeCameraD sphere radii away, so a given rotation of the sphere sweeps (D-1) = 3x
+// the screen distance a pinhole at the same fov would give. Pinning 3 here is what would
+// catch the camera distance and the gain law drifting apart.
+// ---------------------------------------------------------------------------------------
+TEST(DragGain, SmallFovLawsConvergeToEquidistant) {
+  constexpr int kW = 800;
+  constexpr int kH = 600;  // img_radius = 300
+  for (float fov : { 1.0f, 2.0f, 5.0f }) {
+    float reference = ComputeDragGainDegPerPixel(lumice::gui::kLensTypeFisheyeEquidist, fov, kW, kH);
+    ASSERT_GT(reference, 0.0f);
+    // The equidistant law IS half_fov / img_radius, exactly and at every FOV — it is the
+    // limit itself, so it is the natural yardstick for the other five.
+    EXPECT_NEAR(reference, (fov * 0.5f) / 300.0f, 1e-6f) << "fov=" << fov;
+
+    // Every law's departure from the shared limit is second order in half_fov, with 1/3 the
+    // largest coefficient among the six (tan(hf)/hf - 1 = hf^2/3, hit by both linear and
+    // globe), so hf^2 bounds them all with 3x to spare. Compared as a RELATIVE deviation:
+    // globe's expected ratio is 3, and an absolute tolerance would silently give it three
+    // times the budget the others get — which is exactly how the first version of this
+    // assertion went red at fov=5° while claiming a 1e-3 bound.
+    float half_fov_rad = fov * 0.5f * kPi / 180.0f;
+    float tol = std::max(1e-4f, half_fov_rad * half_fov_rad);
+    for (const auto& lc : DraggableLenses()) {
+      float expected_ratio = (lc.lens_type == lumice::gui::kLensTypeGlobe) ? 3.0f : 1.0f;
+      float g = ComputeDragGainDegPerPixel(lc.lens_type, fov, kW, kH);
+      EXPECT_NEAR(g / reference / expected_ratio, 1.0f, tol) << lc.name << " fov=" << fov;
+    }
+  }
+}
+
+// The 0.3 deg/px the drag used before this became FOV-aware, quantified: at the default
+// 30° linear preview it was ~2.3x too slow, and at fov=1° it was ~180x too fast. That
+// spread is the defect AC1 names, recorded here so a regression to a constant is visible.
+TEST(DragGain, FovAwareGainSpansTheRangeTheConstantMissed) {
+  float narrow = ComputeDragGainDegPerPixel(lumice::gui::kLensTypeLinear, 1.0f, 800, 600);
+  float wide = ComputeDragGainDegPerPixel(lumice::gui::kLensTypeLinear, 179.0f, 800, 600);
+  EXPECT_LT(narrow, 0.3f / 100.0f);
+  EXPECT_GT(wide, 0.3f * 50.0f);
+}
+
+// ---------------------------------------------------------------------------------------
+// Degenerate inputs.
+// ---------------------------------------------------------------------------------------
+TEST(DragGain, DegenerateViewportProducesNoRotation) {
+  EXPECT_FLOAT_EQ(ComputeDragGainDegPerPixel(lumice::gui::kLensTypeLinear, 60.0f, 0, 600), 0.0f);
+  EXPECT_FLOAT_EQ(ComputeDragGainDegPerPixel(lumice::gui::kLensTypeLinear, 60.0f, 800, 0), 0.0f);
+  EXPECT_FLOAT_EQ(ComputeDragGainDegPerPixel(lumice::gui::kLensTypeLinear, 60.0f, -1, -1), 0.0f);
+}
+
+// Full-sky lenses never reach the drag branch (app_panels.cpp guards on !LensIsFullSky), so
+// this is the defensive fallback, not a live path: it must stay finite and match the legacy
+// constant rather than return 0 or NaN.
+TEST(DragGain, FullSkyLensesFallBackToLegacyConstant) {
+  for (int lt : lumice::gui::kFullSkyLensTypes) {
+    EXPECT_FLOAT_EQ(ComputeDragGainDegPerPixel(lt, 180.0f, 800, 600), 0.3f) << "lens_type " << lt;
+  }
+}


### PR DESCRIPTION
预览区拖拽此前用固定常数 `0.3 deg/px` 把鼠标位移转成 `azimuth`/`elevation` 增量，与 `fov` 和视口尺寸完全解耦。fov 可缩放到 1°，此时 100px 拖动 = 30° 方位角 ≈ 30 个屏宽；fov=179° 时同样的拖动又过于迟钝。

## 改动

把增益换成**按镜头类型的角分辨率闭式解** —— 即各前向投影函数在画面中心 (θ=0) 处 `dr/dθ` 的倒数，覆盖全部 6 个启用拖拽的镜头类型：

| 镜头 | 前向 `r(θ)` | `dθ/dr` at 0 |
|---|---|---|
| linear | `focal·tanθ` | `tan(half_fov)/img_radius` |
| fisheye equal-area | `sin(θ/2)/sin(half_fov/2)` | `2·sin(half_fov/2)/img_radius` |
| fisheye equidistant | `θ/half_fov` | `half_fov/img_radius` |
| fisheye stereographic | `tan(θ/2)/tan(half_fov/2)` | `2·tan(half_fov/2)/img_radius` |
| fisheye orthographic | `sin(θ)/sin(half_fov)` | `sin(half_fov)/img_radius` |
| globe | `x/(D−z)·focal` | `(D−1)·tan(half_fov)/img_radius` |

`img_radius = min(vp_w, vp_h)/2` 与 `ProjectWorldDirToScreen` 同源，因此 DPI / resize 一致性是同源数据的自然推论，无需额外适配代码。

灵敏度常数 `kDragSensitivity = 2.5`：闭式解本身给的是 1:1（拖 1px、内容动 1px）。1:1 是触摸屏的硬约束，对鼠标只是可选锚点，实测比历史常数慢得多（900px 短边下 fov=90° 慢 2.4×、60° 慢 4.1×、30° 慢 8.8×，仅 fov>134° 反超）。2.5 让 fov=90° 处等效 0.318 deg/px，与用户已适应的 0.3 相差 6% 以内。**跨 fov 的恒定性一分未损，只是恒定值从 1 变成 k。**

未知镜头类型的 `default` 分支保留 `0.3f` 兜底（它本身就是历史手感值，故不乘 k），并按 lens_type 各自一次地打 `GUI_LOG_WARNING` —— 该分支是给"将来新增可拖拽镜头却忘了同步 switch"用的探测器，无节流会在拖拽时每帧刷屏。

## 不在范围内

不碰天顶 clamp / 过极翻转 / `roll`，也不引入 `1/cos(el)` 方位角修正 —— 后者虽是严格跟手所需，但在天顶发散且会把绕视轴自转率抬成 `∝tan(el)`，反而加重已知的近天顶手感问题。`app_panels.cpp` 只替换四处常量，wrap/clamp 逻辑一行未动。

## 验证

- 新增 `test/unit-correctness/gui/test_drag_gain.cpp`：12 个用例，端到端往返校验用**未改动的** `ProjectWorldDirToScreen` 作 oracle，而不是重算一遍"应该等于什么"；覆盖 6 镜头 × 多档 fov × 非方形视口 × 正负向拖动。
- 5 个人为注入缺陷（一阶近似、`img_radius` 用错、接线符号翻转、退回旧常数等）逐一验证测试会转红。
- 告警节流用红绿双态取证：撤掉 latch 时 10 行、装上时 5 行。
- `./scripts/test.sh quick` → `RESULT: PASS`（rebase 到最新 main 后重跑）。
- owner 实机拖拽验收通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)