### PR TITLE
fix(core): remove the closed-form pyramid's unit-of-measure assumption from its tolerances

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1010,7 +1010,40 @@ shipped tolerance binding this path is not expected to fire at all (a 413,280-po
 sweep across the near-apex band never triggered it); if you do see it, you have found
 an edge case narrower than the ones already closed, and the same two remedies apply.
 
-### 7. Missing `prob` in a Scattering Layer
+### 7. Reading the Dropped-Face Warning
+
+**Description**: One of the crystal's faces came out thinner than the geometry solver
+can resolve — typically a side face whose two bounding corners are a few times
+`1e-5` apart relative to the crystal's own size. The solver reached that face while
+walking the cross sections, but could not keep three distinct vertices on it, so the
+face is dropped. Unlike the apex-rescue case above, the result is **not** a valid
+solid: the faces beside the dropped one keep the edges it was supposed to close, so
+the surface has a hole in it.
+
+Nothing downstream rejects such a crystal — the legality check counts present faces
+and does not test whether they form a closed surface — so this warning is the only
+signal you get. Rays traced through it will refract at the remaining faces and the
+run will report statistics as usual.
+
+**What it looks like** (from `src/core/geo3d_closedform.cpp`):
+```
+ComputeClosedFormPyramid: face slot(s) [13] were reached by the emitter but kept
+fewer than 3 distinct vertices, so they are dropped and the surface they bounded is
+left open; face_distance=[...], upper_h_inset=..., lower_h_inset=... This crystal has
+a face thinner than the solver can resolve. To get a well-formed solid instead, widen
+the spread between the face_distance entries around the offending face, or move
+upper_h/lower_h away from that face's collapse height.
+```
+
+**How to respond**: the slot numbers in the message name the offending faces — slots
+`0`/`1` are the two basal faces, `2`–`7` the six prism sides, `8`–`13` the upper cone
+faces, `14`–`19` the lower cone faces, each `i`-th entry sharing direction `i` with
+the corresponding `face_distance[i]`. Widen the spread between the `face_distance`
+entries around that direction so the face is either comfortably present or cleanly
+absent, rather than sitting on the resolution boundary. Moving `upper_h`/`lower_h`
+also helps when the face collapses partway up a cone rather than at the shoulder.
+
+### 8. Missing `prob` in a Scattering Layer
 
 **Description**: A `scene.scattering[]` layer is missing the required `prob` field. There is no
 implicit default — this used to silently fall back to `0.0`, but that fallback has been removed.
@@ -1045,7 +1078,7 @@ historical default was 0.0; add "prob": 0 explicitly to keep that behavior.
 }
 ```
 
-### 8. Distribution Object Missing `type`
+### 9. Distribution Object Missing `type`
 
 **Description**: A distribution slot (`axis.zenith` / `axis.azimuth` / `axis.roll`, or a shape
 scalar such as `height`, `prism_h`, `upper_h`, `lower_h`, or an entry of `face_distance[]`) is
@@ -1081,7 +1114,7 @@ object naming the distribution (e.g. {"type": "gauss", "mean": 20, "std": 5}).
 }
 ```
 
-### 9. `axis` Present but Missing `zenith`
+### 10. `axis` Present but Missing `zenith`
 
 **Description**: Once `axis` is written at all, `zenith` is required — there is no default for
 it in that case. (Omit `axis` entirely to get the default fixed orientation instead; see

--- a/doc/configuration_zh.md
+++ b/doc/configuration_zh.md
@@ -1012,7 +1012,35 @@ entries.
 你真的看到它，说明你撞上了一个比已收窄窗口更极端的边缘情况，同样的两条建议依然
 适用。
 
-### 8. scattering 层缺少 `prob`
+### 8. 读懂"面被丢弃"警告
+
+**错误描述**：晶体上有一个面窄到几何求解器已经分辨不出来了——通常是某个侧面，
+它的两个界定角点之间只差晶体自身尺寸的几倍 `1e-5`。求解器在遍历横截面时确实碰到了
+这个面，却没能在它上面留下 3 个互异顶点，于是这个面被丢弃。与上面的"顶点吸附"不同，
+这次的产出**不是**合法实体：被丢弃那个面旁边的各个面仍然保留着本该由它封口的边，
+于是曲面上留了一个洞。
+
+下游没有任何东西会拦下这样的晶体——合法性检查只数存在的面数，不检验它们是否构成
+闭合曲面——所以这条警告是你唯一能拿到的信号。光线照样会在剩下的面上折射，这一轮
+仿真也照样会给出统计结果。
+
+**日志长这样**（源自 `src/core/geo3d_closedform.cpp`）：
+```
+ComputeClosedFormPyramid: face slot(s) [13] were reached by the emitter but kept
+fewer than 3 distinct vertices, so they are dropped and the surface they bounded is
+left open; face_distance=[...], upper_h_inset=..., lower_h_inset=... This crystal has
+a face thinner than the solver can resolve. To get a well-formed solid instead, widen
+the spread between the face_distance entries around the offending face, or move
+upper_h/lower_h away from that face's collapse height.
+```
+
+**该怎么改**：日志里的 slot 编号就指名了出问题的面——`0`/`1` 是上下两个基面，
+`2`–`7` 是六个棱面，`8`–`13` 是上锥六个面，`14`–`19` 是下锥六个面，其中第 `i` 项与
+`face_distance[i]` 共用方向 `i`。把该方向附近的 `face_distance` 各分量差距拉开，
+让这个面要么明确存在、要么干净地不存在，而不是卡在分辨率边界上。如果这个面不是在
+肩部、而是在锥面中途才收缩掉，调整 `upper_h`/`lower_h` 同样有效。
+
+### 9. scattering 层缺少 `prob`
 
 **错误描述**：`scene.scattering[]` 的某一层缺少必填字段 `prob`。这里没有隐式默认值——
 历史上会静默回落到 `0.0`，但这个回落已经被移除。
@@ -1047,7 +1075,7 @@ historical default was 0.0; add "prob": 0 explicitly to keep that behavior.
 }
 ```
 
-### 9. 分布对象缺少 `type`
+### 10. 分布对象缺少 `type`
 
 **错误描述**：分布槽（`axis.zenith` / `axis.azimuth` / `axis.roll`，或形状标量如 `height`、
 `prism_h`、`upper_h`、`lower_h`、`face_distance[]` 中的某一项）写成了 JSON 对象却省略了
@@ -1082,7 +1110,7 @@ object naming the distribution (e.g. {"type": "gauss", "mean": 20, "std": 5}).
 }
 ```
 
-### 10. `axis` 存在但缺少 `zenith`
+### 11. `axis` 存在但缺少 `zenith`
 
 **错误描述**：只要写了 `axis`，就必须写 `zenith`——此时它没有默认值。
 （想要默认的固定朝向，应整个省略 `axis`；见上方

--- a/src/core/geo3d_closedform.cpp
+++ b/src/core/geo3d_closedform.cpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <cassert>
 #include <cmath>
+#include <cstdio>
 
 #include "core/geo3d.hpp"
 #include "core/math.hpp"
@@ -58,6 +59,7 @@ constexpr uint16_t kPathTagBounded = kClosedFormPathTagBounded;
 constexpr uint16_t kPathTagAllDirsPresent = kClosedFormPathTagAllDirsPresent;
 constexpr uint16_t kPathTagEmpty = kClosedFormPathTagEmpty;
 constexpr uint16_t kPathTagApexRescueDegraded = kClosedFormPathTagApexRescueDegraded;
+constexpr uint16_t kPathTagClaimedFaceDropped = kClosedFormPathTagClaimedFaceDropped;
 
 // Magnitude the half-plane offsets are measured against. Its own function, and
 // not an inline loop at each site, because it is the input to
@@ -362,6 +364,21 @@ bool ApexCollapsedAt(const float dist[kClosedFormPrismSideCnt], double m, double
   return (apex_m - m) <= gap_tol;
 }
 
+// Merge tolerance for 3D vertices that live in the cross-section plane at
+// physical inset `m`, in the units those vertices' (u, v) are expressed in.
+//
+// One helper rather than the two-call combination spelled out at each site: the
+// point of this tolerance is that every consumer is holding THE SAME ruler as
+// SolveHexCrossSection, which resolves a cross section's corners with exactly
+// GapToleranceForScale(CrossSectionScale(r_side_dist)). Written out by hand at
+// each site, one copy drifts and the two answers ("how many corners are there"
+// and "are these two corners the same 3D point") start contradicting each other
+// again — which is the defect this helper exists to close.
+double LateralMergeTol(const float dist[kClosedFormPrismSideCnt], double m) {
+  double r_side_dist[kClosedFormPrismSideCnt];
+  return GapToleranceForScale(ComputeRSideDistAndScale(dist, m, r_side_dist));
+}
+
 // Shared 3×3 solver for a direction triple (i, j, k):
 //   [cs_i sn_i 1] [u]   [d_i]
 //   [cs_j sn_j 1] [v] = [d_j]
@@ -586,6 +603,11 @@ struct ConeDeathEvent {
   double z;
   double u;
   double v;
+  // Physical inset this event sits at. Carried rather than re-derived from z by
+  // the caller: the caller would have to invert z = ±h2/2 ± a·m with the same
+  // a it passed in, and a second inversion of a relation the producer already
+  // has in hand is how the two ends of one quantity drift apart.
+  double m_phys;
   int i, j, k;  // killing triple; upper_cone_slot = 8+i etc.
 };
 
@@ -652,7 +674,7 @@ int EnumerateConeDeathEvents(const double dist_scaled[kClosedFormPyramidSideCnt]
           continue;
         }
         double z = upper_side ? (h2_2 + a * m_phys) : (-h2_2 - a * m_phys);
-        out_events[cnt++] = { z, u, v, i, j, k };
+        out_events[cnt++] = { z, u, v, m_phys, i, j, k };
       }
     }
   }
@@ -864,12 +886,34 @@ ClosedFormPyramidResult ComputeClosedFormPyramidInner(double a1, double a2, floa
   // implementation) produced O(6·N_events) spurious vertices — visible as
   // shrinking-hexagon layers stacked between shoulder and apex.
   int vtx_cnt = 0;
-  const double kDedupTol = 5.0 * static_cast<double>(math::kFloatEps) * std::max(std::fabs(z_top), std::fabs(z_bot));
+  // Every tolerance below is LATERAL — it measures a distance in the plane of a
+  // cross section, in the units that cross section's own solver measured its
+  // corners in. There used to be one global scalar here instead, derived from
+  // max(|z_top|, |z_bot|), serving both the vertex pool and a z-boundary test.
+  // Scaling a vertex-merge radius by a Z magnitude is what let a cone 1e5 tall
+  // set a merge radius of ~6 for a truncation cap whose corners are ~1 apart:
+  // the cap was merged to a single point, dropped below three vertices, and the
+  // user's truncated pyramid came out as a full one without a word. The two
+  // questions ("are these corners one point" and "is this z-event a boundary
+  // one") live on different axes, and one number cannot answer both in the right
+  // unit.
+  //
+  // Merge tolerance for the apex insertion sites. The cross section AT the apex
+  // has zero width by construction (for a regular hexagon every direction is
+  // tight there, so the local scale is exactly 0), which makes a local tolerance
+  // structurally unusable at those sites. What is being asked there is not "are
+  // these distinct corners" but "did two of the 20 direction triples solve the
+  // same point twice", whose residual scales with the (u, v) magnitudes — i.e.
+  // with the crystal's own lateral size, the m = 0 cross section.
+  const double kApexMergeTol = LateralMergeTol(dist, 0.0);
   bool any_face_present[kClosedFormPyramidFaceCnt]{};
 
   // Helper: emit vertex at (u, v, z) and associate with the given face slots.
-  auto emit_vtx = [&](double u, double v, double z, const int* face_slots, int n_slots) {
-    int idx = InsertOrFindVertex(u, v, z, r.vtx, &vtx_cnt, kDedupTol);
+  // `tol` is passed rather than captured: every call site sits at a different
+  // inset and therefore holds a different lateral ruler, and an implicit capture
+  // is what let one global ruler silently serve sites it did not fit.
+  auto emit_vtx = [&](double u, double v, double z, double tol, const int* face_slots, int n_slots) {
+    int idx = InsertOrFindVertex(u, v, z, r.vtx, &vtx_cnt, tol);
     for (int s = 0; s < n_slots; s++) {
       AppendFaceVtx(&r, face_slots[s], idx);
       any_face_present[face_slots[s]] = true;
@@ -887,7 +931,11 @@ ClosedFormPyramidResult ComputeClosedFormPyramidInner(double a1, double a2, floa
   auto emit_ring = [&](double m, double z, const int face_slot_of_dir[6], int basal_slot,
                        const int extra_slot_of_dir[6]) -> int {
     double r_side[6];
-    ComputeRSideDistAndScale(dist, m, r_side);
+    // One scale, two consumers: SolveHexCrossSection decides how many corners
+    // this cross section HAS from it, and the 3D pool decides whether two of
+    // those corners are the same point from it. Same m, same array, same
+    // GapToleranceForScale — so the second decision cannot overturn the first.
+    const double lateral_tol = GapToleranceForScale(ComputeRSideDistAndScale(dist, m, r_side));
     uint16_t local_tag = 0;
     HexCrossSection xs = SolveHexCrossSection(r_side, &local_tag);
     r.path_tag_union |= local_tag;
@@ -915,7 +963,7 @@ ClosedFormPyramidResult ComputeClosedFormPyramidInner(double a1, double a2, floa
       if (basal_slot >= 0) {
         slots[n_slots++] = basal_slot;
       }
-      emit_vtx(xs.corner_x[k], xs.corner_y[k], z, slots, n_slots);
+      emit_vtx(xs.corner_x[k], xs.corner_y[k], z, lateral_tol, slots, n_slots);
     }
     return xs.corner_cnt;
   };
@@ -957,9 +1005,13 @@ ClosedFormPyramidResult ComputeClosedFormPyramidInner(double a1, double a2, floa
       emit_ring(0.0, h2_2, prism_slot, /*basal_slot=*/-1, upper_slot);
     } else {
       // No prism section — the "shoulder" is just the interface between
-      // upper and lower cones at z=0. Associate corners with both cone
-      // slot sets.
-      emit_ring(0.0, 0.0, upper_slot, /*basal_slot=*/-1, lower_slot);
+      // upper and lower cones at z=0. Associate corners with both cone slot
+      // sets — but only with a lower set that exists. Naming the lower cone's
+      // six slots when there is no lower cone marks them as reached by the
+      // emitter, and "reached but under-populated" is precisely the signature
+      // the diagnostic at the end of this function fires on, so an absent cone
+      // would report itself as a dropped face on every coneless crystal.
+      emit_ring(0.0, 0.0, upper_slot, /*basal_slot=*/-1, has_lower ? lower_slot : nullptr);
     }
     // Top layer at z=z_top. Two mutually-exclusive shapes with the same
     // emission code, differing only in whether the basal face is present:
@@ -987,7 +1039,7 @@ ClosedFormPyramidResult ComputeClosedFormPyramidInner(double a1, double a2, floa
       int apex_mask[20];
       int apex_n = EnumerateApexPoints(dist_scaled, m_at_top, apex_us, apex_vs, apex_mask);
       for (int e = 0; e < apex_n; e++) {
-        int idx = InsertOrFindVertex(apex_us[e], apex_vs[e], z_top, r.vtx, &vtx_cnt, kDedupTol);
+        int idx = InsertOrFindVertex(apex_us[e], apex_vs[e], z_top, r.vtx, &vtx_cnt, kApexMergeTol);
         for (int i = 0; i < 6; i++) {
           // Only the cone planes that actually pass through this apex point
           // own it — see EnumerateApexPoints' out_mask contract. A regular
@@ -1003,7 +1055,7 @@ ClosedFormPyramidResult ComputeClosedFormPyramidInner(double a1, double a2, floa
       if (apex_n == 0 && n_top == 0) {
         // Fallback: neither ring nor apex-enum found anything. Insert the
         // canonical apex from MaxFeasibleInsetLP.
-        int idx = InsertOrFindVertex(apex.u, apex.v, z_top, r.vtx, &vtx_cnt, kDedupTol);
+        int idx = InsertOrFindVertex(apex.u, apex.v, z_top, r.vtx, &vtx_cnt, kApexMergeTol);
         for (int i = 0; i < 6; i++) {
           AppendFaceVtx(&r, 8 + i, idx);
           any_face_present[8 + i] = true;
@@ -1014,16 +1066,26 @@ ClosedFormPyramidResult ComputeClosedFormPyramidInner(double a1, double a2, floa
     ConeDeathEvent evs[20];
     int n = EnumerateConeDeathEvents(dist_scaled, m_at_top, h2_2, a1, /*upper_side=*/true, evs);
     for (int e = 0; e < n; e++) {
-      // Skip events at the shoulder or truncation (already handled). Reuse
-      // kDedupTol (scaled by |z_top|/|z_bot|) rather than a fixed absolute
-      // literal — z is solved via an independent Cramer path from z_top/h2_2,
-      // so its absolute error scales with the same extreme-wedge magnitudes
-      // kDedupTol already accounts for.
-      if (std::fabs(evs[e].z - h2_2) < kDedupTol || std::fabs(evs[e].z - z_top) < kDedupTol) {
-        continue;
-      }
+      // No second boundary filter here. Whether an event is "really" the
+      // shoulder or the truncation is a question about the inset it sits at, and
+      // EnumerateConeDeathEvents already answers it in inset units, with the
+      // lateral tolerance the rest of this evaluator uses: it emits only
+      // m_phys ∈ (tol_phys, m_max − tol_phys]. A second filter used to re-ask it
+      // here in Z units, against 5·kFloatEps·max(|z_top|, |z_bot|); converted
+      // back to inset units that band is (that value)/a, which for a shallow
+      // cone (a1 = 0.082 measured) is 4.7x the inset gate's own width, so the
+      // wider ruler won and swallowed genuine interior events. What that costs is not
+      // an extra vertex: the corner these events kill is where a sliver face
+      // closes, so dropping one leaves that face's polygon open and the surface
+      // non-manifold, on the shallow cone only, while the steep cone opposite it
+      // closes correctly from the same event set.
+      //
+      // Duplicates need no filter either — the event's vertex goes through the
+      // same pool as every ring corner, so one that really does coincide with a
+      // shoulder/truncation corner merges into it and contributes its cone slots
+      // to that existing vertex, which is what the surface needs anyway.
       int slots[3] = { 8 + evs[e].i, 8 + evs[e].j, 8 + evs[e].k };
-      emit_vtx(evs[e].u, evs[e].v, evs[e].z, slots, 3);
+      emit_vtx(evs[e].u, evs[e].v, evs[e].z, LateralMergeTol(dist, evs[e].m_phys), slots, 3);
     }
   }
 
@@ -1043,7 +1105,7 @@ ClosedFormPyramidResult ComputeClosedFormPyramidInner(double a1, double a2, floa
       int apex_mask[20];
       int apex_n = EnumerateApexPoints(dist_scaled, m_at_bot, apex_us, apex_vs, apex_mask);
       for (int e = 0; e < apex_n; e++) {
-        int idx = InsertOrFindVertex(apex_us[e], apex_vs[e], z_bot, r.vtx, &vtx_cnt, kDedupTol);
+        int idx = InsertOrFindVertex(apex_us[e], apex_vs[e], z_bot, r.vtx, &vtx_cnt, kApexMergeTol);
         for (int i = 0; i < 6; i++) {
           // See the upper-side note: only the tight cone planes own this point.
           if ((apex_mask[e] & (1 << i)) == 0) {
@@ -1054,7 +1116,7 @@ ClosedFormPyramidResult ComputeClosedFormPyramidInner(double a1, double a2, floa
         }
       }
       if (apex_n == 0 && n_bot == 0) {
-        int idx = InsertOrFindVertex(apex.u, apex.v, z_bot, r.vtx, &vtx_cnt, kDedupTol);
+        int idx = InsertOrFindVertex(apex.u, apex.v, z_bot, r.vtx, &vtx_cnt, kApexMergeTol);
         for (int i = 0; i < 6; i++) {
           AppendFaceVtx(&r, 14 + i, idx);
           any_face_present[14 + i] = true;
@@ -1064,12 +1126,9 @@ ClosedFormPyramidResult ComputeClosedFormPyramidInner(double a1, double a2, floa
     ConeDeathEvent evs[20];
     int n = EnumerateConeDeathEvents(dist_scaled, m_at_bot, h2_2, a2, /*upper_side=*/false, evs);
     for (int e = 0; e < n; e++) {
-      // See the upper-side kDedupTol note above.
-      if (std::fabs(evs[e].z + h2_2) < kDedupTol || std::fabs(evs[e].z - z_bot) < kDedupTol) {
-        continue;
-      }
+      // See the upper-side note above on why there is no z-domain filter here.
       int slots[3] = { 14 + evs[e].i, 14 + evs[e].j, 14 + evs[e].k };
-      emit_vtx(evs[e].u, evs[e].v, evs[e].z, slots, 3);
+      emit_vtx(evs[e].u, evs[e].v, evs[e].z, LateralMergeTol(dist, evs[e].m_phys), slots, 3);
     }
   }
 
@@ -1111,8 +1170,47 @@ ClosedFormPyramidResult ComputeClosedFormPyramidInner(double a1, double a2, floa
 
   // A face is "present" only if it has ≥ 3 distinct vertices in its polygon
   // (bounds a 2D polygon on its plane).
+  //
+  // The two conjuncts are not two spellings of one condition. any_face_present
+  // says an emitter CLAIMED this face — some cross-section corner or apex point
+  // named it as one of the planes it lies on. The count says the 3D pool kept
+  // enough distinct vertices to bound a polygon on it. A face that is claimed
+  // and then comes up short is the signature of every defect in this family: the
+  // corner separation the 2D solver resolved was below what the 3D pool, or the
+  // event enumeration feeding it, could keep apart, so the polygon set loses a
+  // face while its neighbours keep the edges that face was supposed to close —
+  // an open, non-manifold surface that IsValidClosedFormPyramid (which counts
+  // present faces and nothing else) passes straight through into a simulation.
+  //
+  // Not silently. Mark the path and name the input, on the same reasoning as
+  // report_apex_rescue above: the tolerances feeding this are now all lateral and
+  // all derived from one function, so a claimed face coming up short is meant to
+  // be unreachable — and an unreachable degradation that says nothing is
+  // indistinguishable from a silent one on the day someone unbinds them.
+  int underpopulated[kClosedFormPyramidFaceCnt];
+  int underpopulated_cnt = 0;
   for (int slot = 0; slot < kClosedFormPyramidFaceCnt; slot++) {
     r.face_present[slot] = any_face_present[slot] && r.face_vtx_cnt[slot] >= 3;
+    if (any_face_present[slot] && r.face_vtx_cnt[slot] < 3) {
+      underpopulated[underpopulated_cnt++] = slot;
+    }
+  }
+  if (underpopulated_cnt > 0) {
+    r.path_tag_union |= kPathTagClaimedFaceDropped;
+    char slot_list[kClosedFormPyramidFaceCnt * 4 + 1];
+    int written = 0;
+    for (int e = 0; e < underpopulated_cnt && written < static_cast<int>(sizeof(slot_list)) - 4; e++) {
+      written += std::snprintf(slot_list + written, sizeof(slot_list) - static_cast<size_t>(written), "%s%d",
+                               e == 0 ? "" : ",", underpopulated[e]);
+    }
+    LOG_WARNING(
+        "ComputeClosedFormPyramid: face slot(s) [{}] were reached by the emitter but kept fewer than 3 distinct "
+        "vertices, so they are dropped and the surface they bounded is left open; face_distance=[{:.4f}, {:.4f}, "
+        "{:.4f}, {:.4f}, {:.4f}, {:.4f}], upper_h_inset={:.6e}, lower_h_inset={:.6e}. This crystal has a face thinner "
+        "than the solver can resolve. To get a well-formed solid instead, widen the spread between the face_distance "
+        "entries around the offending face, or move upper_h/lower_h away from that face's collapse height.",
+        slot_list, static_cast<double>(dist[0]), static_cast<double>(dist[1]), static_cast<double>(dist[2]),
+        static_cast<double>(dist[3]), static_cast<double>(dist[4]), static_cast<double>(dist[5]), m_at_top, m_at_bot);
   }
   // If a face isn't present, zero its vtx list.
   for (int slot = 0; slot < kClosedFormPyramidFaceCnt; slot++) {

--- a/src/core/geo3d_closedform.cpp
+++ b/src/core/geo3d_closedform.cpp
@@ -90,7 +90,7 @@ double CrossSectionScale(const double r_side_dist[kClosedFormPrismSideCnt]) {
 // second copy of this expression elsewhere re-opens a band on that axis where
 // neither answer applies and a whole cone is dropped in silence.
 double GapToleranceForScale(double scale) {
-  return kClosedFormGapToleranceCoefficient * static_cast<double>(math::kFloatEps) * std::max(scale, 1.0);
+  return kClosedFormGapToleranceCoefficient * static_cast<double>(math::kFloatEps) * scale;
 }
 
 // SolveHexCrossSection — the 2D half-plane intersection over the six fixed
@@ -453,7 +453,7 @@ int EnumerateApexPoints(const double dist_scaled[kClosedFormPyramidSideCnt], dou
     sn[i] = kHexFaceSin[i];
     scale = std::max(scale, std::fabs(dist_scaled[i]));
   }
-  double tol_lp = 5.0 * static_cast<double>(math::kFloatEps) * std::max(scale, 1.0);
+  double tol_lp = 5.0 * static_cast<double>(math::kFloatEps) * scale;
   double m_max_lp = m_max_phys * kInsetK;
   int cnt = 0;
   for (int i = 0; i < kClosedFormPyramidSideCnt; i++) {
@@ -531,7 +531,7 @@ ApexLPResult MaxFeasibleInsetLP(const double dist_scaled[kClosedFormPyramidSideC
     sn[i] = kHexFaceSin[i];
     scale = std::max(scale, std::fabs(dist_scaled[i]));
   }
-  double tol = 5.0 * static_cast<double>(math::kFloatEps) * std::max(scale, 1.0);
+  double tol = 5.0 * static_cast<double>(math::kFloatEps) * scale;
   ApexLPResult best;
   bool found = false;
 
@@ -619,7 +619,7 @@ int EnumerateConeDeathEvents(const double dist_scaled[kClosedFormPyramidSideCnt]
     sn[i] = kHexFaceSin[i];
     scale = std::max(scale, std::fabs(dist_scaled[i]));
   }
-  double tol_lp = 5.0 * static_cast<double>(math::kFloatEps) * std::max(scale, 1.0);
+  double tol_lp = 5.0 * static_cast<double>(math::kFloatEps) * scale;
   double tol_phys = tol_lp / kInsetK;
   int cnt = 0;
   for (int i = 0; i < kClosedFormPyramidSideCnt; i++) {
@@ -864,8 +864,7 @@ ClosedFormPyramidResult ComputeClosedFormPyramidInner(double a1, double a2, floa
   // implementation) produced O(6·N_events) spurious vertices — visible as
   // shrinking-hexagon layers stacked between shoulder and apex.
   int vtx_cnt = 0;
-  const double kDedupTol =
-      5.0 * static_cast<double>(math::kFloatEps) * std::max({ std::fabs(z_top), std::fabs(z_bot), 1.0 });
+  const double kDedupTol = 5.0 * static_cast<double>(math::kFloatEps) * std::max(std::fabs(z_top), std::fabs(z_bot));
   bool any_face_present[kClosedFormPyramidFaceCnt]{};
 
   // Helper: emit vertex at (u, v, z) and associate with the given face slots.

--- a/src/core/geo3d_closedform.cpp
+++ b/src/core/geo3d_closedform.cpp
@@ -364,6 +364,22 @@ bool ApexCollapsedAt(const float dist[kClosedFormPrismSideCnt], double m, double
   return (apex_m - m) <= gap_tol;
 }
 
+// The inset one cone side actually truncates at, once ApexCollapsedAt has ruled
+// on it: the apex inset when collapsed, the requested one otherwise.
+//
+// A function rather than an if that overwrites the requested value in place, so
+// the caller's effective inset can be a `const` initialized AFTER the ruling.
+// The whole height/plane/inset chain below it — z, inset_at_*, the basal d, and
+// every emit_ring call — must read the post-snap value; written as an in-place
+// overwrite, that requirement lives in the order the statements happen to sit
+// in, and a comment cannot stop the next reader from inserting a use above the
+// overwrite. Resolved through here, the effective value has no name before the
+// ruling, so reading one early is a compile error rather than a silent wrong
+// answer.
+double ResolveTruncationInset(bool collapsed, double requested_m, double apex_m) {
+  return collapsed ? apex_m : requested_m;
+}
+
 // Merge tolerance for 3D vertices that live in the cross-section plane at
 // physical inset `m`, in the units those vertices' (u, v) are expressed in.
 //
@@ -827,12 +843,15 @@ ClosedFormPyramidResult ComputeClosedFormPyramidInner(double a1, double a2, floa
   if (has_upper || has_lower) {
     apex = MaxFeasibleInsetLP(dist_scaled);
   }
-  double m_apex_upper = has_upper ? apex.m : 0.0;
-  double m_apex_lower = has_lower ? apex.m : 0.0;
-  double m_at_top = has_upper ? std::min(static_cast<double>(h1) * m_apex_upper, m_apex_upper) : 0.0;
-  double m_at_bot = has_lower ? std::min(static_cast<double>(h3) * m_apex_lower, m_apex_lower) : 0.0;
+  const double m_apex_upper = has_upper ? apex.m : 0.0;
+  const double m_apex_lower = has_lower ? apex.m : 0.0;
+  // The truncation each side ASKS for, from its height fraction. Named apart
+  // from the effective inset below because the two differ exactly when the apex
+  // collapses, and report_apex_rescue needs this one.
+  const double m_requested_top = has_upper ? std::min(static_cast<double>(h1) * m_apex_upper, m_apex_upper) : 0.0;
+  const double m_requested_bot = has_lower ? std::min(static_cast<double>(h3) * m_apex_lower, m_apex_lower) : 0.0;
   // Apex-collapse decision, taken here rather than at the emission site because
-  // a collapsed side's truncation inset IS the apex inset: snapping m before z,
+  // a collapsed side's truncation inset IS the apex inset: resolving m before z,
   // inset_at_* and the basal d are derived from it keeps the whole solid — the
   // emitted vertices, the plane the basal d describes and the inset the caller
   // reads back — consistent with the one decision, instead of emitting an apex
@@ -841,16 +860,16 @@ ClosedFormPyramidResult ComputeClosedFormPyramidInner(double a1, double a2, floa
   // The requested truncation is at most one gate width below the apex when this
   // fires (see ApexCollapsedAt), so the snap moves the tip by at most that, and
   // it is exactly what an h ≥ 1 request already got from the std::min above.
-  const bool upper_apex_collapsed = has_upper && ApexCollapsedAt(dist, m_at_top, apex.m);
-  const bool lower_apex_collapsed = has_lower && ApexCollapsedAt(dist, m_at_bot, apex.m);
-  if (upper_apex_collapsed) {
-    m_at_top = apex.m;
-  }
-  if (lower_apex_collapsed) {
-    m_at_bot = apex.m;
-  }
-  double z_top = has_upper ? (h2_2 + a1 * m_at_top) : h2_2;
-  double z_bot = has_lower ? (-h2_2 - a2 * m_at_bot) : -h2_2;
+  const bool upper_apex_collapsed = has_upper && ApexCollapsedAt(dist, m_requested_top, apex.m);
+  const bool lower_apex_collapsed = has_lower && ApexCollapsedAt(dist, m_requested_bot, apex.m);
+  // The EFFECTIVE insets. Everything downstream — z_top/z_bot, inset_at_*,
+  // plane_coef[3,7], every emit_ring and apex enumeration below — reads these,
+  // and they exist only from here on, after the decision (see
+  // ResolveTruncationInset).
+  const double m_at_top = ResolveTruncationInset(upper_apex_collapsed, m_requested_top, apex.m);
+  const double m_at_bot = ResolveTruncationInset(lower_apex_collapsed, m_requested_bot, apex.m);
+  const double z_top = has_upper ? (h2_2 + a1 * m_at_top) : h2_2;
+  const double z_bot = has_lower ? (-h2_2 - a2 * m_at_bot) : -h2_2;
   r.inset_at_top = static_cast<float>(m_at_top);
   r.inset_at_bottom = static_cast<float>(m_at_bot);
   // Basal d values, matching FillHexCrystalCoef's convention (d = -z_top for
@@ -1025,7 +1044,7 @@ ClosedFormPyramidResult ComputeClosedFormPyramidInner(double a1, double a2, floa
     const int upper_basal_slot = upper_apex_collapsed ? -1 : 0;
     int n_top = emit_ring(m_at_top, z_top, upper_slot, upper_basal_slot, nullptr);
     if (!upper_apex_collapsed && n_top == 0) {
-      report_apex_rescue("upper", m_at_top);
+      report_apex_rescue("upper", m_requested_top);
     }
     if (upper_apex_collapsed || n_top == 0) {
       // At the apex, the LP maximum may be degenerate: multiple triples
@@ -1098,7 +1117,7 @@ ClosedFormPyramidResult ComputeClosedFormPyramidInner(double a1, double a2, floa
     const int lower_basal_slot = lower_apex_collapsed ? -1 : 1;
     int n_bot = emit_ring(m_at_bot, z_bot, lower_slot, lower_basal_slot, nullptr);
     if (!lower_apex_collapsed && n_bot == 0) {
-      report_apex_rescue("lower", m_at_bot);
+      report_apex_rescue("lower", m_requested_bot);
     }
     if (lower_apex_collapsed || n_bot == 0) {
       double apex_us[20], apex_vs[20];

--- a/src/core/geo3d_closedform.hpp
+++ b/src/core/geo3d_closedform.hpp
@@ -113,6 +113,23 @@ enum ClosedFormHexPathTag : uint16_t {
   // be unreachable; the bit exists so a change that unbinds them is caught by a
   // test rather than by a user with a crystal that quietly lost a cone.
   kClosedFormPathTagApexRescueDegraded = 1u << 5,
+  // A face slot was reached by the vertex emitter — some cross-section corner or
+  // apex point named it as one of the planes it lies on — but ended up with
+  // fewer than 3 distinct vertices in the shared pool, so it is dropped while the
+  // faces beside it keep the edges it was supposed to close. What that leaves is
+  // an OPEN surface: Euler characteristic off 2, edges bordered by one face
+  // instead of two. The pyramid evaluator sets this (the second of the two bits
+  // here it owns) and logs a warning naming the input and the slots.
+  //
+  // It is meant to be unreachable: every tolerance deciding "are these two
+  // corners the same point" is now lateral and derived from GapToleranceForScale
+  // over the cross section the corners actually live in, which is the same ruler
+  // the 2D solver used to decide how many corners there are. The bit exists
+  // because the alternative to a diagnostic here is the worst failure this
+  // evaluator has: a crystal that is not a closed solid, which
+  // IsValidClosedFormPyramid (a present-face count, nothing more) admits, and
+  // which then traces rays and reports statistics while looking healthy.
+  kClosedFormPathTagClaimedFaceDropped = 1u << 6,
 };
 
 // ============================================================================

--- a/src/core/geo3d_closedform.hpp
+++ b/src/core/geo3d_closedform.hpp
@@ -1,7 +1,11 @@
-// Closed-form hex-crystal geometry — parallel implementation of the geometry
-// generation used by the golden-analytic tests and benches. Does NOT touch the
-// production path (FillHexCrystalCoef / SolveConvexPolyhedronVtxD / Crystal);
-// swap-in belongs to a later subtask.
+// Closed-form hex-crystal geometry. This IS the production geometry factory for
+// the prism and pyramid families: Crystal::MakePrismClosedForm /
+// MakePyramidClosedForm (crystal.cpp) call the two entry points below, and
+// Crystal::CreatePrism / CreatePyramid funnel into those. A tolerance changed
+// here changes what every simulation traces, not only what a golden-analytic
+// test compares. (This header used to say the opposite — "does NOT touch the
+// production path ... swap-in belongs to a later subtask" — which stopped being
+// true when the swap-in landed.)
 //
 // The hex-crystal family (prism + pyramid) is characterised by six fixed
 // horizontal normal directions θᵢ = i·60°: the prism is the degenerate case
@@ -183,7 +187,11 @@ struct ClosedFormPrismResult {
 // (corner_cnt = 0, every face_present = false), aligning with
 // FillHexCrystalCoef's zero-volume early exit.
 //
-// This function does not consult the production path.
+// It solves the geometry outright rather than calling FillHexCrystalCoef and
+// SolveConvexPolyhedronVtxD — that is what "closed form" means here, and it is
+// why a golden-analytic test comparing the two is comparing two independent
+// derivations. It is not, however, off the production path: see the note at the
+// top of this header.
 ClosedFormPrismResult ComputeClosedFormPrism(float h, const float dist[6]);
 
 // ============================================================================

--- a/src/core/geo3d_closedform.hpp
+++ b/src/core/geo3d_closedform.hpp
@@ -182,7 +182,7 @@ ClosedFormPrismResult ComputeClosedFormPrism(float h, const float dist[6]);
 //   slot 14+i → lower cone face i (face_number 23+i, i = 0..5)
 constexpr int kClosedFormPyramidFaceCnt = 20;
 constexpr int kClosedFormPyramidSideCnt = 6;
-// Multiplier in GapToleranceForScale's `coefficient * kFloatEps * max(scale, 1)`
+// Multiplier in GapToleranceForScale's `coefficient * kFloatEps * scale`
 // (geo3d_closedform.cpp), which is the single tolerance the apex-collapse gate
 // and the cross-section existence test are both derived from. Named here, in the
 // header, for one reason: a test that re-derives the gate width independently —

--- a/test/golden-analytic/core/pyramid_topology_golden_generated.hpp
+++ b/test/golden-analytic/core/pyramid_topology_golden_generated.hpp
@@ -241,8 +241,17 @@ inline constexpr PyramidTopologyGolden kPyramidFlatTailAlpha89Topology[40] = {
   { 20, 0xffffcu, 0x1fu }, { 22, 0xffffeu, 0x1fu }, { 22, 0xffffdu, 0x1fu }, { 22, 0xffffeu, 0x1fu },
   { 22, 0xffffdu, 0x1fu }, { 20, 0xffffcu, 0x1fu }, { 22, 0xffffeu, 0x1fu }, { 24, 0xfffffu, 0x0cu },
 };
+// Entry #2 carries kClosedFormPathTagClaimedFaceDropped (0x40) on top of the
+// 0x0f its generation run recorded. Hand-edited, one field of one entry, rather
+// than regenerated: nothing about that sample's geometry moved. Its vtx_cnt (23)
+// and face_present mask (0xfdfff — slot 13 absent) are byte-identical before and
+// after, and its published polygon set was already an open surface
+// (V=23 E=41 F=19, χ=1, 3 edges bordered by one face) when this snapshot was
+// taken. The only change is that the evaluator now says so: the bit is a
+// diagnostic the evaluator did not have when this file was generated, and this
+// sample is one of the two in the committed pools that trips it.
 inline constexpr PyramidTopologyGolden kPyramidFlatTailAlpha895Topology[40] = {
-  { 22, 0xffffdu, 0x1fu }, { 24, 0xfffffu, 0x0du }, { 23, 0xfdfffu, 0x0fu }, { 22, 0xffffeu, 0x1fu },
+  { 22, 0xffffdu, 0x1fu }, { 24, 0xfffffu, 0x0du }, { 23, 0xfdfffu, 0x4fu }, { 22, 0xffffeu, 0x1fu },
   { 24, 0xfffffu, 0x0cu }, { 22, 0xffffeu, 0x1fu }, { 22, 0xffffeu, 0x1fu }, { 22, 0xffffeu, 0x1fu },
   { 20, 0xffffcu, 0x1fu }, { 22, 0xffffdu, 0x1fu }, { 20, 0xffffcu, 0x1fu }, { 22, 0xffffdu, 0x1fu },
   { 22, 0xffffdu, 0x1fu }, { 22, 0xffffdu, 0x1fu }, { 20, 0xffffcu, 0x1fu }, { 20, 0xffffcu, 0x1fu },

--- a/test/golden-analytic/core/test_closed_form_pyramid.cpp
+++ b/test/golden-analytic/core/test_closed_form_pyramid.cpp
@@ -41,10 +41,10 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <limits>
 #include <map>
 #include <memory>
-#include <cstdlib>
 #include <random>
 #include <sstream>
 #include <string>
@@ -1485,55 +1485,45 @@ TEST(ClosedFormPyramid, CombinatoricsAreInvariantUnderUniformScaling) {
                           << first_offender;
 }
 
-// ==== TEMPORARY PROBE — Step 0/1, not for commit. ==========================
-// Two observations on the UNMODIFIED evaluator:
-//   TruncationWindowScan — the backlog matrix (alpha x upper_h x dist), one row
-//     per cell, reporting whether the requested truncation cap survived plus the
-//     two tolerances that compete over it.
-//   T10298Replay        — regenerates the named 439.2 regression sample bit-for-
-//     bit from the same generator/seed and dumps its exact float bits so the
-//     permanent test can embed them instead of re-running a non-portable RNG.
+// ============================================================================
+// Contract 2d — the truncation cap must survive every legal upper_h.
 //
-// Run with:
-//   ./build/Release/static/bin/golden_analytic_test \
-//       --gtest_also_run_disabled_tests --gtest_filter='DedupTolProbe.*'
+// A truncated pyramid (upper_h < 1) has a top cap. Losing it does not produce a
+// broken solid — it produces a perfectly well-formed DIFFERENT one, the full
+// pyramid the user did not ask for, with no diagnostic anywhere. That is what
+// makes it worth its own contract: none of the structural invariants above can
+// see it, because nothing about the result is invalid.
+//
+// The failure it guards was a 3D vertex-merge radius scaled by |z|. A cone's tip
+// height carries the wedge slope a = (√3/4)/tan(alpha), so a near-horizontal
+// wedge inflates it without bound while the cap's corners stay ~dist apart:
+// at alpha = 0.2° the radius reached 6.2 against a corner spacing of 0.5 and
+// swallowed the cap whole. The ratio is what matters, and it is scale-free —
+// both terms are linear in dist — so the scan crosses dist deliberately: the
+// window is NOT confined to large crystals, and a scan that only tried
+// dist = 1000 would have left the impression that it was.
+//
+// Assertion per cell: the cap is present, and no face the emitter reached was
+// dropped for lack of distinct vertices. The second half is what makes this a
+// contract about silence rather than about one cap — a future change that keeps
+// the cap by coarsening some other face away fails here.
+// ============================================================================
 
-// Analytic mirror of the evaluator's two competing tolerances for a REGULAR
-// hexagon (all dist equal), where m_apex == dist and every corner sits at the
-// same radius. Not a general re-derivation — only the scan below uses it.
-struct RegularHexTolerances {
-  double a1;              // cone slope
-  double z_top;           // truncation height
-  double z_scale_tol;     // today's kDedupTol: 5*eps*max(|z_top|,|z_bot|)
-  double lateral_tol;     // GapToleranceForScale(CrossSectionScale(r_side(m_top)))
-  double corner_spacing;  // distance between adjacent cap corners
-};
-
-RegularHexTolerances RegularHexTolerancesAt(double alpha_deg, double d, double h1, double h2) {
-  RegularHexTolerances t;
-  t.a1 = static_cast<double>(math::kSqrt3_4) / std::tan(alpha_deg * static_cast<double>(math::kDegreeToRad));
-  const double m_top = h1 * d;  // m_apex == d for a regular hexagon
-  t.z_top = 0.5 * h2 + t.a1 * m_top;
-  const double z_bot = -0.5 * h2;
-  t.z_scale_tol =
-      5.0 * static_cast<double>(math::kFloatEps) * std::max(std::fabs(t.z_top), std::fabs(z_bot));
-  const double r_side = static_cast<double>(math::kSqrt3_4) * (d - m_top);
-  t.lateral_tol = 5.0 * static_cast<double>(math::kFloatEps) * r_side;
-  // Adjacent corners of a regular hexagon whose apothem is r_side are
-  // r_side / cos(30 deg) apart in radius and r_side apart along the ring.
-  t.corner_spacing = r_side / static_cast<double>(math::kSqrt3_2);
-  return t;
-}
-
-TEST(DedupTolProbe, DISABLED_TruncationWindowScan) {
-  static const double kAlphas[] = { 0.2, 1.0, 5.0 };
+TEST(ClosedFormPyramid, TruncationCapSurvivesEveryLegalUpperH) {
+  // alpha spans the near-horizontal wedges where the defect lived (0.2° is one
+  // tick above production's 0.1° floor) up to a slope where it never appeared.
+  static const double kAlphas[] = { 0.2, 1.0, 5.0, 28.0 };
+  // 1 − upper_h from 1e-1 down to 1e-3: the observed window opened at 1e-3 for
+  // alpha ≤ 1° and the partial merge (cap present but corners already fused)
+  // showed at 1e-2.
   static const double kUpperH[] = { 0.9, 0.99, 0.999 };
+  // The repo's own working scale and the large one the defect was first seen at.
   static const double kDists[] = { 1.0, 1000.0 };
+  // With and without a prism section: the same over-wide radius also merged the
+  // two shoulder rings of a 0.3-tall prism into one when |z_top| was large.
   static const double kPrismH[] = { 0.0, 0.3 };
 
-  std::fprintf(stderr,
-               "%-7s %-7s %-8s %-7s | %-4s %-3s %-4s | %-11s %-11s %-11s %s\n",
-               "alpha", "upper_h", "dist", "prism_h", "cap", "vtx", "F", "z_tol", "lat_tol", "spacing", "verdict");
+  int checked = 0;
   for (double prism_h : kPrismH) {
     for (double alpha : kAlphas) {
       for (double d : kDists) {
@@ -1544,234 +1534,140 @@ TEST(DedupTolProbe, DISABLED_TruncationWindowScan) {
           }
           auto cf = ComputeClosedFormPyramid(static_cast<float>(alpha), static_cast<float>(alpha),
                                              static_cast<float>(h1), static_cast<float>(prism_h), 0.0f, dist);
-          const StructuralCensus census = TakeStructuralCensus(cf);
-          const RegularHexTolerances t = RegularHexTolerancesAt(alpha, d, h1, prism_h);
-          // The user asked for a truncated cone (upper_h < 1) — the cap must be
-          // there. Anything else is the defect under test.
-          const bool cap = cf.face_present[0];
-          std::fprintf(stderr,
-                       "%-7.3f %-7.3f %-8.1f %-7.2f | %-4s %-3d %-4d | %-11.4e %-11.4e %-11.4e %s\n",
-                       alpha, h1, d, prism_h, cap ? "yes" : "NO", cf.vtx_cnt, census.f, t.z_scale_tol, t.lateral_tol,
-                       t.corner_spacing, cap ? "ok" : "CAP LOST");
+          checked++;
+          const std::string where = "alpha=" + std::to_string(alpha) + " upper_h=" + std::to_string(h1) +
+                                    " dist=" + std::to_string(d) + " prism_h=" + std::to_string(prism_h);
+          EXPECT_TRUE(cf.face_present[0])
+              << where
+              << ": upper_h < 1 was requested but the top cap (slot 0) is absent — the user asked for a "
+                 "truncated pyramid and got a full one, silently";
+          EXPECT_EQ(cf.path_tag_union & kClosedFormPathTagClaimedFaceDropped, 0u)
+              << where
+              << ": a face the emitter reached kept fewer than 3 distinct vertices on a well-conditioned "
+                 "regular hexagon";
+          // The prism section must survive too: its two shoulder rings are only
+          // prism_h apart in z, which an over-wide merge radius fuses.
+          if (prism_h > 0.0) {
+            EXPECT_EQ(PresentFaceCountInBand(cf, 2), kSideCnt)
+                << where << ": " << PresentFaceCountInBand(cf, 2)
+                << " of 6 prism faces present — the prism section was merged away";
+          }
         }
       }
     }
   }
-  SUCCEED();
+  // Anti-vacuous: a scan that evaluated nothing would report no failure.
+  EXPECT_EQ(checked, 48) << "the cap scan did not cover its full matrix";
 }
 
-TEST(DedupTolProbe, DISABLED_T10298Replay) {
-  // Byte-identical regeneration of the 439.2 AC3 scan (same seed, same
-  // distribution declaration order, same draw order) up to the target index.
-  // LUMICE_PROBE_IDX overrides it so any scan sample can be dumped the same way.
-  const char* idx_env = std::getenv("LUMICE_PROBE_IDX");
-  const int kTarget = idx_env != nullptr ? std::atoi(idx_env) : 10298;
-  constexpr uint32_t kSeed = 20260807u;
-  std::mt19937 gen(kSeed);
-  std::normal_distribution<double> dist_d(1.0, 0.8);
-  std::uniform_real_distribution<double> alpha_d(12.0, 80.0);
-  std::uniform_real_distribution<double> h_d(0.0, 1.0);
-  std::uniform_real_distribution<double> prism_d(0.0, 1.2);
+// ============================================================================
+// Contract 2e — named near-degenerate samples must publish a CLOSED surface.
+//
+// Both entries are individual regressions caught by full-population scans, and
+// both are near-degenerate in the same specific way: one prism face is a sliver
+// a few times 1e-5 wide, resolvable by the cross-section solver but only just.
+// Such a sliver has to be closed at each end by a micro triangle on the cone
+// above and below it. Emit the sliver and drop one of those triangles and the
+// surface is left open — a crystal that is not a solid, which
+// IsValidClosedFormPyramid admits because it counts present faces and nothing
+// else, and which then traces rays and reports statistics looking healthy.
+//
+// The parameters are written as hex float literals because they came from a
+// std::mt19937 sweep whose distributions are not portable across standard
+// libraries: re-running the generator here would sample a different crystal on a
+// different platform and silently stop testing what this pins.
+// ============================================================================
 
-  PyramidSample s{};
-  for (int t = 0; t <= kTarget; t++) {
-    s.upper_alpha = static_cast<float>(alpha_d(gen));
-    s.lower_alpha = static_cast<float>(alpha_d(gen));
-    s.h1 = static_cast<float>(h_d(gen));
-    s.h2 = static_cast<float>(prism_d(gen));
-    s.h3 = static_cast<float>(h_d(gen));
-    for (int i = 0; i < kSideCnt; i++) {
-      s.dist[i] = static_cast<float>(dist_d(gen));
-    }
-  }
-
-  std::fprintf(stderr, "[t10298] alpha=%.6f/%.6f h=%.6f/%.6f/%.6f d=%.6f,%.6f,%.6f,%.6f,%.6f,%.6f\n",
-               static_cast<double>(s.upper_alpha), static_cast<double>(s.lower_alpha), static_cast<double>(s.h1),
-               static_cast<double>(s.h2), static_cast<double>(s.h3), static_cast<double>(s.dist[0]),
-               static_cast<double>(s.dist[1]), static_cast<double>(s.dist[2]), static_cast<double>(s.dist[3]),
-               static_cast<double>(s.dist[4]), static_cast<double>(s.dist[5]));
-  std::fprintf(stderr, "[t10298] exact bits: %a, %a, %a, %a, %a, {%a, %a, %a, %a, %a, %a}\n",
-               static_cast<double>(s.upper_alpha), static_cast<double>(s.lower_alpha), static_cast<double>(s.h1),
-               static_cast<double>(s.h2), static_cast<double>(s.h3), static_cast<double>(s.dist[0]),
-               static_cast<double>(s.dist[1]), static_cast<double>(s.dist[2]), static_cast<double>(s.dist[3]),
-               static_cast<double>(s.dist[4]), static_cast<double>(s.dist[5]));
-
-  auto cf = ComputeClosedFormPyramid(s.upper_alpha, s.lower_alpha, s.h1, s.h2, s.h3, s.dist);
-  const StructuralCensus census = TakeStructuralCensus(cf);
-  const double char_len = ProductionCharLen(s);
-  std::fprintf(stderr, "[t10298] V=%d E=%d F=%d chi=%d nm=%d off=%.3e min_area/char_area=%.6e tags=0x%04x\n", census.v,
-               census.e, census.f, census.v - census.e + census.f, census.non_manifold_edges, census.worst_off_plane,
-               census.min_face_area / (char_len * char_len), cf.path_tag_union);
-  std::fprintf(stderr, "[t10298] inset_top=%.9e inset_bot=%.9e a1=%.6f a2=%.6f\n",
-               static_cast<double>(cf.inset_at_top), static_cast<double>(cf.inset_at_bottom),
-               static_cast<double>(cf.a1), static_cast<double>(cf.a2));
-  for (int i = 0; i < cf.vtx_cnt; i++) {
-    std::fprintf(stderr, "[t10298]   V%02d (%.9e, %.9e, %.9e)\n", i, static_cast<double>(cf.vtx[i * 3 + 0]),
-                 static_cast<double>(cf.vtx[i * 3 + 1]), static_cast<double>(cf.vtx[i * 3 + 2]));
-  }
-  for (int slot = 0; slot < kClosedFormPyramidFaceCnt; slot++) {
-    if (!cf.face_present[slot]) {
-      continue;
-    }
-    std::fprintf(stderr, "[t10298]   F%02d area=%.6e n=%d :", slot, FacePolygonArea(cf, slot), cf.face_vtx_cnt[slot]);
-    for (int k = 0; k < cf.face_vtx_cnt[slot]; k++) {
-      std::fprintf(stderr, " %d", cf.face_vtx[slot][k]);
-    }
-    std::fprintf(stderr, "\n");
-  }
-  std::map<std::pair<int, int>, int> edge_use;
-  for (int slot = 0; slot < kClosedFormPyramidFaceCnt; slot++) {
-    if (!cf.face_present[slot]) {
-      continue;
-    }
-    const int m = cf.face_vtx_cnt[slot];
-    for (int k = 0; k < m; k++) {
-      const int va = cf.face_vtx[slot][k];
-      const int vb = cf.face_vtx[slot][(k + 1) % m];
-      edge_use[std::make_pair(std::min(va, vb), std::max(va, vb))]++;
-    }
-  }
-  for (const auto& [edge, use_cnt] : edge_use) {
-    if (use_cnt != 2) {
-      std::fprintf(stderr, "[t10298]   NONMANIFOLD edge (%d,%d) used %d times\n", edge.first, edge.second, use_cnt);
-    }
-  }
-  SUCCEED();
-}
-// Step 1 open question: does the LOCAL lateral scale at the apex inset collapse
-// to (near) zero, making a per-m local tolerance unusable at the apex insertion
-// sites? Measured, not reasoned: run each pool at upper_h = 1 so that
-// cf.inset_at_top IS the LP apex inset, then compute the cross-section scale the
-// evaluator would see there and compare it with the m = 0 (global lateral) one.
-TEST(DedupTolProbe, DISABLED_ApexLocalScaleCollapse) {
-  struct Case {
+TEST(ClosedFormPyramid, NamedSliverSamplesPublishAClosedSurface) {
+  struct NamedSliver {
     const char* label;
+    float upper_alpha;
+    float lower_alpha;
+    float h1;
+    float h2;
+    float h3;
     float dist[kSideCnt];
+    // Face count below which "fixed" would mean "coarsened away instead".
+    int min_faces;
   };
-  static const Case kCases[] = {
-    { "regular", { 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f } },
-    { "M-crystal", { 0.2f, 1.0f, 1.0f, 0.2f, 1.0f, 1.0f } },
-    { "mild-irregular", { 0.9f, 1.0f, 1.0f, 0.9f, 1.0f, 1.0f } },
-    { "rot-irregular", { 1.0f, 0.2f, 1.0f, 1.0f, 0.2f, 1.0f } },
-    { "wide-spread", { 0.05f, 1.4f, 0.2f, 1.1f, 0.9f, 1.5f } },
+  static const NamedSliver kSamples[] = {
+    // Upper cone a1 = 0.082 against lower a2 = 1.83 on one shared event set:
+    // the shallow side dropped its closing triangle, the steep side kept its.
+    // Before: V=15 E=27 F=13, χ=1, 3 non-manifold edges. The floor of 12 is
+    // above the 11 faces the coarse merge that preceded it produced, so a
+    // regression that "fixes" this by fusing the sliver away fails here.
+    { "t10298",
+      0x1.3d1c3p+6f,
+      0x1.a96456p+3f,
+      0x1.355cfp-4f,
+      0x1.5e83p-1f,
+      0x1.425d5p-2f,
+      { 0x1.12ed04p+0f, 0x1.bb359p-3f, 0x1.64033ep+0f, 0x1.b27f3p-5f, 0x1.70c03cp+0f, 0x1.b716a6p-1f },
+      12 },
+    // Two more from the same sweep, each with the sliver on a different pair of
+    // directions and a different pair of wedge slopes, so the contract is not
+    // pinned to one accident of geometry. Before: F=19 and F=16, both χ=1 with
+    // 3 non-manifold edges.
+    { "t16868",
+      0x1.d85e52p+5f,
+      0x1.051516p+6f,
+      0x1.7be862p-1f,
+      0x1.00e57ep-1f,
+      0x1.c654ecp-1f,
+      { 0x1.87b452p-3f, 0x1.008a38p-1f, 0x1.225f76p-1f, 0x1.1fcfe6p+0f, 0x1.0817a2p+0f, 0x1.013f6ap-1f },
+      19 },
+    { "t27140",
+      0x1.9e5b38p+5f,
+      0x1.3674dcp+6f,
+      0x1.1a669ap-2f,
+      0x1.8e3636p-1f,
+      0x1.acb562p-1f,
+      { 0x1.37ffc2p-3f, 0x1.c52d94p+0f, 0x1.e217aap-1f, 0x1.051f68p+1f, 0x1.19415cp+0f, 0x1.2664b2p+0f },
+      16 },
   };
-  const double k = static_cast<double>(math::kSqrt3_4);
-  std::fprintf(stderr, "%-16s %-11s %-11s %-11s %-11s\n", "case", "apex_m", "scale@apex", "scale@m=0", "ratio");
-  for (const Case& c : kCases) {
-    auto cf = ComputeClosedFormPyramid(28.0f, 28.0f, 1.0f, 0.3f, 0.0f, c.dist);
-    const double apex_m = cf.inset_at_top;
-    double s_apex = 0.0;
-    double s_zero = 0.0;
-    for (int i = 0; i < kSideCnt; i++) {
-      s_apex = std::max(s_apex, std::fabs(k * (static_cast<double>(c.dist[i]) - apex_m)));
-      s_zero = std::max(s_zero, std::fabs(k * static_cast<double>(c.dist[i])));
-    }
-    std::fprintf(stderr, "%-16s %-11.4e %-11.4e %-11.4e %-11.4e\n", c.label, apex_m, s_apex, s_zero,
-                 s_zero > 0.0 ? s_apex / s_zero : -1.0);
-  }
-  SUCCEED();
-}
-TEST(DedupTolProbe, DISABLED_StructuralScan40k) {
-  constexpr int kN = 40000;
-  constexpr uint32_t kSeed = 20260807u;
-  constexpr double kRelTol = 1e-4;
-  constexpr double kMinAreaFrac = 1e-6;
 
-  std::mt19937 gen(kSeed);
-  std::normal_distribution<double> dist_d(1.0, 0.8);
-  std::uniform_real_distribution<double> alpha_d(12.0, 80.0);
-  std::uniform_real_distribution<double> h_d(0.0, 1.0);
-  std::uniform_real_distribution<double> prism_d(0.0, 1.2);
-
-  struct Bucket {
-    int n = 0;
-    int empty = 0;
-    int chi_bad = 0;
-    int nonmanifold = 0;
-    int offplane = 0;
-    int zeroarea = 0;
-    int anybad = 0;
-  };
-  Bucket lo;  // scale < 1
-  Bucket hi;  // scale >= 1
-
-  for (int t = 0; t < kN; t++) {
-    PyramidSample s;
-    s.upper_alpha = static_cast<float>(alpha_d(gen));
-    s.lower_alpha = static_cast<float>(alpha_d(gen));
-    s.h1 = static_cast<float>(h_d(gen));
-    s.h2 = static_cast<float>(prism_d(gen));
-    s.h3 = static_cast<float>(h_d(gen));
-    for (int i = 0; i < kSideCnt; i++) {
-      s.dist[i] = static_cast<float>(dist_d(gen));
-    }
-
-    double max_abs_dist = 0.0;
-    for (int i = 0; i < kSideCnt; i++) {
-      max_abs_dist = std::max(max_abs_dist, std::fabs(static_cast<double>(s.dist[i])));
-    }
-    // The same quantity the LP-site tolerances reduce over: dist_scaled = (√3/4)·dist.
-    const double scale = static_cast<double>(math::kSqrt3_4) * max_abs_dist;
-    Bucket& b = (scale >= 1.0) ? hi : lo;
-    b.n++;
-
+  for (const NamedSliver& s : kSamples) {
     auto cf = ComputeClosedFormPyramid(s.upper_alpha, s.lower_alpha, s.h1, s.h2, s.h3, s.dist);
-    const StructuralCensus census = TakeStructuralCensus(cf);
-    const double char_len = ProductionCharLen(s);
-    const double char_area = char_len * char_len;
-
-    if (census.f == 0) {
-      b.empty++;
-      std::fprintf(stderr, "IDX %5d scale=%.6f EMPTY\n", t, scale);
-      continue;
-    }
-    const int chi = census.v - census.e + census.f;
-    const bool chi_bad = (chi != 2);
-    const bool nm_bad = (census.non_manifold_edges != 0);
-    const bool off_bad = (census.worst_off_plane > kRelTol * char_len);
-    const bool area_bad = (census.min_face_area <= kMinAreaFrac * char_area);
-    if (chi_bad) {
-      b.chi_bad++;
-    }
-    if (nm_bad) {
-      b.nonmanifold++;
-    }
-    if (off_bad) {
-      b.offplane++;
-    }
-    if (area_bad) {
-      b.zeroarea++;
-    }
-    if (chi_bad || nm_bad || off_bad || area_bad) {
-      b.anybad++;
-      std::fprintf(stderr,
-                   "IDX %5d scale=%.6f chi=%d nm=%d off=%d area=%d F=%d min_area=%.6e alpha=%.4f/%.4f "
-                   "h=%.4f/%.4f/%.4f d=%.6f,%.6f,%.6f,%.6f,%.6f,%.6f\n",
-                   t, scale, chi, census.non_manifold_edges, off_bad ? 1 : 0, area_bad ? 1 : 0, census.f,
-                   census.min_face_area / char_area, static_cast<double>(s.upper_alpha),
-                   static_cast<double>(s.lower_alpha), static_cast<double>(s.h1), static_cast<double>(s.h2),
-                   static_cast<double>(s.h3), static_cast<double>(s.dist[0]), static_cast<double>(s.dist[1]),
-                   static_cast<double>(s.dist[2]), static_cast<double>(s.dist[3]), static_cast<double>(s.dist[4]),
-                   static_cast<double>(s.dist[5]));
-    }
+    const StructuralCensus c = TakeStructuralCensus(cf);
+    const int chi = c.v - c.e + c.f;
+    std::fprintf(stderr, "[named-sliver] %-8s V=%2d E=%2d F=%2d chi=%3d non_manifold=%2d tags=0x%04x\n", s.label, c.v,
+                 c.e, c.f, chi, c.non_manifold_edges, cf.path_tag_union);
+    ASSERT_GT(c.f, 0) << s.label << ": cf emitted nothing";
+    EXPECT_EQ(chi, 2) << s.label << ": V−E+F = " << chi << " (V=" << c.v << " E=" << c.e << " F=" << c.f
+                      << ") — the published polygon set is not a closed surface";
+    EXPECT_EQ(c.non_manifold_edges, 0) << s.label << ": " << c.non_manifold_edges
+                                       << " polygon edge(s) are not shared by exactly 2 present faces";
+    EXPECT_GE(c.f, s.min_faces) << s.label << ": only " << c.f << " faces present (floor " << s.min_faces
+                                << ") — the surface closed by coarsening the sliver away rather than by emitting the "
+                                   "faces that bound it";
+    EXPECT_EQ(cf.path_tag_union & kClosedFormPathTagClaimedFaceDropped, 0u)
+        << s.label << ": a face the emitter reached was dropped for lack of distinct vertices";
   }
-
-  auto dump = [](const char* label, const Bucket& b) {
-    std::fprintf(stderr, "SUMMARY %-10s n=%5d empty=%5d chi_bad=%4d nonmanifold=%4d offplane=%4d zeroarea=%4d anybad=%5d\n",
-                 label, b.n, b.empty, b.chi_bad, b.nonmanifold, b.offplane, b.zeroarea, b.anybad);
-  };
-  dump("scale<1", lo);
-  dump("scale>=1", hi);
-  SUCCEED();
 }
 
+// ============================================================================
+// Contract 2f — no committed sample may publish an open surface SILENTLY, and
+// the number that still publish one at all may not grow.
+//
+// Two separate claims, and the weaker one is deliberate. The strong claim —
+// every sample is a closed 2-manifold — is not true today and this task did not
+// make it true: 4 of the committed samples still come out open, all of them in
+// the two degenerate pools, which are built by construction to sit below
+// production's own merge tolerance. What IS enforced is that the count cannot
+// climb back: it was 37 before the merge tolerances were made lateral, and a
+// change that reintroduces a mismatched ruler shows up here as a jump, not as a
+// number nobody was watching.
+//
+// The ratchet is a ceiling, not an equality, for one reason: lowering it is the
+// goal, and a test that fails when someone improves the evaluator teaches people
+// to stop improving it. Lower the constant when you lower the count.
+// ============================================================================
 
-// Step 2 adjudication: every committed sample pool, reporting which entries trip
-// the claimed-face-dropped bit and, independently, whether their published
-// polygon set is actually an open surface. A trip on a CLOSED surface is a false
-// alarm and the predicate has to narrow; a trip on an OPEN one is the bit doing
-// its job on a defect that was already there.
-TEST(DedupTolProbe, DISABLED_ClaimedFaceDroppedAudit) {
+TEST(ClosedFormPyramid, CommittedPoolsPublishNoNewOpenSurfaces) {
+  // Measured on this commit: f895#2, deg030#1, deg050#0, deg050#19. Was 37
+  // before the vertex-merge tolerances stopped being derived from |z|.
+  constexpr int kOpenSurfaceCeiling = 4;
+
   struct Pool {
     const char* label;
     const test_support::PyramidDirectSample* p;
@@ -1790,37 +1686,37 @@ TEST(DedupTolProbe, DISABLED_ClaimedFaceDroppedAudit) {
     { "deg050", test_support::kPyramidDegenerateSigma050Samples,
       std::size(test_support::kPyramidDegenerateSigma050Samples) },
   };
-  int tripped = 0;
-  int tripped_and_open = 0;
-  int open_no_trip = 0;
+
+  int evaluated = 0;
+  int open_cnt = 0;
+  std::string open_list;
   for (const Pool& pool : kPools) {
     for (size_t i = 0; i < pool.n; i++) {
       PyramidSample s = MakeSample(pool.p[i]);
       auto cf = ComputeClosedFormPyramid(s.upper_alpha, s.lower_alpha, s.h1, s.h2, s.h3, s.dist);
       const StructuralCensus c = TakeStructuralCensus(cf);
-      const bool trip = (cf.path_tag_union & kClosedFormPathTagClaimedFaceDropped) != 0;
-      const bool open = c.f > 0 && (c.v - c.e + c.f != 2 || c.non_manifold_edges != 0);
-      if (trip) {
-        tripped++;
+      evaluated++;
+      if (c.f == 0) {
+        continue;  // empty result — a separate contract's business, not this one
       }
-      if (trip && open) {
-        tripped_and_open++;
+      const bool open = (c.v - c.e + c.f != 2) || (c.non_manifold_edges != 0);
+      if (!open) {
+        continue;
       }
-      if (open && !trip) {
-        open_no_trip++;
-      }
-      if (trip || open) {
-        std::fprintf(stderr, "[audit] %-6s #%3zu trip=%d open=%d V=%d E=%d F=%d chi=%d nm=%d\n", pool.label, i,
-                     trip ? 1 : 0, open ? 1 : 0, c.v, c.e, c.f, c.v - c.e + c.f, c.non_manifold_edges);
-      }
+      open_cnt++;
+      open_list += " " + std::string(pool.label) + "#" + std::to_string(i);
     }
   }
-  std::fprintf(stderr, "[audit] tripped=%d tripped_and_open=%d open_without_trip=%d\n", tripped, tripped_and_open,
-               open_no_trip);
-  SUCCEED();
+  // Anti-vacuous: a run that evaluated nothing would report zero open surfaces.
+  ASSERT_GT(evaluated, 500) << "the pool sweep evaluated " << evaluated << " samples — the pools are not being read";
+  EXPECT_LE(open_cnt, kOpenSurfaceCeiling)
+      << open_cnt << " committed samples publish an open surface (ceiling " << kOpenSurfaceCeiling << "):" << open_list
+      << ". A tolerance deciding whether two corners are one point is no longer measuring the cross section those "
+         "corners live in.";
+  std::fprintf(stderr, "[open-surface-ratchet] evaluated=%d open=%d (ceiling %d)%s\n", evaluated, open_cnt,
+               kOpenSurfaceCeiling, open_list.c_str());
 }
 
-// ==== end TEMPORARY PROBE ==================================================
 
 }  // namespace
 }  // namespace lumice

--- a/test/golden-analytic/core/test_closed_form_pyramid.cpp
+++ b/test/golden-analytic/core/test_closed_form_pyramid.cpp
@@ -869,9 +869,10 @@ TEST(ClosedFormPyramid, ApexRescueDegradationNeverFiresOnLegalShapes) {
     { "three-fold", { 1, 0, 1, 0, 1, 0 } }, { "five", { 1, 1, 1, 1, 1, 0 } },
   };
   // Overall size spans the range real crystals use and four decades past it in
-  // both directions: the tolerance this test is about is scale-clamped, so
-  // whether a configuration sits above or below the clamp changes which end of
-  // the binding is doing the work.
+  // both directions. The tolerance this test is about is relative to the cross
+  // section's own size, so the agreement between the collapse gate and the
+  // feasibility test is a claim about every size equally — a sweep confined to
+  // one decade could only ever confirm it at that decade.
   static const double kScales[] = { 0.01, 0.05, 0.2, 1.0, 5.0, 20.0, 100.0, 1000.0 };
   static const double kRatios[] = { 1.0, 0.9, 0.5, 0.2, 0.05, 0.01, 0.002 };
   static const float kAlphas[] = { 0.2f, 5.0f, 28.0f, 60.0f, 89.0f };
@@ -979,9 +980,12 @@ TEST(ClosedFormPyramid, ApexRescueDegradationNeverFiresOnLegalShapes) {
 // compares it to itself asserts nothing.
 //
 // Measured, not assumed: the sweep reports the largest gap it actually snapped
-// away, both as an absolute inset (comparable to the scale-clamped 1.15e-4) and
-// as a fraction of each configuration's own gate width, plus the resulting
-// vertical displacement of the tip.
+// away as a fraction of each configuration's own gate width, alongside the
+// absolute worst case and the resulting vertical displacement of the tip. The
+// gate width is proportional to the cross section's own size, so there is no
+// one absolute ceiling to compare against — 5·kFloatEps/(√3/4) ≈ 1.15e-4 is the
+// width at unit offset scale and nothing more. The bound that holds everywhere
+// is the ratio one.
 // ============================================================================
 
 TEST(ClosedFormPyramid, ApexSnapDeviationStaysWithinTheGateWidth) {
@@ -1010,7 +1014,7 @@ TEST(ClosedFormPyramid, ApexSnapDeviationStaysWithinTheGateWidth) {
 
   int snapped = 0;
   double worst_ratio = 0.0;         // snapped gap / that configuration's gate width
-  double worst_gap_clamped = 0.0;   // largest snapped gap where the scale clamp was active
+  double worst_gap = 0.0;           // largest snapped gap in absolute inset units
   double worst_tip_shift = 0.0;     // tip displacement, relative to the crystal size
   double worst_gap_fraction = 0.0;  // snapped gap as a fraction of the apex inset
   std::string worst_label;
@@ -1068,9 +1072,8 @@ TEST(ClosedFormPyramid, ApexSnapDeviationStaysWithinTheGateWidth) {
                 offset_scale =
                     std::max(offset_scale, std::fabs(kInsetFactor * (static_cast<double>(dist[i]) - m_requested)));
               }
-              const bool clamp_active = offset_scale <= 1.0;
               const double gate_width =
-                  kTolCoefficient * static_cast<double>(math::kFloatEps) * std::max(offset_scale, 1.0) / kInsetFactor;
+                  kTolCoefficient * static_cast<double>(math::kFloatEps) * offset_scale / kInsetFactor;
               const double ratio_of_gate = gap / gate_width;
               const double a1 = A1FromAlpha(alpha, (side == 0) ? h1 : h3);
               const double tip_shift = std::max(0.0, a1) * gap;
@@ -1083,9 +1086,7 @@ TEST(ClosedFormPyramid, ApexSnapDeviationStaysWithinTheGateWidth) {
                               (side == 0) ? "upper" : "lower", t, gap);
                 worst_label = buf;
               }
-              if (clamp_active) {
-                worst_gap_clamped = std::max(worst_gap_clamped, gap);
-              }
+              worst_gap = std::max(worst_gap, gap);
               worst_tip_shift = std::max(worst_tip_shift, tip_shift / scale);
               worst_gap_fraction = std::max(worst_gap_fraction, gap / apex_inset);
             }
@@ -1095,11 +1096,11 @@ TEST(ClosedFormPyramid, ApexSnapDeviationStaysWithinTheGateWidth) {
     }
   }
 
-  const double kClampedGateWidth = kTolCoefficient * static_cast<double>(math::kFloatEps) / kInsetFactor;
   std::fprintf(stderr,
-               "[apex-snap] snapped=%d worst_gap/gate=%.4f worst_gap(clamped)=%.4e (clamped gate width %.4e) "
+               "[apex-snap] snapped=%d worst_gap/gate=%.4f worst_gap=%.4e (gate width at unit offset scale %.4e) "
                "worst_gap/apex_inset=%.4e worst_tip_shift/scale=%.4e\n",
-               snapped, worst_ratio, worst_gap_clamped, kClampedGateWidth, worst_gap_fraction, worst_tip_shift);
+               snapped, worst_ratio, worst_gap, kTolCoefficient * static_cast<double>(math::kFloatEps) / kInsetFactor,
+               worst_gap_fraction, worst_tip_shift);
   std::fprintf(stderr, "[apex-snap] worst case: %s\n", worst_label.c_str());
 
   // Anti-vacuous, both directions: the sweep must snap something, and must get
@@ -1111,8 +1112,6 @@ TEST(ClosedFormPyramid, ApexSnapDeviationStaysWithinTheGateWidth) {
 
   EXPECT_LE(worst_ratio, 1.0) << "a snapped gap exceeded the gate width that authorised it (" << worst_label
                               << ") — the inset↔offset conversion in the gate is not the one that bounds the error";
-  EXPECT_LE(worst_gap_clamped, kClampedGateWidth) << "largest snapped gap in the scale-clamped regime was "
-                                                  << worst_gap_clamped << ", above the predicted " << kClampedGateWidth;
 }
 
 // ============================================================================
@@ -1272,6 +1271,216 @@ TEST(ClosedFormPyramid, SpecialisedConfigurationsAgreeAndNoSpecialCaseBranches) 
         << b.label << " batch triggered path-tag bits absent from the regular batch " << "(batch=0x" << std::hex
         << batch_union << " regular=0x" << regular_union << std::dec << ") — check for special-case branches";
   }
+}
+
+// ============================================================================
+// Contract 2f — two named shapes that must keep all twenty faces.
+//
+// Both are ordinary crystals: every face distance positive, every wedge angle
+// well inside the legal range, no parameter near an endpoint. They are here
+// because a scale-floored tolerance (a `max(scale, 1)` that compares a
+// dimensioned half-plane offset against the pure number 1) used to drop ONE
+// upper cone face on each of them, silently: the surface came out open
+// (V − E + F = 1) with three non-manifold edges, and every consumer downstream
+// kept running on it.
+//
+// The assertions are the structural ones the rest of this file already uses,
+// pinned to these two inputs so the specific regression cannot come back
+// unnoticed. They are stated as full topology (closed surface, 2-manifold, all
+// twenty slots present) rather than "slot 11 is present", because the defect is
+// a whole face going missing, not a particular index.
+// ============================================================================
+
+struct NamedDefectSample {
+  const char* label;
+  float upper_alpha;
+  float lower_alpha;
+  float h1;
+  float h2;
+  float h3;
+  float dist[kSideCnt];
+};
+
+TEST(ClosedFormPyramid, NamedOrdinaryShapesKeepEveryFace) {
+  // Six-decimal values as sampled; feeding the rounded decimals back in
+  // reproduces the defect, so these are a parameter REGION rather than a
+  // knife-edge coincidence.
+  static const NamedDefectSample kSamples[] = {
+    { "t24365",
+      75.2224f,
+      73.8216f,
+      0.7390f,
+      0.4669f,
+      0.1608f,
+      { 0.545105f, 1.037084f, 0.743922f, 0.552757f, 0.167164f, 0.591390f } },
+    { "t8457",
+      78.7637f,
+      45.6552f,
+      0.3811f,
+      0.0045f,
+      0.5277f,
+      { 0.778984f, 1.310429f, 0.745357f, 0.345724f, 1.666781f, 1.576542f } },
+  };
+
+  for (const NamedDefectSample& s : kSamples) {
+    auto cf = ComputeClosedFormPyramid(s.upper_alpha, s.lower_alpha, s.h1, s.h2, s.h3, s.dist);
+    const StructuralCensus census = TakeStructuralCensus(cf);
+
+    std::fprintf(stderr, "[named-defect] %-8s V=%2d E=%2d F=%2d chi=%3d non_manifold=%2d present=0x%05x\n", s.label,
+                 census.v, census.e, census.f, census.v - census.e + census.f, census.non_manifold_edges,
+                 PackFacePresent(cf));
+
+    // EXPECT rather than ASSERT: one sample failing must not hide the other.
+    EXPECT_EQ(census.f, kClosedFormPyramidFaceCnt)
+        << s.label << ": only " << census.f << " of " << kClosedFormPyramidFaceCnt
+        << " faces are present — an ordinary crystal lost a face (present mask 0x" << std::hex << PackFacePresent(cf)
+        << std::dec << ")";
+    EXPECT_EQ(census.v - census.e + census.f, 2)
+        << s.label << ": V−E+F = " << (census.v - census.e + census.f) << " (V=" << census.v << " E=" << census.e
+        << " F=" << census.f << ") — the emitted polygon set is not a closed sphere-like surface";
+    EXPECT_EQ(census.non_manifold_edges, 0)
+        << s.label << ": " << census.non_manifold_edges << " polygon edge(s) are not shared by exactly 2 present faces";
+  }
+}
+
+// ============================================================================
+// Contract 2g — scale invariance.
+//
+// Every tolerance in the closed form is supposed to be relative to the size of
+// the thing it measures. Multiplying all the LENGTH inputs by a power of two is
+// the sharpest available test of that claim: powers of two multiply and divide
+// exactly in binary floating point, so the scaled input describes a strictly
+// similar solid — not an approximately similar one. A relative tolerance must
+// therefore return a bit-identical combinatorial answer at every scale, and any
+// difference is attributable to a scale-dependent threshold with no
+// alternative explanation (input rounding cannot produce one).
+//
+// h1 / h3 are deliberately NOT scaled: they are fractions of their cone's
+// height, not lengths. dist[] and h2 are.
+//
+// What is compared is combinatorics only — which faces are present, how many
+// vertices bound each of them, and which solver branches were walked. Vertex
+// coordinates are not compared: those are floats and scale exactly, but the
+// contract under test is about decisions, not arithmetic.
+//
+// The check is an all-pairs equality expressed against one member of the set;
+// which member holds that role is arbitrary and carries no assumption that any
+// particular scale is the correct one.
+// ============================================================================
+
+// Combinatorial fingerprint used by the scale-invariance check.
+struct CombinatorialSignature {
+  uint32_t face_present_mask = 0;
+  int face_vtx_cnt[kClosedFormPyramidFaceCnt]{};
+  uint16_t path_tag_union = 0;
+
+  bool operator==(const CombinatorialSignature& o) const {
+    if (face_present_mask != o.face_present_mask || path_tag_union != o.path_tag_union) {
+      return false;
+    }
+    for (int slot = 0; slot < kClosedFormPyramidFaceCnt; slot++) {
+      if (face_vtx_cnt[slot] != o.face_vtx_cnt[slot]) {
+        return false;
+      }
+    }
+    return true;
+  }
+};
+
+CombinatorialSignature TakeCombinatorialSignature(const ClosedFormPyramidResult& cf) {
+  CombinatorialSignature sig;
+  sig.face_present_mask = PackFacePresent(cf);
+  sig.path_tag_union = cf.path_tag_union;
+  for (int slot = 0; slot < kClosedFormPyramidFaceCnt; slot++) {
+    sig.face_vtx_cnt[slot] = cf.face_present[slot] ? cf.face_vtx_cnt[slot] : 0;
+  }
+  return sig;
+}
+
+TEST(ClosedFormPyramid, CombinatoricsAreInvariantUnderUniformScaling) {
+  // Thirteen octaves, 1/64 … 64 around the pools' native size. Powers of two
+  // only — see the header note: this is what makes a divergence attributable.
+  constexpr int kMinExp = -6;
+  constexpr int kMaxExp = 6;
+
+  struct Pool {
+    const char* label;
+    const test_support::PyramidDirectSample* samples;
+    size_t n;
+  };
+  const Pool kPools[] = {
+    { "well-conditioned", test_support::kPyramidWellConditionedSamples,
+      std::size(test_support::kPyramidWellConditionedSamples) },
+    { "degenerate-sigma030", test_support::kPyramidDegenerateSigma030Samples,
+      std::size(test_support::kPyramidDegenerateSigma030Samples) },
+    { "degenerate-sigma050", test_support::kPyramidDegenerateSigma050Samples,
+      std::size(test_support::kPyramidDegenerateSigma050Samples) },
+    { "flat-tail-alpha89", test_support::kPyramidFlatTailAlpha89Samples,
+      std::size(test_support::kPyramidFlatTailAlpha89Samples) },
+  };
+
+  int compared = 0;
+  int divergent = 0;
+  std::string first_offender;
+
+  for (const Pool& pool : kPools) {
+    int pool_divergent = 0;
+    for (size_t i = 0; i < pool.n; i++) {
+      const test_support::PyramidDirectSample& s = pool.samples[i];
+
+      auto eval = [&s](int exp) {
+        const float k = std::ldexp(1.0f, exp);
+        float dist[kSideCnt];
+        for (int d = 0; d < kSideCnt; d++) {
+          dist[d] = s.dist[d] * k;
+        }
+        return ComputeClosedFormPyramid(s.upper_alpha, s.lower_alpha, s.h1, s.h2 * k, s.h3, dist);
+      };
+
+      const CombinatorialSignature ref = TakeCombinatorialSignature(eval(0));
+      for (int exp = kMinExp; exp <= kMaxExp; exp++) {
+        if (exp == 0) {
+          continue;
+        }
+        const CombinatorialSignature sig = TakeCombinatorialSignature(eval(exp));
+        compared++;
+        if (!(sig == ref)) {
+          divergent++;
+          pool_divergent++;
+          if (first_offender.empty()) {
+            // Name the first field that differs — a mask/tag pair that reads
+            // identical means the divergence is in a per-face vertex count, and
+            // a message that stopped at the mask would look like a bug in the
+            // message rather than a real difference.
+            int slot_diff = -1;
+            for (int slot = 0; slot < kClosedFormPyramidFaceCnt; slot++) {
+              if (sig.face_vtx_cnt[slot] != ref.face_vtx_cnt[slot]) {
+                slot_diff = slot;
+                break;
+              }
+            }
+            char buf[288];
+            std::snprintf(buf, sizeof(buf),
+                          "%s #%zu at 2^%d: present 0x%05x vs 0x%05x, tags 0x%04x vs 0x%04x, first differing "
+                          "face_vtx_cnt slot %d (%d vs %d)",
+                          pool.label, i, exp, sig.face_present_mask, ref.face_present_mask, sig.path_tag_union,
+                          ref.path_tag_union, slot_diff, slot_diff < 0 ? -1 : sig.face_vtx_cnt[slot_diff],
+                          slot_diff < 0 ? -1 : ref.face_vtx_cnt[slot_diff]);
+            first_offender = buf;
+          }
+        }
+      }
+    }
+    std::fprintf(stderr, "[scale-invariance] %-20s samples=%3zu divergent=%d\n", pool.label, pool.n, pool_divergent);
+  }
+
+  // Anti-vacuous: a run that compared nothing would report zero divergences for
+  // the wrong reason.
+  ASSERT_GT(compared, 0) << "no scaled comparison ran — the sample pools are empty";
+  EXPECT_EQ(divergent, 0) << divergent << " of " << compared
+                          << " uniformly-scaled evaluations changed their combinatorial answer — a tolerance in the "
+                             "closed form is not relative to the quantity it measures. First: "
+                          << first_offender;
 }
 
 }  // namespace

--- a/test/golden-analytic/core/test_closed_form_pyramid.cpp
+++ b/test/golden-analytic/core/test_closed_form_pyramid.cpp
@@ -41,11 +41,9 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
-#include <cstdlib>
 #include <limits>
 #include <map>
 #include <memory>
-#include <random>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -1716,7 +1714,6 @@ TEST(ClosedFormPyramid, CommittedPoolsPublishNoNewOpenSurfaces) {
   std::fprintf(stderr, "[open-surface-ratchet] evaluated=%d open=%d (ceiling %d)%s\n", evaluated, open_cnt,
                kOpenSurfaceCeiling, open_list.c_str());
 }
-
 
 }  // namespace
 }  // namespace lumice

--- a/test/golden-analytic/core/test_closed_form_pyramid.cpp
+++ b/test/golden-analytic/core/test_closed_form_pyramid.cpp
@@ -44,6 +44,8 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <cstdlib>
+#include <random>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -1482,6 +1484,343 @@ TEST(ClosedFormPyramid, CombinatoricsAreInvariantUnderUniformScaling) {
                              "closed form is not relative to the quantity it measures. First: "
                           << first_offender;
 }
+
+// ==== TEMPORARY PROBE — Step 0/1, not for commit. ==========================
+// Two observations on the UNMODIFIED evaluator:
+//   TruncationWindowScan — the backlog matrix (alpha x upper_h x dist), one row
+//     per cell, reporting whether the requested truncation cap survived plus the
+//     two tolerances that compete over it.
+//   T10298Replay        — regenerates the named 439.2 regression sample bit-for-
+//     bit from the same generator/seed and dumps its exact float bits so the
+//     permanent test can embed them instead of re-running a non-portable RNG.
+//
+// Run with:
+//   ./build/Release/static/bin/golden_analytic_test \
+//       --gtest_also_run_disabled_tests --gtest_filter='DedupTolProbe.*'
+
+// Analytic mirror of the evaluator's two competing tolerances for a REGULAR
+// hexagon (all dist equal), where m_apex == dist and every corner sits at the
+// same radius. Not a general re-derivation — only the scan below uses it.
+struct RegularHexTolerances {
+  double a1;              // cone slope
+  double z_top;           // truncation height
+  double z_scale_tol;     // today's kDedupTol: 5*eps*max(|z_top|,|z_bot|)
+  double lateral_tol;     // GapToleranceForScale(CrossSectionScale(r_side(m_top)))
+  double corner_spacing;  // distance between adjacent cap corners
+};
+
+RegularHexTolerances RegularHexTolerancesAt(double alpha_deg, double d, double h1, double h2) {
+  RegularHexTolerances t;
+  t.a1 = static_cast<double>(math::kSqrt3_4) / std::tan(alpha_deg * static_cast<double>(math::kDegreeToRad));
+  const double m_top = h1 * d;  // m_apex == d for a regular hexagon
+  t.z_top = 0.5 * h2 + t.a1 * m_top;
+  const double z_bot = -0.5 * h2;
+  t.z_scale_tol =
+      5.0 * static_cast<double>(math::kFloatEps) * std::max(std::fabs(t.z_top), std::fabs(z_bot));
+  const double r_side = static_cast<double>(math::kSqrt3_4) * (d - m_top);
+  t.lateral_tol = 5.0 * static_cast<double>(math::kFloatEps) * r_side;
+  // Adjacent corners of a regular hexagon whose apothem is r_side are
+  // r_side / cos(30 deg) apart in radius and r_side apart along the ring.
+  t.corner_spacing = r_side / static_cast<double>(math::kSqrt3_2);
+  return t;
+}
+
+TEST(DedupTolProbe, DISABLED_TruncationWindowScan) {
+  static const double kAlphas[] = { 0.2, 1.0, 5.0 };
+  static const double kUpperH[] = { 0.9, 0.99, 0.999 };
+  static const double kDists[] = { 1.0, 1000.0 };
+  static const double kPrismH[] = { 0.0, 0.3 };
+
+  std::fprintf(stderr,
+               "%-7s %-7s %-8s %-7s | %-4s %-3s %-4s | %-11s %-11s %-11s %s\n",
+               "alpha", "upper_h", "dist", "prism_h", "cap", "vtx", "F", "z_tol", "lat_tol", "spacing", "verdict");
+  for (double prism_h : kPrismH) {
+    for (double alpha : kAlphas) {
+      for (double d : kDists) {
+        for (double h1 : kUpperH) {
+          float dist[kSideCnt];
+          for (int i = 0; i < kSideCnt; i++) {
+            dist[i] = static_cast<float>(d);
+          }
+          auto cf = ComputeClosedFormPyramid(static_cast<float>(alpha), static_cast<float>(alpha),
+                                             static_cast<float>(h1), static_cast<float>(prism_h), 0.0f, dist);
+          const StructuralCensus census = TakeStructuralCensus(cf);
+          const RegularHexTolerances t = RegularHexTolerancesAt(alpha, d, h1, prism_h);
+          // The user asked for a truncated cone (upper_h < 1) — the cap must be
+          // there. Anything else is the defect under test.
+          const bool cap = cf.face_present[0];
+          std::fprintf(stderr,
+                       "%-7.3f %-7.3f %-8.1f %-7.2f | %-4s %-3d %-4d | %-11.4e %-11.4e %-11.4e %s\n",
+                       alpha, h1, d, prism_h, cap ? "yes" : "NO", cf.vtx_cnt, census.f, t.z_scale_tol, t.lateral_tol,
+                       t.corner_spacing, cap ? "ok" : "CAP LOST");
+        }
+      }
+    }
+  }
+  SUCCEED();
+}
+
+TEST(DedupTolProbe, DISABLED_T10298Replay) {
+  // Byte-identical regeneration of the 439.2 AC3 scan (same seed, same
+  // distribution declaration order, same draw order) up to the target index.
+  // LUMICE_PROBE_IDX overrides it so any scan sample can be dumped the same way.
+  const char* idx_env = std::getenv("LUMICE_PROBE_IDX");
+  const int kTarget = idx_env != nullptr ? std::atoi(idx_env) : 10298;
+  constexpr uint32_t kSeed = 20260807u;
+  std::mt19937 gen(kSeed);
+  std::normal_distribution<double> dist_d(1.0, 0.8);
+  std::uniform_real_distribution<double> alpha_d(12.0, 80.0);
+  std::uniform_real_distribution<double> h_d(0.0, 1.0);
+  std::uniform_real_distribution<double> prism_d(0.0, 1.2);
+
+  PyramidSample s{};
+  for (int t = 0; t <= kTarget; t++) {
+    s.upper_alpha = static_cast<float>(alpha_d(gen));
+    s.lower_alpha = static_cast<float>(alpha_d(gen));
+    s.h1 = static_cast<float>(h_d(gen));
+    s.h2 = static_cast<float>(prism_d(gen));
+    s.h3 = static_cast<float>(h_d(gen));
+    for (int i = 0; i < kSideCnt; i++) {
+      s.dist[i] = static_cast<float>(dist_d(gen));
+    }
+  }
+
+  std::fprintf(stderr, "[t10298] alpha=%.6f/%.6f h=%.6f/%.6f/%.6f d=%.6f,%.6f,%.6f,%.6f,%.6f,%.6f\n",
+               static_cast<double>(s.upper_alpha), static_cast<double>(s.lower_alpha), static_cast<double>(s.h1),
+               static_cast<double>(s.h2), static_cast<double>(s.h3), static_cast<double>(s.dist[0]),
+               static_cast<double>(s.dist[1]), static_cast<double>(s.dist[2]), static_cast<double>(s.dist[3]),
+               static_cast<double>(s.dist[4]), static_cast<double>(s.dist[5]));
+  std::fprintf(stderr, "[t10298] exact bits: %a, %a, %a, %a, %a, {%a, %a, %a, %a, %a, %a}\n",
+               static_cast<double>(s.upper_alpha), static_cast<double>(s.lower_alpha), static_cast<double>(s.h1),
+               static_cast<double>(s.h2), static_cast<double>(s.h3), static_cast<double>(s.dist[0]),
+               static_cast<double>(s.dist[1]), static_cast<double>(s.dist[2]), static_cast<double>(s.dist[3]),
+               static_cast<double>(s.dist[4]), static_cast<double>(s.dist[5]));
+
+  auto cf = ComputeClosedFormPyramid(s.upper_alpha, s.lower_alpha, s.h1, s.h2, s.h3, s.dist);
+  const StructuralCensus census = TakeStructuralCensus(cf);
+  const double char_len = ProductionCharLen(s);
+  std::fprintf(stderr, "[t10298] V=%d E=%d F=%d chi=%d nm=%d off=%.3e min_area/char_area=%.6e tags=0x%04x\n", census.v,
+               census.e, census.f, census.v - census.e + census.f, census.non_manifold_edges, census.worst_off_plane,
+               census.min_face_area / (char_len * char_len), cf.path_tag_union);
+  std::fprintf(stderr, "[t10298] inset_top=%.9e inset_bot=%.9e a1=%.6f a2=%.6f\n",
+               static_cast<double>(cf.inset_at_top), static_cast<double>(cf.inset_at_bottom),
+               static_cast<double>(cf.a1), static_cast<double>(cf.a2));
+  for (int i = 0; i < cf.vtx_cnt; i++) {
+    std::fprintf(stderr, "[t10298]   V%02d (%.9e, %.9e, %.9e)\n", i, static_cast<double>(cf.vtx[i * 3 + 0]),
+                 static_cast<double>(cf.vtx[i * 3 + 1]), static_cast<double>(cf.vtx[i * 3 + 2]));
+  }
+  for (int slot = 0; slot < kClosedFormPyramidFaceCnt; slot++) {
+    if (!cf.face_present[slot]) {
+      continue;
+    }
+    std::fprintf(stderr, "[t10298]   F%02d area=%.6e n=%d :", slot, FacePolygonArea(cf, slot), cf.face_vtx_cnt[slot]);
+    for (int k = 0; k < cf.face_vtx_cnt[slot]; k++) {
+      std::fprintf(stderr, " %d", cf.face_vtx[slot][k]);
+    }
+    std::fprintf(stderr, "\n");
+  }
+  std::map<std::pair<int, int>, int> edge_use;
+  for (int slot = 0; slot < kClosedFormPyramidFaceCnt; slot++) {
+    if (!cf.face_present[slot]) {
+      continue;
+    }
+    const int m = cf.face_vtx_cnt[slot];
+    for (int k = 0; k < m; k++) {
+      const int va = cf.face_vtx[slot][k];
+      const int vb = cf.face_vtx[slot][(k + 1) % m];
+      edge_use[std::make_pair(std::min(va, vb), std::max(va, vb))]++;
+    }
+  }
+  for (const auto& [edge, use_cnt] : edge_use) {
+    if (use_cnt != 2) {
+      std::fprintf(stderr, "[t10298]   NONMANIFOLD edge (%d,%d) used %d times\n", edge.first, edge.second, use_cnt);
+    }
+  }
+  SUCCEED();
+}
+// Step 1 open question: does the LOCAL lateral scale at the apex inset collapse
+// to (near) zero, making a per-m local tolerance unusable at the apex insertion
+// sites? Measured, not reasoned: run each pool at upper_h = 1 so that
+// cf.inset_at_top IS the LP apex inset, then compute the cross-section scale the
+// evaluator would see there and compare it with the m = 0 (global lateral) one.
+TEST(DedupTolProbe, DISABLED_ApexLocalScaleCollapse) {
+  struct Case {
+    const char* label;
+    float dist[kSideCnt];
+  };
+  static const Case kCases[] = {
+    { "regular", { 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f } },
+    { "M-crystal", { 0.2f, 1.0f, 1.0f, 0.2f, 1.0f, 1.0f } },
+    { "mild-irregular", { 0.9f, 1.0f, 1.0f, 0.9f, 1.0f, 1.0f } },
+    { "rot-irregular", { 1.0f, 0.2f, 1.0f, 1.0f, 0.2f, 1.0f } },
+    { "wide-spread", { 0.05f, 1.4f, 0.2f, 1.1f, 0.9f, 1.5f } },
+  };
+  const double k = static_cast<double>(math::kSqrt3_4);
+  std::fprintf(stderr, "%-16s %-11s %-11s %-11s %-11s\n", "case", "apex_m", "scale@apex", "scale@m=0", "ratio");
+  for (const Case& c : kCases) {
+    auto cf = ComputeClosedFormPyramid(28.0f, 28.0f, 1.0f, 0.3f, 0.0f, c.dist);
+    const double apex_m = cf.inset_at_top;
+    double s_apex = 0.0;
+    double s_zero = 0.0;
+    for (int i = 0; i < kSideCnt; i++) {
+      s_apex = std::max(s_apex, std::fabs(k * (static_cast<double>(c.dist[i]) - apex_m)));
+      s_zero = std::max(s_zero, std::fabs(k * static_cast<double>(c.dist[i])));
+    }
+    std::fprintf(stderr, "%-16s %-11.4e %-11.4e %-11.4e %-11.4e\n", c.label, apex_m, s_apex, s_zero,
+                 s_zero > 0.0 ? s_apex / s_zero : -1.0);
+  }
+  SUCCEED();
+}
+TEST(DedupTolProbe, DISABLED_StructuralScan40k) {
+  constexpr int kN = 40000;
+  constexpr uint32_t kSeed = 20260807u;
+  constexpr double kRelTol = 1e-4;
+  constexpr double kMinAreaFrac = 1e-6;
+
+  std::mt19937 gen(kSeed);
+  std::normal_distribution<double> dist_d(1.0, 0.8);
+  std::uniform_real_distribution<double> alpha_d(12.0, 80.0);
+  std::uniform_real_distribution<double> h_d(0.0, 1.0);
+  std::uniform_real_distribution<double> prism_d(0.0, 1.2);
+
+  struct Bucket {
+    int n = 0;
+    int empty = 0;
+    int chi_bad = 0;
+    int nonmanifold = 0;
+    int offplane = 0;
+    int zeroarea = 0;
+    int anybad = 0;
+  };
+  Bucket lo;  // scale < 1
+  Bucket hi;  // scale >= 1
+
+  for (int t = 0; t < kN; t++) {
+    PyramidSample s;
+    s.upper_alpha = static_cast<float>(alpha_d(gen));
+    s.lower_alpha = static_cast<float>(alpha_d(gen));
+    s.h1 = static_cast<float>(h_d(gen));
+    s.h2 = static_cast<float>(prism_d(gen));
+    s.h3 = static_cast<float>(h_d(gen));
+    for (int i = 0; i < kSideCnt; i++) {
+      s.dist[i] = static_cast<float>(dist_d(gen));
+    }
+
+    double max_abs_dist = 0.0;
+    for (int i = 0; i < kSideCnt; i++) {
+      max_abs_dist = std::max(max_abs_dist, std::fabs(static_cast<double>(s.dist[i])));
+    }
+    // The same quantity the LP-site tolerances reduce over: dist_scaled = (√3/4)·dist.
+    const double scale = static_cast<double>(math::kSqrt3_4) * max_abs_dist;
+    Bucket& b = (scale >= 1.0) ? hi : lo;
+    b.n++;
+
+    auto cf = ComputeClosedFormPyramid(s.upper_alpha, s.lower_alpha, s.h1, s.h2, s.h3, s.dist);
+    const StructuralCensus census = TakeStructuralCensus(cf);
+    const double char_len = ProductionCharLen(s);
+    const double char_area = char_len * char_len;
+
+    if (census.f == 0) {
+      b.empty++;
+      std::fprintf(stderr, "IDX %5d scale=%.6f EMPTY\n", t, scale);
+      continue;
+    }
+    const int chi = census.v - census.e + census.f;
+    const bool chi_bad = (chi != 2);
+    const bool nm_bad = (census.non_manifold_edges != 0);
+    const bool off_bad = (census.worst_off_plane > kRelTol * char_len);
+    const bool area_bad = (census.min_face_area <= kMinAreaFrac * char_area);
+    if (chi_bad) {
+      b.chi_bad++;
+    }
+    if (nm_bad) {
+      b.nonmanifold++;
+    }
+    if (off_bad) {
+      b.offplane++;
+    }
+    if (area_bad) {
+      b.zeroarea++;
+    }
+    if (chi_bad || nm_bad || off_bad || area_bad) {
+      b.anybad++;
+      std::fprintf(stderr,
+                   "IDX %5d scale=%.6f chi=%d nm=%d off=%d area=%d F=%d min_area=%.6e alpha=%.4f/%.4f "
+                   "h=%.4f/%.4f/%.4f d=%.6f,%.6f,%.6f,%.6f,%.6f,%.6f\n",
+                   t, scale, chi, census.non_manifold_edges, off_bad ? 1 : 0, area_bad ? 1 : 0, census.f,
+                   census.min_face_area / char_area, static_cast<double>(s.upper_alpha),
+                   static_cast<double>(s.lower_alpha), static_cast<double>(s.h1), static_cast<double>(s.h2),
+                   static_cast<double>(s.h3), static_cast<double>(s.dist[0]), static_cast<double>(s.dist[1]),
+                   static_cast<double>(s.dist[2]), static_cast<double>(s.dist[3]), static_cast<double>(s.dist[4]),
+                   static_cast<double>(s.dist[5]));
+    }
+  }
+
+  auto dump = [](const char* label, const Bucket& b) {
+    std::fprintf(stderr, "SUMMARY %-10s n=%5d empty=%5d chi_bad=%4d nonmanifold=%4d offplane=%4d zeroarea=%4d anybad=%5d\n",
+                 label, b.n, b.empty, b.chi_bad, b.nonmanifold, b.offplane, b.zeroarea, b.anybad);
+  };
+  dump("scale<1", lo);
+  dump("scale>=1", hi);
+  SUCCEED();
+}
+
+
+// Step 2 adjudication: every committed sample pool, reporting which entries trip
+// the claimed-face-dropped bit and, independently, whether their published
+// polygon set is actually an open surface. A trip on a CLOSED surface is a false
+// alarm and the predicate has to narrow; a trip on an OPEN one is the bit doing
+// its job on a defect that was already there.
+TEST(DedupTolProbe, DISABLED_ClaimedFaceDroppedAudit) {
+  struct Pool {
+    const char* label;
+    const test_support::PyramidDirectSample* p;
+    size_t n;
+  };
+  const Pool kPools[] = {
+    { "wc", test_support::kPyramidWellConditionedSamples, std::size(test_support::kPyramidWellConditionedSamples) },
+    { "f85", test_support::kPyramidFlatTailAlpha85Samples, std::size(test_support::kPyramidFlatTailAlpha85Samples) },
+    { "f87", test_support::kPyramidFlatTailAlpha87Samples, std::size(test_support::kPyramidFlatTailAlpha87Samples) },
+    { "f875", test_support::kPyramidFlatTailAlpha875Samples, std::size(test_support::kPyramidFlatTailAlpha875Samples) },
+    { "f88", test_support::kPyramidFlatTailAlpha88Samples, std::size(test_support::kPyramidFlatTailAlpha88Samples) },
+    { "f89", test_support::kPyramidFlatTailAlpha89Samples, std::size(test_support::kPyramidFlatTailAlpha89Samples) },
+    { "f895", test_support::kPyramidFlatTailAlpha895Samples, std::size(test_support::kPyramidFlatTailAlpha895Samples) },
+    { "deg030", test_support::kPyramidDegenerateSigma030Samples,
+      std::size(test_support::kPyramidDegenerateSigma030Samples) },
+    { "deg050", test_support::kPyramidDegenerateSigma050Samples,
+      std::size(test_support::kPyramidDegenerateSigma050Samples) },
+  };
+  int tripped = 0;
+  int tripped_and_open = 0;
+  int open_no_trip = 0;
+  for (const Pool& pool : kPools) {
+    for (size_t i = 0; i < pool.n; i++) {
+      PyramidSample s = MakeSample(pool.p[i]);
+      auto cf = ComputeClosedFormPyramid(s.upper_alpha, s.lower_alpha, s.h1, s.h2, s.h3, s.dist);
+      const StructuralCensus c = TakeStructuralCensus(cf);
+      const bool trip = (cf.path_tag_union & kClosedFormPathTagClaimedFaceDropped) != 0;
+      const bool open = c.f > 0 && (c.v - c.e + c.f != 2 || c.non_manifold_edges != 0);
+      if (trip) {
+        tripped++;
+      }
+      if (trip && open) {
+        tripped_and_open++;
+      }
+      if (open && !trip) {
+        open_no_trip++;
+      }
+      if (trip || open) {
+        std::fprintf(stderr, "[audit] %-6s #%3zu trip=%d open=%d V=%d E=%d F=%d chi=%d nm=%d\n", pool.label, i,
+                     trip ? 1 : 0, open ? 1 : 0, c.v, c.e, c.f, c.v - c.e + c.f, c.non_manifold_edges);
+      }
+    }
+  }
+  std::fprintf(stderr, "[audit] tripped=%d tripped_and_open=%d open_without_trip=%d\n", tripped, tripped_and_open,
+               open_no_trip);
+  SUCCEED();
+}
+
+// ==== end TEMPORARY PROBE ==================================================
 
 }  // namespace
 }  // namespace lumice


### PR DESCRIPTION
## 摘要

删掉闭式棱锥几何里 `max(·, 1.0)` 形态的容差地板（**逐字 5 处**），并顺带收掉同族的两条残余。

立项时的判断是「结构性清理」，**实测发现是真缺陷**。

`max(·, 1.0)` 把**有量纲的** `scale`（长度 = `kInsetK · face_distance`）与**纯数** `1` 相比 ——
这不是容差参数，而是「假定用户的长度单位下晶体是 O(1) 大」的**单位制假设**，
而晶体几何是**尺度自由**的，问题里没有任何内禀长度。

## 为什么它是缺陷，不是整洁度问题

| | 实测证据 |
|---|---|
| **来历** | 这个 `1.0` **从未被任何人论证过**。引入它的 commit 注释只解释 `kFloatEps` 为何是 1e-5，对地板一字未提，标题却自称 "Relative feasibility tolerance"（作者以为写的就是相对容差）。本文件最近一次最仔细的审视（PR #256）在头文件里**逐字引用**了 `max(scale, 1)`、并明确区分了「有人决定的数」与「数学常数」，却**没把它归入任何一类**。 |
| **可达性** | 形状采样链**全程无 clamp**（`simulator.cpp` 明写 face_distance 有符号、故意不在采样边界取绝对值；`math.cpp` 的高斯采样无界；config 侧无上界校验）。端到端跑真 CLI：**仓库现成 config** `test/e2e/configs/repro_crash_pyramid_face_distance.json`（`std=0.5`）跨界率 **2.75%**，`std=0.8` → **27.2%**，`std=1.5` → **74.6%**（GUI 允许到 2.0）⇒ 两套容差 regime 在**一次运行内逐晶体随机交替，无任何诊断信号**。 |
| **后果** | 用 PR #256 建立的结构不变量测量：`χ = 1`（曲面不闭合）+ 3 条非流形边，机制是**静默丢一个上锥面**。最小复现的参数**完全普通**：六个 `face_distance` **全为正、全在 `[0.17, 1.04]`**、wedge 角在合法区间、无任何极端值，且 `scale = 0.449` **< 1** —— 即落在钳位生效那一侧，**本仓全部现有 config 所在的域**。⇒ **不需要跨过边界就会发生。** |
| **修复** | 删掉即修复，**不需要任何补偿性特判**：`scale == 0` 的四例退化输入（全零 / 1e-7 / 1e-3 / 混合零）与修改前**逐位相同**，公式自己就正确降级。 |

## 改动内容

- **`fix(core)`：五处容差改为纯相对**（`GapToleranceForScale` / `EnumerateApexPoints` /
  `MaxFeasibleInsetLP` / `EnumerateConeDeathEvents` / 3D 顶点合并），核心是 5 行。
- **`fix(core)`：3D 顶点合并换横向尺子** —— 原先它的尺度取自**竖直量** `max(|z_top|, |z_bot|)`，
  在近水平 wedge + 大晶体下会涨到吞掉整个顶盖（用户要截断、拿到满锥，无 warning）。
  同一病灶的另一个方向：一个被钳死在下方，一个被 `|z|` 放大到上方。
- **`refactor(core)`：apex 吸附从就地改写改为返回值 + `const` 数据流**，
  让「必须在吸附之后再推导 `z_top`/`inset_at_*`」这条跨十几行的不变量由编译器维持，而不是靠书写顺序。
- **`test`：两个具名普通形状钉成结构不变量回归**、截断顶盖存活哨兵、三个 sliver 样本、开曲面棘轮，
  以及一条**尺度不变性哨兵**。
- **`docs`**：更正头文件里「不在生产路径上」的失实声明，同步 `doc/configuration{,_zh}.md`。

## 验证

- 全部新增断言/哨兵**先在未修代码上实测为红**（本仓有零检测力哨兵前科）。
- 40000 样本结构扫描：结构违规 **31 → 16**；`empty`（零体积）计数**逐位不变**。
- apex 吸附重构：**68289 行参数扫描 dump 逐字节相同**，`pyramid_topology_golden_generated.hpp`
  **0 行变化**。
- `./scripts/test.sh quick` **`RESULT: PASS`**（ctest 6/6、fast-e2e、`gui_test` 314/314）；
  `format.sh --check` / `check_policies.py` / `check_new_refs.py` 均 exit 0。
- 三个实施子任务的 code-review 均 **APPROVE、0 Critical / 0 Major**。

## ⭐ 方法论产出（可复用）

**均匀缩放 2 的幂 = 零假阳性的相对容差判据。** 把长度类输入同乘 2 的幂，在二进制浮点下
**精确无舍入** ⇒ 两组输入是**严格相似**的几何 ⇒ 真·相对容差必须给出**逐位相同的组合签名**。
有效性有正面证据：解掉全部地板后，13 档尺度 × 319 样本 = **4147 个观测点读数全为 0**
（没有假阳性地板）。已作为常驻哨兵落地。

## ⚠️ 已知未闭合（已记 backlog，本 PR 不含）

修复之后**仍有 4 个已提交样本（+ 40k 扫描里 14 个）产出开曲面**，而
`IsValidClosedFormPyramid`（`src/core/crystal.cpp`）**只检查 `present_cnt >= 4`，不查 Euler、
不查流形性** ⇒ 这类晶体过闸进仿真。原本的假设是「根因修好则不需要该闸」，**已被实测推翻**。
不在本 PR 顺手加闸的理由：PR #132–#137 一族的教训是**闸变严会误伤合法退化形状**，
须先回答「那些开曲面是几何真的该是开的，还是还有第三个容差没对齐」。

## 范围说明

- 与在飞的 GUI 测试重构分支**零文件重合**（已逐文件核对）。
- 改动全部在 host 侧几何生成，`ClosedFormPyramidResult` 布局未动，
  GPU 后端只 memcpy host accessor 的产出 ⇒ 三后端同修。CUDA/Metal 未本地实测。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
