### PR TITLE
fix(gui,core): 以 core 为参照收敛「静默替用户挑一个语义」的加载分支

### DIFF
--- a/src/config/crystal_config.cpp
+++ b/src/config/crystal_config.cpp
@@ -4,6 +4,8 @@
 #include <iterator>
 #include <nlohmann/json.hpp>
 #include <numeric>
+#include <stdexcept>
+#include <string>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -417,7 +419,10 @@ void from_json(const nlohmann::json& j, CrystalConfig& c) {
   } else if (j_type == "pyramid") {
     c.param_ = j.at("shape").get<PyramidCrystalParam>();
   } else {
-    LOG_ERROR("Unknown crystal type!");
+    // Rejecting rather than logging: with no type there is no shape to parse, so `param_` would
+    // keep its default-constructed prism — a crystal nobody wrote, entering the simulation while
+    // the error line scrolls past. The id is prepended by the caller in config_manager.cpp.
+    throw std::invalid_argument("unknown crystal type: " + j_type.dump() + ". Write either \"prism\" or \"pyramid\".");
   }
 
   if (j.contains("axis")) {

--- a/src/config/light_config.cpp
+++ b/src/config/light_config.cpp
@@ -1,6 +1,8 @@
 #include "config/light_config.hpp"
 
 #include <nlohmann/json.hpp>
+#include <stdexcept>
+#include <string>
 #include <variant>
 #include <vector>
 
@@ -51,7 +53,14 @@ void from_json(const nlohmann::json& j, LightSourceConfig& l) {
     }
     l.spectrum_ = std::move(wl_params);
   } else {
-    LOG_ERROR("Invalid spectrum format: expected string or array");
+    // Rejecting rather than logging: neither branch runs, so `spectrum_` keeps its
+    // default-constructed alternative — an EMPTY wavelength table, i.e. a light source that emits
+    // nothing. There is no neutral value to fall back on here, so there is nothing to degrade to.
+    // Unlike a crystal, a scene has exactly one light source, so no caller adds an id prefix and
+    // the field has to name itself.
+    throw std::invalid_argument("light_source.spectrum is neither a string nor an array: " + j_spectrum.dump() +
+                                ". Write either an illuminant name (e.g. \"D65\") or an array of "
+                                "{\"wavelength\": ..., \"weight\": ...} objects.");
   }
 
   const auto& j_type = j.at("type");

--- a/src/core/math.cpp
+++ b/src/core/math.cpp
@@ -14,7 +14,6 @@
 #include "core/lat_lut.hpp"
 #include "core/shared/lat_path_selection.hpp"
 #include "core/shared/pcg_shared.h"
-#include "util/logger.hpp"
 
 
 namespace lumice {
@@ -622,7 +621,13 @@ void from_json(const nlohmann::json& obj, Distribution& dist) {
       obj.at("std").get_to(dist.spread);
     }
   } else {
-    LOG_ERROR("Cannot recognize distribution!");
+    // Rejecting rather than logging: neither branch runs, so `dist` silently keeps whatever the
+    // caller handed in — the destination's default, not anything written in the document. Same
+    // honest boundary as the missing-"type" branch above: this function serves every distribution
+    // slot in the document and cannot name which one it is on.
+    throw std::invalid_argument("distribution value is neither a number nor an object: " + obj.dump() +
+                                ". Write either a bare number (e.g. 20) or an object naming the distribution "
+                                "(e.g. {\"type\": \"gauss\", \"mean\": 20, \"std\": 5}).");
   }
 }
 

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -86,6 +86,10 @@ PendingAction g_pending_action = PendingAction::kNone;
 bool g_show_save_modified_popup = false;
 PendingSaveKind g_pending_save_kind = PendingSaveKind::kNone;
 
+bool g_show_export_overwrite_confirm_popup = false;
+std::filesystem::path g_pending_export_json_path;
+std::string g_pending_export_json_content;
+
 float ComputeGridStep(float fov) {
   // FOV here is full-angle in degrees (matches RenderConfig::fov / ViewProjection::fov).
   // Aim: ~4–6 grid lines across the visible FOV; round to a "nice" step.
@@ -502,8 +506,46 @@ void DoExportConfigJson() {
     SetGuiWarning(warning);
     return;
   }
-  ExportConfigJson(path, json_str);
+  RequestConfigJsonExport(path, json_str);
+}
+
+void RequestConfigJsonExport(const std::filesystem::path& path, const std::string& json_str) {
+  if (path.empty()) {
+    return;
+  }
+  if (ConfigJsonExportNeedsOverwriteConfirm(path)) {
+    // Hold everything and ask. Nothing is written on this branch — the whole point is that the
+    // document already on disk survives until the user says otherwise.
+    g_pending_export_json_path = path;
+    g_pending_export_json_content = json_str;
+    g_show_export_overwrite_confirm_popup = true;
+    return;
+  }
+  if (!ExportConfigJson(path, json_str)) {
+    GUI_LOG_ERROR("[GUI] Export config JSON failed: {}", PathToU8(path));
+    return;
+  }
   GUI_LOG_INFO("[GUI] Export config JSON: {}", PathToU8(path));
+}
+
+void ConfirmPendingConfigJsonExport() {
+  if (g_pending_export_json_path.empty()) {
+    return;
+  }
+  const std::filesystem::path path = std::move(g_pending_export_json_path);
+  const std::string json_str = std::move(g_pending_export_json_content);
+  g_pending_export_json_path.clear();
+  g_pending_export_json_content.clear();
+  if (!ExportConfigJson(path, json_str)) {
+    GUI_LOG_ERROR("[GUI] Export config JSON failed: {}", PathToU8(path));
+    return;
+  }
+  GUI_LOG_INFO("[GUI] Export config JSON (overwrote existing file): {}", PathToU8(path));
+}
+
+void CancelPendingConfigJsonExport() {
+  g_pending_export_json_path.clear();
+  g_pending_export_json_content.clear();
 }
 
 // Helper: load image from path, downsample if needed, upload to bg texture.

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -671,7 +671,12 @@ void DoOpen(const std::filesystem::path& path) {
   std::vector<unsigned char> tex_data;
   int tex_w = 0;
   int tex_h = 0;
-  TakeShapeDistDowngradeCount();  // discard any stale count so only this load's downgrades are counted
+  // Discard any stale counts so only this load's downgrades are counted. Both channels need the
+  // drain, and the filter one needs it for a reason the shape one does not have: MakeNewDocumentState
+  // runs the user's personal defaults through the same deserializer, so a hand-edited defaults file
+  // can leave a count behind that belongs to no load at all.
+  TakeShapeDistDowngradeCount();
+  TakeFilterNoPredicateDowngradeCount();
   if (LoadLmcFile(path, g_state, tex_data, tex_w, tex_h)) {
     // Data restore + command-semantic fields (path/dirty/run_intent stay in handler).
     g_state.current_file_path = path;
@@ -702,6 +707,18 @@ void DoOpen(const std::filesystem::path& path) {
           "Some crystal shape distributions used non-uniform types (e.g. gauss, laplacian). The GUI "
           "edits uniform distributions only, so they were loaded as uniform. Edit the config file / "
           "CLI directly to keep other distribution types.");
+    }
+
+    // Notify: a filter object in the file described no rule a reader could use (an empty summands
+    // array, a legacy form with no raypath text, a filter type the GUI no longer has). The entry
+    // was loaded without a filter rather than with one that matches everything — under filter_out
+    // the latter hides every ray, and a black picture says nothing about why. Same one-time popup
+    // as the shape-distribution notice above; the two append rather than replace each other.
+    if (TakeFilterNoPredicateDowngradeCount() > 0) {
+      SetImportComplexFilterWarning(
+          "Some filters in this file described no rule (no ray paths and no entry/exit faces). They "
+          "were loaded as no filter at all, so the entries they belonged to now let every ray "
+          "through. Re-add the rule in the entry's Filter tab if the file was meant to carry one.");
     }
   }
 }

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -625,6 +625,15 @@ void ResetFrontendState(GuiState& state, FrontendResetReason reason, const Front
   }
 }
 
+// The GUI edits uniform shape distributions only. If a document carried non-uniform families
+// (gauss/laplacian/...) they were loaded as uniform (see ParseShapeDist). This is a deliberate
+// capability downgrade, surfaced once via the shared import-warning popup — from BOTH load
+// branches, which is why the sentence lives here instead of being spelled out twice.
+constexpr const char* kShapeDistDowngradeNotice =
+    "Some crystal shape distributions used non-uniform types (e.g. gauss, laplacian). The GUI "
+    "edits uniform distributions only, so they were loaded as uniform. Edit the config file / "
+    "CLI directly to keep other distribution types.";
+
 void DoOpen() {
   DoOpen(ShowOpenDialog());
 }
@@ -651,6 +660,11 @@ void DoOpen(const std::filesystem::path& path) {
     // left in place, this read's counts would surface on the next New and describe THAT load.
     TakeUserDefaultsDowngradeCount();
     TakeUserDefaultsDowngradeNotices();
+    // Same pre-load drain the .lmc branch does below, for the same reason: MakeNewDocumentState
+    // just ran the user's personal defaults through this very deserializer, so a hand-edited
+    // defaults file can leave a count behind that belongs to no load at all. Without it, the
+    // post-load take further down would report that count as this document's downgrade.
+    TakeShapeDistDowngradeCount();
     if (DeserializeFromJson(json_str, new_state)) {
       // Data restore + command-semantic fields (path/dirty/run_intent stay in handler per
       // plan §2 — they are command intent, not frontend reset).
@@ -663,6 +677,14 @@ void DoOpen(const std::filesystem::path& path) {
       ResetFrontendState(g_state, FrontendResetReason::kOpenJson);
       LoadBackgroundWithDegrade(g_state);
       GUI_LOG_INFO("[GUI] DoOpen (JSON import): {}", PathToU8(path));
+
+      // Same notice the .lmc branch raises below, and it belongs here even more than there: a core
+      // JSON is exactly the document that carries the distribution families the GUI cannot edit
+      // (gauss/laplacian/...), and until this call the downgrade happened with nothing said. The
+      // wording is shared with that branch — one downgrade, one sentence, wherever it is read from.
+      if (TakeShapeDistDowngradeCount() > 0) {
+        SetImportComplexFilterWarning(kShapeDistDowngradeNotice);
+      }
     }
     return;
   }
@@ -699,14 +721,9 @@ void DoOpen(const std::filesystem::path& path) {
     // already ClearBackground()'d, so a missing bg_path leaves the preview blank (as before).
     LoadBackgroundWithDegrade(g_state);
 
-    // Notify: the GUI edits uniform shape distributions only. If the file carried non-uniform
-    // families (gauss/laplacian/...) they were loaded as uniform (see ParseShapeDist). This is a
-    // deliberate capability downgrade, surfaced once via the shared import-warning popup.
+    // Notify: same downgrade, same sentence as the JSON-import branch above (kShapeDistDowngradeNotice).
     if (TakeShapeDistDowngradeCount() > 0) {
-      SetImportComplexFilterWarning(
-          "Some crystal shape distributions used non-uniform types (e.g. gauss, laplacian). The GUI "
-          "edits uniform distributions only, so they were loaded as uniform. Edit the config file / "
-          "CLI directly to keep other distribution types.");
+      SetImportComplexFilterWarning(kShapeDistDowngradeNotice);
     }
 
     // Notify: a filter object in the file described no rule a reader could use (an empty summands

--- a/src/gui/app.hpp
+++ b/src/gui/app.hpp
@@ -408,6 +408,17 @@ void RenderUnsavedPopup(GLFWwindow* window);
 // a fresh render matching the current config, then re-invoke Save.
 void RenderSaveModifiedPopup(GLFWwindow* window);
 void RenderImportWarningPopup();
+// What that modal has to say, and why it is not a generic "file exists, overwrite?": the file being
+// replaced may be a core config the GUI merely read, and what goes back is the GUI's own re-emission
+// of it — everything the GUI cannot express is gone from the copy on disk. "Overwrite?" asks about a
+// filename; the user has to be asked about the content.
+//
+// Named and declared here rather than written inline at the ImGui call so the wording is one thing
+// that can be asserted (ConfigJsonExportContractChain.TheOverwritePromptSaysWhatIsLost). That test
+// pins the sentence; the gui_test case pins that the modal renders at all. What neither can state is
+// the join — the renderer's single use of this constant is what makes it one proposition.
+extern const char* const kExportOverwriteWarningText;
+
 // Opens iff g_show_export_overwrite_confirm_popup is true. Must be called every frame, outside any
 // Begin/End block, like the other Render*Popup above it — an export that raised the prompt and
 // found nobody rendering it would sit pending forever, which is the same as losing the command.

--- a/src/gui/app.hpp
+++ b/src/gui/app.hpp
@@ -86,6 +86,15 @@ extern PendingAction g_pending_action;
 extern bool g_show_save_modified_popup;
 extern PendingSaveKind g_pending_save_kind;
 
+// Export-config-JSON overwrite prompt state. Set by RequestConfigJsonExport when the target
+// already exists; consumed by RenderExportOverwriteConfirmPopup, which resolves it through
+// ConfirmPendingConfigJsonExport / CancelPendingConfigJsonExport. The JSON is built BEFORE the
+// prompt (it is what the user asked to export) and held here until they answer, so the document
+// they confirm is the one that gets written even if the state changes underneath.
+extern bool g_show_export_overwrite_confirm_popup;
+extern std::filesystem::path g_pending_export_json_path;
+extern std::string g_pending_export_json_content;
+
 // Queue a user-visible warning surfaced by RenderImportWarningPopup; consecutive
 // calls within one import concatenate so all offending filters are reported.
 void SetImportComplexFilterWarning(const std::string& msg);
@@ -155,6 +164,21 @@ void DoExportPreviewPng();
 void DoExportDualFisheyeEqualAreaPng();
 void DoExportEquirectangularPng();
 void DoExportConfigJson();
+
+// The half of DoExportConfigJson that is not the file dialog: write `json_str` to `path`, OR — when
+// something is already at `path` (ConfigJsonExportNeedsOverwriteConfirm) — hold both in the pending
+// slots above and raise the confirmation prompt instead. Exporting is the one way the GUI can write
+// over a document it did not author, and what it writes is only what the GUI can express, so that
+// write is an explicit act rather than a side effect of picking a filename.
+//
+// Split out from the dialog wrapper so the decision is testable without NFD (the same shape as
+// BuildExportJsonOrWarn). Does nothing on an empty path.
+void RequestConfigJsonExport(const std::filesystem::path& path, const std::string& json_str);
+
+// Resolve a pending export. Confirm writes the held JSON to the held path; Cancel drops both. Both
+// clear the pending slots, and both are no-ops when nothing is pending.
+void ConfirmPendingConfigJsonExport();
+void CancelPendingConfigJsonExport();
 void DoOpen();
 void DoOpen(const std::filesystem::path& path);
 void DoNew();
@@ -384,6 +408,10 @@ void RenderUnsavedPopup(GLFWwindow* window);
 // a fresh render matching the current config, then re-invoke Save.
 void RenderSaveModifiedPopup(GLFWwindow* window);
 void RenderImportWarningPopup();
+// Opens iff g_show_export_overwrite_confirm_popup is true. Must be called every frame, outside any
+// Begin/End block, like the other Render*Popup above it — an export that raised the prompt and
+// found nobody rendering it would sit pending forever, which is the same as losing the command.
+void RenderExportOverwriteConfirmPopup();
 // Generic GUI warning modal (see app_panels.cpp). SetGuiWarning queues a message (idempotent
 // while the same message is in-flight, so a persistent condition re-detected every debounced
 // commit does not re-spam the modal). ClearGuiWarning re-arms it (called on a successful

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -1351,15 +1351,16 @@ void RenderImportWarningPopup() {
   }
 }
 
+// See app.hpp for why this sentence is a named constant and what is asserted about it.
+const char* const kExportOverwriteWarningText =
+    "Exporting replaces it with what the GUI can express, so anything in it the GUI\n"
+    "cannot represent will be lost. Save as .lmc instead to keep this project\n"
+    "without touching that file.";
+
 // Export config JSON, onto a path that already holds a file. Same modal idiom as
 // RenderSaveModifiedPopup above (BeginPopupModal + explicit buttons, so Escape and click-outside
 // cannot dismiss it — see the note there for why that holds for every modal in this app), because
 // the same thing is being protected: a write the user cannot undo.
-//
-// What the wording has to say, and why it is not a generic "file exists, overwrite?": the file
-// being replaced may be a core config the GUI merely read, and what goes back is the GUI's own
-// re-emission of it — everything the GUI cannot express is gone from the copy on disk. "Overwrite?"
-// asks about a filename; the user needs to be asked about the content.
 void RenderExportOverwriteConfirmPopup() {
   if (g_show_export_overwrite_confirm_popup) {
     ImGui::OpenPopup("Overwrite Config File");
@@ -1370,9 +1371,7 @@ void RenderExportOverwriteConfirmPopup() {
     ImGui::TextUnformatted("A file already exists at:");
     ImGui::TextUnformatted(PathToU8(g_pending_export_json_path).c_str());
     ImGui::Separator();
-    ImGui::TextUnformatted("Exporting replaces it with what the GUI can express, so anything in it");
-    ImGui::TextUnformatted("the GUI cannot represent will be lost. Save as .lmc instead to keep");
-    ImGui::TextUnformatted("this project without touching that file.");
+    ImGui::TextUnformatted(kExportOverwriteWarningText);
     ImGui::Separator();
 
     if (ImGui::Button("Overwrite", ImVec2(120, 0))) {

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -23,6 +23,7 @@
 #include "gui/sim_state_rules.hpp"
 #include "gui/sun_circle_rules.hpp"
 #include "imgui.h"
+#include "util/path_utils.hpp"  // PathToU8 — the pending export path is shown in the overwrite prompt
 
 // =============================================================================
 // GUI window z-order convention (task-gui-window-zorder, scrum-gui-polish-v12)
@@ -1346,6 +1347,44 @@ void RenderImportWarningPopup() {
       active_msg.clear();
       ImGui::CloseCurrentPopup();
     }
+    ImGui::EndPopup();
+  }
+}
+
+// Export config JSON, onto a path that already holds a file. Same modal idiom as
+// RenderSaveModifiedPopup above (BeginPopupModal + explicit buttons, so Escape and click-outside
+// cannot dismiss it — see the note there for why that holds for every modal in this app), because
+// the same thing is being protected: a write the user cannot undo.
+//
+// What the wording has to say, and why it is not a generic "file exists, overwrite?": the file
+// being replaced may be a core config the GUI merely read, and what goes back is the GUI's own
+// re-emission of it — everything the GUI cannot express is gone from the copy on disk. "Overwrite?"
+// asks about a filename; the user needs to be asked about the content.
+void RenderExportOverwriteConfirmPopup() {
+  if (g_show_export_overwrite_confirm_popup) {
+    ImGui::OpenPopup("Overwrite Config File");
+    g_show_export_overwrite_confirm_popup = false;
+  }
+
+  if (ImGui::BeginPopupModal("Overwrite Config File", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+    ImGui::TextUnformatted("A file already exists at:");
+    ImGui::TextUnformatted(PathToU8(g_pending_export_json_path).c_str());
+    ImGui::Separator();
+    ImGui::TextUnformatted("Exporting replaces it with what the GUI can express, so anything in it");
+    ImGui::TextUnformatted("the GUI cannot represent will be lost. Save as .lmc instead to keep");
+    ImGui::TextUnformatted("this project without touching that file.");
+    ImGui::Separator();
+
+    if (ImGui::Button("Overwrite", ImVec2(120, 0))) {
+      ConfirmPendingConfigJsonExport();
+      ImGui::CloseCurrentPopup();
+    }
+    ImGui::SameLine();
+    if (ImGui::Button("Cancel", ImVec2(80, 0))) {
+      CancelPendingConfigJsonExport();
+      ImGui::CloseCurrentPopup();
+    }
+
     ImGui::EndPopup();
   }
 }

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -418,9 +418,13 @@ void OpenEditModal(const EditRequest& req, GuiState& state) {
   g_axis_buf[2] = src_crystal.roll;
   // Filter buffers (H5 sum-of-products): top-level shared fields (name / action
   // / sym_*) go into g_filter_top; per-row SoP text goes into g_summand_rows,
-  // keyed by stable uid. Default-constructed FilterConfig carries a 1-row empty
-  // SoP so "no filter" opens with exactly one blank row (matches the pre-task
-  // "empty raypath ≡ no filter" UX).
+  // keyed by stable uid. A default-constructed FilterConfig states nothing — its
+  // SoP is empty. The "no filter" case still opens with exactly one blank row,
+  // but that row comes from SetRowsFromSop, which supplies one for an empty SoP:
+  // the blank row is an editor affordance, not the model's default value. The
+  // two were the same object back when the default was a 1-row empty-raypath
+  // SoP, and reading them as one is how that shape came to be constructed in
+  // places that meant "no filter" and got a match-all.
   const FilterConfig src = entry.filter_id.has_value() ? state.filters[*entry.filter_id] : FilterConfig{};
   g_filter_top = FilterConfig{};
   g_filter_top.name = src.name;

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -2154,6 +2154,17 @@ bool DeserializeFromJson(const std::string& json_str, GuiState& state) {
           state.sun.custom_spectrum = ParseWlWeightArray(sp);
           state.sun.spectrum_index = state.sun.custom_spectrum.empty() ? 2 /* D65 */ : kCustomSpectrumIndex;
         }
+      } else {
+        // `spectrum` discriminates how the rest of this reads (a string names a built-in, an array
+        // is a discrete custom one), and no spectrum is the neutral one — D65 is a specific choice.
+        // light_source is a singleton, so there is no unit to drop and nothing downstream to fall
+        // back to: what changes here is that the choice is stated instead of made in silence.
+        // state.sun already holds SunConfig{}'s default from the `state = GuiState{}` above.
+        const std::string msg = std::string("scene.light_source states no \"spectrum\"; loaded as ") +
+                                kSpectrumNames[SunConfig{}.spectrum_index] +
+                                " (core rejects this document outright, since it requires it).";
+        GUI_LOG_WARNING("[FileIO] DeserializeFromJson: {}", msg);
+        SetImportComplexFilterWarning(msg);
       }
     }
 
@@ -2379,8 +2390,22 @@ bool DeserializeFromJson(const std::string& json_str, GuiState& state) {
     RenderConfig r;
 
     if (jr.contains("lens")) {
-      r.lens_type = LensTypeFromString(jr["lens"].value("type", kLensTypeJsonNames[RenderConfig{}.lens_type]));
-      r.fov = jr["lens"].value("fov", RenderConfig{}.fov);
+      const auto& jlens = jr["lens"];
+      if (jlens.contains("type")) {
+        r.lens_type = LensTypeFromString(jlens.at("type").get<std::string>());
+      } else {
+        // Same shape as light_source.spectrum above: `type` selects the whole projection branch the
+        // preview inverts, `linear` is one specific projection rather than the absence of one, and a
+        // single renderer means there is no unit to drop. `fov` beside it is genuinely optional to
+        // core, so its absence is a document saying nothing rather than a malformed one.
+        r.lens_type = RenderConfig{}.lens_type;
+        const std::string msg = std::string("render[0].lens states no \"type\"; loaded as ") +
+                                kLensTypeJsonNames[RenderConfig{}.lens_type] +
+                                " (core rejects this document outright, since it requires it).";
+        GUI_LOG_WARNING("[FileIO] DeserializeFromJson: {}", msg);
+        SetImportComplexFilterWarning(msg);
+      }
+      r.fov = jlens.value("fov", RenderConfig{}.fov);
     }
 
     if (jr.contains("resolution") && jr["resolution"].is_array() && jr["resolution"].size() == 2) {

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <map>
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <sstream>
 #include <utility>
 #include <vector>
@@ -747,13 +748,30 @@ static AxisDist ParseAxisDist(const json& j, const std::string& crystal_label, c
 
 // `crystal_label` names this crystal in any import warning raised while parsing it — "crystal
 // id=3" where the document numbers its crystals, or a positional stand-in where it does not.
-static CrystalConfig ParseCrystal(const json& j, const std::string& crystal_label) {
+//
+// nullopt = this crystal states no `type`, so there is no crystal here to load. `type` is the
+// discriminant for everything below it: it decides whether `shape` is read as a prism's keys or a
+// pyramid's, and neither of the two is the neutral answer. Core rejects such a document outright
+// (`.at("type")`); the GUI is an editor and loads the rest of the document, minus this crystal.
+static std::optional<CrystalConfig> ParseCrystal(const json& j, const std::string& crystal_label) {
   CrystalConfig c;
   c.name = j.value("name", CrystalConfig{}.name);
 
-  // Only "pyramid" selects the non-default arm; an absent (or unrecognised) `type` lands on
-  // CrystalConfig's own default rather than on a literal that could drift away from it.
-  const auto type_str = j.value("type", std::string{});
+  if (!j.contains("type")) {
+    const std::string msg = crystal_label +
+                            " states no \"type\"; the crystal is dropped rather than "
+                            "loaded as a prism (core rejects this document outright, "
+                            "since \"type\" decides how the rest of the crystal reads).";
+    GUI_LOG_WARNING("[FileIO] ParseCrystal: {}", msg);
+    SetImportComplexFilterWarning(msg);
+    return std::nullopt;
+  }
+
+  // Only "pyramid" selects the non-default arm; an unrecognised `type` lands on CrystalConfig's own
+  // default rather than on a literal that could drift away from it. That is a present-but-unknown
+  // VALUE, which core answers the same way (it logs and carries on) — a different case from the
+  // absent key refused above.
+  const auto type_str = j.at("type").get<std::string>();
   c.type = (type_str == "pyramid") ? CrystalType::kPyramid : CrystalConfig{}.type;
   const LUMICE_CrystalKind kind = (c.type == CrystalType::kPrism) ? LUMICE_CRYSTAL_PRISM : LUMICE_CRYSTAL_PYRAMID;
 
@@ -836,6 +854,33 @@ static CrystalConfig ParseCrystal(const json& j, const std::string& crystal_labe
   }
 
   return c;
+}
+
+// The one place a document's crystal array becomes an id-keyed map. Both wire formats that carry
+// such an array (the core config JSON and the legacy pool-shaped .lmc) go through here, because the
+// `id` refusal below is a property of the map, not of either format — and the two loops used to hold
+// a verbatim copy of it each, which is how one of them would get fixed and the other left behind.
+//
+// `id` is refused rather than defaulted because it is the map's KEY: an absent one is not a guessed
+// value but a collision. Two crystals that both omit it both land on key 0, where the second
+// destroys the first — a crystal the document did state, gone, with a Save-As able to freeze the
+// loss. No integer is the neutral "unspecified" (0 is a legal id in its own right), so there is
+// nothing to fall back to. Core rejects the document outright (`.at("id")`).
+static void ParseCrystalIntoMap(const json& jc, std::map<int, CrystalConfig>& crystal_map) {
+  if (!jc.contains("id")) {
+    const std::string msg =
+        "A crystal states no \"id\"; it is dropped rather than filed under a "
+        "guessed one (core rejects this document outright, and the id is what "
+        "the scattering entries reference).";
+    GUI_LOG_WARNING("[FileIO] ParseCrystalIntoMap: {}", msg);
+    SetImportComplexFilterWarning(msg);
+    return;
+  }
+  const int id = jc.at("id").get<int>();
+  // ParseCrystal reports its own refusal, so nullopt is simply not filed.
+  if (std::optional<CrystalConfig> c = ParseCrystal(jc, "crystal id=" + std::to_string(id))) {
+    crystal_map[id] = *std::move(c);
+  }
 }
 
 static int LensTypeFromString(const std::string& s) {
@@ -1953,8 +1998,7 @@ bool DeserializeFromJson(const std::string& json_str, GuiState& state) {
   std::map<int, CrystalConfig> crystal_map;
   if (root.contains("crystal") && root["crystal"].is_array()) {
     for (auto& jc : root["crystal"]) {
-      int id = jc.value("id", 0);
-      crystal_map[id] = ParseCrystal(jc, "crystal id=" + std::to_string(id));
+      ParseCrystalIntoMap(jc, crystal_map);
     }
   }
 
@@ -2484,16 +2528,19 @@ bool DeserializeGuiStateJson(const std::string& json_str, GuiState& state) {
       if (jl.contains("entries") && jl["entries"].is_array()) {
         for (auto& je : jl["entries"]) {
           EntryCard entry;
+          // The GUI-native form inlines each crystal in its entry and carries no id, so the warning
+          // names it by where it sits instead. A refused crystal (no `type`) lands in the same place
+          // an entry with no inline crystal at all does: a default pool slot, so entry.crystal_id
+          // stays valid. The document said nothing usable about this crystal either way.
+          entry.crystal_id = static_cast<int>(state.crystals.size());
+          std::optional<CrystalConfig> inline_crystal;
           if (je.contains("crystal")) {
-            entry.crystal_id = static_cast<int>(state.crystals.size());
-            // The GUI-native form inlines each crystal in its entry and carries no id, so the
-            // warning names it by where it sits instead.
-            state.crystals.push_back(ParseCrystal(je["crystal"], "layer " + std::to_string(state.layers.size()) +
-                                                                     " entry " + std::to_string(layer.entries.size()) +
-                                                                     "'s crystal"));
+            inline_crystal = ParseCrystal(je["crystal"], "layer " + std::to_string(state.layers.size()) + " entry " +
+                                                             std::to_string(layer.entries.size()) + "'s crystal");
+          }
+          if (inline_crystal) {
+            state.crystals.push_back(*std::move(inline_crystal));
           } else {
-            // No inline crystal — provide a default slot so entry stays valid.
-            entry.crystal_id = static_cast<int>(state.crystals.size());
             state.crystals.emplace_back();
           }
           entry.proportion = je.value("proportion", EntryCard{}.proportion);
@@ -2518,8 +2565,7 @@ bool DeserializeGuiStateJson(const std::string& json_str, GuiState& state) {
     std::map<int, CrystalConfig> crystal_map;
     if (root["crystals"].is_array()) {
       for (auto& jc : root["crystals"]) {
-        int id = jc.value("id", 0);
-        crystal_map[id] = ParseCrystal(jc, "crystal id=" + std::to_string(id));
+        ParseCrystalIntoMap(jc, crystal_map);
       }
     }
     std::map<int, FilterConfig> filter_map;

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -2289,11 +2289,22 @@ bool DeserializeFromJson(const std::string& json_str, GuiState& state) {
             if (!jc.is_object()) {
               continue;
             }
+            // No colour is the neutral one — black and white both read as deliberate choices in a
+            // composite, and a class whose colour is undefined has no rendering meaning at all — so
+            // the class goes rather than getting one assigned. Core rejects the document outright
+            // (`j.at("color")`). Dropping the whole class, not just the field, is the same move the
+            // block above already makes for a filter and for a colour ref it cannot express.
+            if (!jc.contains("color") || !jc["color"].is_array() || jc["color"].size() != 3) {
+              const std::string msg = "raypath_color class " + std::to_string(ci) +
+                                      " states no usable \"color\" (three numbers); the class is dropped rather "
+                                      "than given one nobody chose (core rejects this document outright).";
+              GUI_LOG_WARNING("[FileIO] DeserializeFromJson: {}", msg);
+              SetImportComplexFilterWarning(msg);
+              continue;
+            }
             ColorClassConfig cls;
-            if (jc.contains("color") && jc["color"].is_array() && jc["color"].size() == 3) {
-              for (int k = 0; k < 3; k++) {
-                cls.color[k] = jc["color"][k].get<float>();
-              }
+            for (int k = 0; k < 3; k++) {
+              cls.color[k] = jc["color"][k].get<float>();
             }
             if (jc.contains("combine") && jc["combine"].is_string() && jc["combine"].get<std::string>() == "all") {
               cls.combine = LUMICE_COLOR_COMBINE_ALL;
@@ -2302,7 +2313,12 @@ bool DeserializeFromJson(const std::string& json_str, GuiState& state) {
             }
             cls.visible = jc.value("visible", ColorClassConfig{}.visible);
             cls.solo = jc.value("solo", ColorClassConfig{}.solo);
-            cls.z_order = static_cast<int>(ci);
+            // The DESTINATION's current length, not the source index `ci`: z_order has to be a
+            // compact permutation of [0, size) over the vector that actually holds the classes
+            // (CompactZOrder exists to repair holes), and the two counters part company the moment a
+            // class is dropped above. Where nothing is dropped they advance together, so this is the
+            // same number the source index used to give.
+            cls.z_order = static_cast<int>(state.raypath_color.size());
             if (jc.contains("match") && jc["match"].is_array()) {
               for (const auto& jr : jc["match"]) {
                 if (!jr.is_object()) {

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -2919,6 +2919,18 @@ bool ExportConfigJson(const std::filesystem::path& path, const std::string& json
   return out.good();
 }
 
+bool ConfigJsonExportNeedsOverwriteConfirm(const std::filesystem::path& path) {
+  if (path.empty()) {
+    return false;  // nothing to overwrite; ExportConfigJson refuses this path anyway
+  }
+  std::error_code ec;
+  // The non-throwing overload: an unreadable parent directory must not take the app down, and
+  // "cannot tell" is answered as "nothing there" — the export that follows fails on its own and
+  // reports that, which is a better outcome than a confirmation prompt for a write that cannot
+  // happen.
+  return std::filesystem::is_regular_file(path, ec);
+}
+
 // ========== File Dialogs ==========
 
 std::filesystem::path ShowOpenDialog() {

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -693,7 +693,18 @@ int TakeShapeDistDowngradeCount() {
 // simplified editor), surfaced via a load-complete notice — NOT a silent loss (contrast the earlier
 // bug where loading collapsed a distribution to its bare mean and dropped type/std with no notice).
 // NO_RANDOM (off) and UNIFORM pass through unchanged. Downgrades bump g_shape_dist_downgrade_count.
-static ShapeDist ParseShapeDist(const json& j, float default_center) {
+//
+// `crystal_label` / `slot_key` say WHICH slot of WHICH crystal a warning is about, same as
+// ParseAxisDist's — and for the same reason, since core states `type`'s requirement once for both
+// halves and only the axis half used to report it.
+//
+// `enforce_type_field` == false holds one slot out of that report: a `type`-less object still lands
+// on the same value, silently. It exists for `prism_h`, whose requiredness core has not settled —
+// changing what the GUI makes of it before core does would move a value from underneath the answer
+// core is about to give. Re-evaluate whether this parameter is still needed once core states
+// whether `prism_h` is optional.
+static ShapeDist ParseShapeDist(const json& j, float default_center, const std::string& crystal_label,
+                                const char* slot_key, bool enforce_type_field = true) {
   ShapeDist d;
   d.center = default_center;
   if (j.is_number()) {
@@ -701,7 +712,17 @@ static ShapeDist ParseShapeDist(const json& j, float default_center) {
     d.center = j.get<float>();
     d.spread = 0.0f;
   } else if (j.is_object()) {
-    d.type = ParseShapeDistType(j.value("type", ShapeDistTypeToString(ShapeDist{}.type)));
+    if (enforce_type_field && !j.contains("type")) {
+      d.type = ShapeDist{}.type;
+      const std::string msg = crystal_label + " shape." + slot_key +
+                              " is written as an object with no \"type\"; loaded as " +
+                              ShapeDistTypeToString(ShapeDist{}.type) +
+                              " (core rejects this document outright, since Distribution requires \"type\").";
+      GUI_LOG_WARNING("[FileIO] ParseShapeDist: {}", msg);
+      SetImportComplexFilterWarning(msg);
+    } else {
+      d.type = ParseShapeDistType(j.value("type", ShapeDistTypeToString(ShapeDist{}.type)));
+    }
     d.center = j.value("mean", default_center);
     d.spread = j.value("std", ShapeDist{}.spread);
   }
@@ -780,7 +801,7 @@ static std::optional<CrystalConfig> ParseCrystal(const json& j, const std::strin
     if (c.type == CrystalType::kPrism) {
       const char* height_key = LUMICE_ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_HEIGHT);
       if (s.contains(height_key)) {
-        c.height = ParseShapeDist(s[height_key], CrystalConfig{}.height.center);
+        c.height = ParseShapeDist(s[height_key], CrystalConfig{}.height.center, crystal_label, height_key);
       }
     } else {
       // prism_h takes CrystalConfig's own default when absent. upper_h/lower_h deliberately do
@@ -789,10 +810,17 @@ static std::optional<CrystalConfig> ParseCrystal(const json& j, const std::strin
       const char* prism_h_key = LUMICE_ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_PRISM_H);
       const char* upper_h_key = LUMICE_ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_UPPER_H);
       const char* lower_h_key = LUMICE_ShapeScalarSyncKeyName(kind, LUMICE_SHAPE_SCALAR_LOWER_H);
-      c.prism_h = s.contains(prism_h_key) ? ParseShapeDist(s[prism_h_key], CrystalConfig{}.prism_h.center) :
-                                            CrystalConfig{}.prism_h;
-      c.upper_h = s.contains(upper_h_key) ? ParseShapeDist(s[upper_h_key], 0.0f) : ShapeDist(0.0f);
-      c.lower_h = s.contains(lower_h_key) ? ParseShapeDist(s[lower_h_key], 0.0f) : ShapeDist(0.0f);
+      // prism_h alone passes enforce_type_field=false: it is the one slot held out of the
+      // missing-`type` report, because core has not yet settled whether it requires the field at
+      // all. See ParseShapeDist's own comment.
+      c.prism_h = s.contains(prism_h_key) ?
+                      ParseShapeDist(s[prism_h_key], CrystalConfig{}.prism_h.center, crystal_label, prism_h_key,
+                                     /*enforce_type_field=*/false) :
+                      CrystalConfig{}.prism_h;
+      c.upper_h =
+          s.contains(upper_h_key) ? ParseShapeDist(s[upper_h_key], 0.0f, crystal_label, upper_h_key) : ShapeDist(0.0f);
+      c.lower_h =
+          s.contains(lower_h_key) ? ParseShapeDist(s[lower_h_key], 0.0f, crystal_label, lower_h_key) : ShapeDist(0.0f);
       // Wedge angle: prefer the explicit angle, fallback to the Miller-index conversion
       for (int upper = 1; upper >= 0; upper--) {
         float& alpha = upper ? c.upper_alpha : c.lower_alpha;
@@ -810,7 +838,11 @@ static std::optional<CrystalConfig> ParseCrystal(const json& j, const std::strin
     if (s.contains(fd_key) && s[fd_key].is_array()) {
       size_t n = std::min(s[fd_key].size(), static_cast<size_t>(6));
       for (size_t i = 0; i < n; i++) {
-        c.face_distance[i] = ParseShapeDist(s[fd_key][i], CrystalConfig{}.face_distance[i].center);
+        // Six slots share one key, so the index goes in the slot name: "which face" is the part a
+        // reader needs and the array key alone does not say.
+        const std::string fd_slot = std::string(fd_key) + "[" + std::to_string(i) + "]";
+        c.face_distance[i] =
+            ParseShapeDist(s[fd_key][i], CrystalConfig{}.face_distance[i].center, crystal_label, fd_slot.c_str());
       }
     }
     // shape.sync_group: read into the wire form's parallel array, then scatter back into each

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -945,7 +945,43 @@ static RenderConfig ParseRendererFromGuiJson(const json& jr) {
 //     canonical FromLegacyRaypath / FromLegacyEntryExit converters (';' fan-out
 //     for raypath, single EE row otherwise).
 
-static FilterConfig ParseFilterFromGuiJson(const json& jf) {
+// Count of filters dropped on load because the file described no predicate for them (see
+// NoFilterIfNoPredicate). Consumed + reset by TakeFilterNoPredicateDowngradeCount(), the same shape
+// as g_shape_dist_downgrade_count above and for the same reason: GUI file loading is single-
+// threaded, so a TU-local counter beats threading an accumulator through every parse call site.
+static int g_filter_no_predicate_downgrade_count = 0;
+
+int TakeFilterNoPredicateDowngradeCount() {
+  int n = g_filter_no_predicate_downgrade_count;
+  g_filter_no_predicate_downgrade_count = 0;
+  return n;
+}
+
+// The single disposition point for "the file's filter object states no predicate".
+//
+// Both readers below can end there — a v3 `summands` array that yields no rows, and a legacy form
+// whose `raypath_text` is absent or empty (including an unknown/removed `type` that falls through
+// to the raypath arm). Both used to answer it by writing a 1-row / 1-factor SoP holding an empty
+// RaypathParams. That shape is NOT "no filter": a row carrying a factor whose text is empty is the
+// editor's match-all and commits as core's `none`, so under filter_out the entry excluded every ray
+// and the render was black, with nothing on screen saying why. Under filter_in it admitted
+// everything, so the same shape was harmless there — the harm is asymmetric in `action`, while
+// having no filter at all is harmless under both.
+//
+// Removing the predicate rather than picking a value for it is the disposition the load-degrade
+// contract settled on for a filter the GUI's own format left underspecified. Returning
+// std::nullopt rather than an empty-param FilterConfig is what keeps it from having to be
+// re-decided at each call site: there is no "forgot to check" spelling of the caller.
+static std::optional<FilterConfig> NoFilterIfNoPredicate(FilterConfig f) {
+  if (f.param.empty()) {
+    ++g_filter_no_predicate_downgrade_count;
+    GUI_LOG_WARNING("[FileIO] Filter '{}' describes no rule; loading the entry without a filter.", f.name);
+    return std::nullopt;
+  }
+  return f;
+}
+
+static std::optional<FilterConfig> ParseFilterFromGuiJson(const json& jf) {
   FilterConfig f;
   f.name = jf.value("name", FilterConfig{}.name);
   auto action_str = jf.value("action", FilterActionToString(FilterConfig{}.action));
@@ -968,13 +1004,11 @@ static FilterConfig ParseFilterFromGuiJson(const json& jf) {
       std::string text = js.get<std::string>();
       sop.push_back(SummandText{ text, ParseSummandText(text) });
     }
-    if (sop.empty()) {
-      // Defensive: an empty summands array is not a valid state — fall back to
-      // the default 1-row / 1-factor empty-raypath SoP.
-      sop.push_back(SummandText{ std::string{}, std::vector<Factor>{ Factor{ RaypathParams{} } } });
-    }
+    // An empty summands array is not a valid state, and the disposition is the one at the bottom
+    // of this function: no predicate means no filter. It used to be backfilled here with a 1-row /
+    // 1-factor empty-raypath SoP, which is the editor's match-all — see the return below.
     f.param = std::move(sop);
-    return f;
+    return NoFilterIfNoPredicate(std::move(f));
   }
 
   // Legacy type-discriminated form → upgrade to SoP.
@@ -1020,7 +1054,7 @@ static FilterConfig ParseFilterFromGuiJson(const json& jf) {
     // FromLegacyRaypath splits ';' multi-segment sugar into canonical OR rows.
     f.param = FromLegacyRaypath(RaypathParams{ jf.value("raypath_text", RaypathParams{}.raypath_text) });
   }
-  return f;
+  return NoFilterIfNoPredicate(std::move(f));
 }
 
 
@@ -2464,8 +2498,13 @@ bool DeserializeGuiStateJson(const std::string& json_str, GuiState& state) {
           }
           entry.proportion = je.value("proportion", EntryCard{}.proportion);
           if (je.contains("filter") && !je["filter"].is_null()) {
-            entry.filter_id = static_cast<int>(state.filters.size());
-            state.filters.push_back(ParseFilterFromGuiJson(je["filter"]));
+            // nullopt = the file's filter object stated no predicate, so the entry gets no filter
+            // and nothing enters the pool (NoFilterIfNoPredicate). Same end state as an entry whose
+            // file carried no "filter" key at all, which is what the document actually says.
+            if (std::optional<FilterConfig> fc = ParseFilterFromGuiJson(je["filter"])) {
+              entry.filter_id = static_cast<int>(state.filters.size());
+              state.filters.push_back(*std::move(fc));
+            }
           }
           layer.entries.push_back(entry);
         }
@@ -2487,7 +2526,12 @@ bool DeserializeGuiStateJson(const std::string& json_str, GuiState& state) {
     if (root.contains("filters") && root["filters"].is_array()) {
       for (auto& jf : root["filters"]) {
         int id = jf.value("id", 0);
-        filter_map[id] = ParseFilterFromGuiJson(jf);
+        // A pool filter that states no predicate is simply not put in the map: the consuming
+        // entries below look it up by `filter_map.count(filter_id)` and leave their filter_id unset
+        // when it is absent, so they land in the same "no filter" state the v2 arm above produces.
+        if (std::optional<FilterConfig> fc = ParseFilterFromGuiJson(jf)) {
+          filter_map[id] = *std::move(fc);
+        }
       }
     }
     if (root["scattering"].is_array()) {

--- a/src/gui/file_io.hpp
+++ b/src/gui/file_io.hpp
@@ -149,6 +149,15 @@ bool LoadLmcFile(const std::filesystem::path& path, GuiState& state, std::vector
 // "some distributions were simplified" notice. Call once before a load to discard any stale count.
 int TakeShapeDistDowngradeCount();
 
+// Returns the number of filters dropped since the last call because the file described no rule for
+// them, and resets the counter. A `.lmc` filter object that yields no predicate (an empty
+// `summands` array, a legacy form with no raypath text, a filter type the GUI no longer has) loads
+// as no filter at all rather than as one that happens to match everything — under filter_out the
+// latter excludes every ray. Same shape and same call discipline as TakeShapeDistDowngradeCount():
+// call once before a load to discard any stale count, and again after it to decide whether to show
+// the notice.
+int TakeFilterNoPredicateDowngradeCount();
+
 // Export preview as PNG (renders via FBO, must be called on GL thread).
 // Thin wrapper over RenderExportToRgba + WriteRgbaBufferToPng.
 bool ExportPreviewPng(const std::filesystem::path& path, PreviewRenderer& renderer, const PreviewViewport& vp);

--- a/src/gui/file_io.hpp
+++ b/src/gui/file_io.hpp
@@ -170,6 +170,17 @@ bool ExportPreviewPng(const std::filesystem::path& path, PreviewRenderer& render
 // Export configuration as JSON (CLI-compatible format)
 bool ExportConfigJson(const std::filesystem::path& path, const std::string& json_str);
 
+// Must exporting the config JSON to `path` be confirmed by the user first? True iff something is
+// already there to lose — the export is a full overwrite, and what it writes is the GUI's own
+// re-emission, which carries only what the GUI can express. Overwriting the very document that was
+// imported is the case the ruling is about, but the harm ("a file you did not write is now the
+// GUI's lossy view of it") is the same for any existing target, and answering the narrower
+// question would mean carrying a "where did this document come from" field for nothing else.
+//
+// Pure, and separate from the dialog wrapper for the same reason BuildExportJsonOrWarn is: the
+// decision is testable, the file dialog is not.
+bool ConfigJsonExportNeedsOverwriteConfirm(const std::filesystem::path& path);
+
 // File dialog wrappers (return empty path on cancel)
 std::filesystem::path ShowOpenDialog();
 std::filesystem::path ShowSaveDialog();

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -617,23 +617,33 @@ struct SummandText {
 
 // Sum-of-products container: an OR of AND-of-factors rows. Concrete type for
 // FilterConfig::param (replaces the pre-uplift Factor alias). An empty vector
-// is not a valid state — a "no filter" FilterConfig holds a single-row single-
-// factor SoP with an empty RaypathParams (see the FilterConfig default below).
+// is the canonical form of "this filter states no rule" — it expands to zero
+// clauses, which the commit path reads as "no filter" (see the FilterConfig
+// default below).
 using SumOfProducts = std::vector<SummandText>;
 
 // GUI-only data structure: filter configuration.
 //
 // Top-level fields (name/action/sym_*) apply to all filter types; per-summand
-// data lives inside `param` (sum-of-products of Factors). Default-constructed
-// FilterConfig holds a 1-row / 1-factor SoP containing an empty RaypathParams
-// (the "no filter" state of pre-variant builds).
+// data lives inside `param` (sum-of-products of Factors). A default-constructed
+// FilterConfig states nothing: its SoP is empty.
+//
+// It used to default to a 1-row / 1-factor SoP holding an empty RaypathParams,
+// inherited from pre-variant builds where "empty raypath" WAS how the editor
+// spelled "no filter". That stopped being true once a factor with empty text
+// became the editor's match-all: the same shape now commits as core's `none`,
+// which under filter_out excludes every ray. The default is the empty vector so
+// that the type's own zero value is the harmless state rather than a match-all
+// one construction away. The editor still opens "no filter" as exactly one
+// blank row — that row is supplied by SetRowsFromSop (edit_modals.cpp) as a
+// display affordance, and is a separate thing from this model default.
 struct FilterConfig {
   std::string name;
   int action = 0;  // 0=filter_in, 1=filter_out
   bool sym_p = true;
   bool sym_b = true;
   bool sym_d = true;
-  SumOfProducts param{ SummandText{ std::string{}, std::vector<Factor>{ Factor{ RaypathParams{} } } } };
+  SumOfProducts param;
 
   // Compat accessors — degenerate single-factor path.
   //

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -378,6 +378,7 @@ int main(int argc, char** argv) {
     gui::RenderSaveModifiedPopup(window);
     gui::RenderDefaultsPanel(gui::g_state);
     gui::RenderImportWarningPopup();
+    gui::RenderExportOverwriteConfirmPopup();
     gui::RenderGuiWarningPopup();
 
     // Reset aspect ratio to Free when panel collapse state changes (window size doesn't adjust automatically).

--- a/src/gui/raypath_segments.hpp
+++ b/src/gui/raypath_segments.hpp
@@ -767,13 +767,18 @@ inline std::string FormatSopExpansionPreview(const SumOfProducts& sop) {
 // ---------------------------------------------------------------------------
 
 // Split RaypathParams.raypath_text on ';' into one OR-row per segment. Empty
-// input → single row with empty raypath (the "no filter" degenerate state, to
-// match the FilterConfig default).
+// input → empty SoP, which is "no filter" said in the type's own vocabulary and
+// is also the FilterConfig default.
+//
+// It used to return a single row holding an empty RaypathParams instead. That
+// row is not "no filter": a row carrying a factor whose text is empty is the
+// editor's match-all, and it commits as core's `none` — so under filter_out a
+// legacy file that named no raypath at all excluded every ray and rendered a
+// black frame. An empty SoP expands to zero clauses, which ExpandFilterToScene
+// reads as kNoFilter, and that is harmless under both actions.
 inline SumOfProducts FromLegacyRaypath(const RaypathParams& rp) {
   SumOfProducts out;
   if (rp.raypath_text.empty()) {
-    RaypathParams empty_rp;
-    out.push_back(SummandText{ std::string{}, std::vector<Factor>{ Factor{ empty_rp } } });
     return out;
   }
   auto segs = SplitRaypathSegments(rp.raypath_text);

--- a/src/gui/raypath_segments.hpp
+++ b/src/gui/raypath_segments.hpp
@@ -793,8 +793,20 @@ inline SumOfProducts FromLegacyRaypath(const RaypathParams& rp) {
 // Wrap an EntryExitParams into a single-row SoP. The comma-list multi-value OR
 // semantics inside entry_text / exit_text are preserved as-is (cartesian
 // expansion into multiple core simple filters is 333.3's job, not this task).
+//
+// entry_text empty + exit_text empty + no length constraint is the wildcard shape — it names no
+// face on either end and no length bound, i.e. no predicate at all — and gets the same empty-SoP
+// answer FromLegacyRaypath gives an empty raypath_text above: zero rows is "no filter" in the
+// type's own vocabulary, which NoFilterIfNoPredicate (file_io.cpp) reads as "drop the filter". It
+// used to construct the single-row match-all shape unconditionally; a legacy `.lmc` whose
+// entry_exit filter named neither face nor length came back as a filter matching everything, and
+// under filter_out that excluded every ray. A length constraint alone (length_mode != 0) is still
+// a real predicate and keeps the single-row form.
 inline SumOfProducts FromLegacyEntryExit(const EntryExitParams& ep) {
   SumOfProducts out;
+  if (ep.entry_text.empty() && ep.exit_text.empty() && ep.length_mode == 0) {
+    return out;
+  }
   std::string text = FormatEntryExitFactorText(ep);
   out.push_back(SummandText{ std::move(text), std::vector<Factor>{ Factor{ ep } } });
   return out;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -316,6 +316,7 @@ if(BUILD_GUI)
     "${PROJ_TEST_DIR}/composition-correctness/gui/test_document_defaults_chain.cpp"
     "${PROJ_TEST_DIR}/composition-correctness/gui/test_document_switch_chain.cpp"
     "${PROJ_TEST_DIR}/composition-correctness/gui/test_legacy_document_chain.cpp"
+    "${PROJ_TEST_DIR}/composition-correctness/gui/test_json_import_contract_chain.cpp"
     "${PROJ_TEST_DIR}/composition-correctness/gui/test_scene_commit_chain.cpp"
     "${PROJ_TEST_DIR}/composition-correctness/gui/test_filter_reconstruct_chain.cpp"
     "${PROJ_TEST_DIR}/composition-correctness/gui/test_raypath_color_document_chain.cpp"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -316,7 +316,7 @@ if(BUILD_GUI)
     "${PROJ_TEST_DIR}/composition-correctness/gui/test_document_defaults_chain.cpp"
     "${PROJ_TEST_DIR}/composition-correctness/gui/test_document_switch_chain.cpp"
     "${PROJ_TEST_DIR}/composition-correctness/gui/test_legacy_document_chain.cpp"
-    "${PROJ_TEST_DIR}/composition-correctness/gui/test_json_import_contract_chain.cpp"
+    "${PROJ_TEST_DIR}/composition-correctness/gui/test_json_document_contract_chain.cpp"
     "${PROJ_TEST_DIR}/composition-correctness/gui/test_scene_commit_chain.cpp"
     "${PROJ_TEST_DIR}/composition-correctness/gui/test_filter_reconstruct_chain.cpp"
     "${PROJ_TEST_DIR}/composition-correctness/gui/test_raypath_color_document_chain.cpp"

--- a/test/composition-correctness/gui/test_document_defaults_chain.cpp
+++ b/test/composition-correctness/gui/test_document_defaults_chain.cpp
@@ -65,18 +65,26 @@ constexpr const char* kRoot = "{}";
 constexpr const char* kSun = R"({"sun":{}})";
 constexpr const char* kSim = R"({"sim":{}})";
 constexpr const char* kRenderer = R"({"renderer":{}})";
-constexpr const char* kCrystal = R"({"layers":[{"entries":[{"crystal":{}}]}]})";
+// Every crystal below states its `type`, and has to. `type` is not a field with a missing-key
+// default at all: it is the discriminant deciding how the rest of the crystal reads, so a crystal
+// that omits it is refused outright and the entry falls back to a default POOL SLOT. Rows reading
+// `s.crystals.at(0)` would then still find something to compare — an untouched slot — and pass
+// without the parse under test having run. So the rows keep their subject the only absent key by
+// stating `type`, and the refusal itself is pinned where it belongs, next to the other
+// core-rejects-this-document cases (JsonImportContractChain in the sibling contract-chain file).
+constexpr const char* kCrystal = R"({"layers":[{"entries":[{"crystal":{"type":"prism"}}]}]})";
 // The filter document carries a raypath, and it has to. A filter object that names no rule at all
 // is not loaded as a filter with default fields — it is loaded as no filter, so there would be no
 // `s.filters.at(0)` for the rows below to read a default off. That disposition is a row of its own
 // (kEmptyFilter, in the test body) rather than a silent property of this constant.
-constexpr const char* kFilter = R"({"layers":[{"entries":[{"crystal":{},"filter":{"raypath_text":"3-5"}}]}]})";
+constexpr const char* kFilter =
+    R"({"layers":[{"entries":[{"crystal":{"type":"prism"},"filter":{"raypath_text":"3-5"}}]}]})";
 // entry_text carries a real value: an entry_exit filter naming neither face nor length is now the
 // wildcard shape (FromLegacyEntryExit) and does not become a filter in the pool at all — that
 // disposition is its own row below (kEmptyEeFilter, in the test body), same as kEmptyFilter for the
 // raypath arm above it.
 constexpr const char* kEeFilter =
-    R"({"layers":[{"entries":[{"crystal":{},"filter":{"type":"entry_exit","entry_text":"2"}}]}]})";
+    R"({"layers":[{"entries":[{"crystal":{"type":"prism"},"filter":{"type":"entry_exit","entry_text":"2"}}]}]})";
 
 const MissingKeyCase kGuiNativeCases[] = {
   // -- root-level GuiState fields; the parent object is the document root, always present --
@@ -126,28 +134,33 @@ const MissingKeyCase kGuiNativeCases[] = {
                          EntryCard{}.proportion),
 
   // -- the inline crystal (ParseCrystal, shared by both entry points) --
+  // `crystal.type` has no row of its own in either table, and the absence is the statement: it is
+  // the one crystal key whose omission is not answered with a default (see kCrystal above).
   LUMICE_MISSING_KEY_ROW(kCrystal, s.crystals.at(0).name, CrystalConfig{}.name),
-  LUMICE_MISSING_KEY_ROW(kCrystal, s.crystals.at(0).type, CrystalConfig{}.type),
   // ParseShapeDist: `type` is owned by ShapeDist; `center` comes from the per-scalar default the
   // CALL SITE passes, so it is pinned against that scalar's own struct default.
-  LUMICE_MISSING_KEY_ROW(R"({"layers":[{"entries":[{"crystal":{"shape":{"height":{}}}}]}]})",
+  LUMICE_MISSING_KEY_ROW(R"({"layers":[{"entries":[{"crystal":{"type":"prism","shape":{"height":{}}}}]}]})",
                          s.crystals.at(0).height.type, ShapeDist{}.type),
-  LUMICE_MISSING_KEY_ROW(R"({"layers":[{"entries":[{"crystal":{"shape":{"height":{"type":"uniform","mean":2.0}}}}]}]})",
-                         s.crystals.at(0).height.spread, ShapeDist{}.spread),
-  LUMICE_MISSING_KEY_ROW(R"({"layers":[{"entries":[{"crystal":{"shape":{"height":{"type":"uniform","std":0.5}}}}]}]})",
-                         s.crystals.at(0).height.center, CrystalConfig{}.height.center),
   LUMICE_MISSING_KEY_ROW(
-      R"({"layers":[{"entries":[{"crystal":{"shape":{"face_distance":[{"type":"uniform","std":0.1}]}}}]}]})",
+      R"({"layers":[{"entries":[{"crystal":{"type":"prism","shape":{"height":{"type":"uniform","mean":2.0}}}}]}]})",
+      s.crystals.at(0).height.spread, ShapeDist{}.spread),
+  LUMICE_MISSING_KEY_ROW(
+      R"({"layers":[{"entries":[{"crystal":{"type":"prism","shape":{"height":{"type":"uniform","std":0.5}}}}]}]})",
+      s.crystals.at(0).height.center, CrystalConfig{}.height.center),
+  LUMICE_MISSING_KEY_ROW(
+      R"({"layers":[{"entries":[{"crystal":{"type":"prism","shape":{"face_distance":[{"type":"uniform","std":0.1}]}}}]}]})",
       s.crystals.at(0).face_distance[0].center, CrystalConfig{}.face_distance[0].center),
   LUMICE_MISSING_KEY_ROW(
       R"({"layers":[{"entries":[{"crystal":{"type":"pyramid","shape":{"prism_h":{"type":"uniform","std":0.1}}}}]}]})",
       s.crystals.at(0).prism_h.center, CrystalConfig{}.prism_h.center),
   // ParseAxisDist: `mean` / `std` are owned by AxisDist. `type` is pinned explicitly in each row so
   // the field under test is the only one the document leaves out.
-  LUMICE_MISSING_KEY_ROW(R"({"layers":[{"entries":[{"crystal":{"axis":{"zenith":{"type":"uniform","std":360.0}}}}]}]})",
-                         s.crystals.at(0).zenith.mean, AxisDist{}.mean),
-  LUMICE_MISSING_KEY_ROW(R"({"layers":[{"entries":[{"crystal":{"axis":{"zenith":{"type":"uniform","mean":0.0}}}}]}]})",
-                         s.crystals.at(0).zenith.std, AxisDist{}.std),
+  LUMICE_MISSING_KEY_ROW(
+      R"({"layers":[{"entries":[{"crystal":{"type":"prism","axis":{"zenith":{"type":"uniform","std":360.0}}}}]}]})",
+      s.crystals.at(0).zenith.mean, AxisDist{}.mean),
+  LUMICE_MISSING_KEY_ROW(
+      R"({"layers":[{"entries":[{"crystal":{"type":"prism","axis":{"zenith":{"type":"uniform","mean":0.0}}}}]}]})",
+      s.crystals.at(0).zenith.std, AxisDist{}.std),
 
   // -- the inline filter (ParseFilterFromGuiJson) --
   LUMICE_MISSING_KEY_ROW(kFilter, s.filters.at(0).name, FilterConfig{}.name),
@@ -181,13 +194,15 @@ const MissingKeyCase kGuiNativeCases[] = {
 
 // Documents for the legacy core/CLI path, where a crystal needs an id and a scattering entry
 // pointing at it before any of its fields exist to check.
-constexpr const char* kCoreCrystal = R"({"crystal":[{"id":1}],"scene":{"scattering":[{"entries":[{"crystal":1}]}]}})";
-constexpr const char* kCoreFilter = R"({"crystal":[{"id":1}],"filter":[{"id":1,"type":"raypath"}],
+constexpr const char* kCoreCrystal =
+    R"({"crystal":[{"id":1,"type":"prism"}],"scene":{"scattering":[{"entries":[{"crystal":1}]}]}})";
+constexpr const char* kCoreFilter = R"({"crystal":[{"id":1,"type":"prism"}],"filter":[{"id":1,"type":"raypath"}],
         "scene":{"scattering":[{"entries":[{"crystal":1,"filter":1}]}]}})";
-constexpr const char* kCoreComplex = R"({"crystal":[{"id":1}],
+constexpr const char* kCoreComplex = R"({"crystal":[{"id":1,"type":"prism"}],
         "filter":[{"id":1,"type":"raypath","raypath":[3,5]},{"id":2,"type":"complex","composition":[[1]]}],
         "scene":{"scattering":[{"entries":[{"crystal":1,"filter":2}]}]}})";
-constexpr const char* kCoreColor = R"({"crystal":[{"id":1}],"scene":{"scattering":[{"entries":[{"crystal":1}]}]},
+constexpr const char* kCoreColor =
+    R"({"crystal":[{"id":1,"type":"prism"}],"scene":{"scattering":[{"entries":[{"crystal":1}]}]},
         "raypath_color":{"classes":[{"match":[{"crystal":1}]}]}})";
 
 const MissingKeyCase kCoreJsonCases[] = {
@@ -203,7 +218,6 @@ const MissingKeyCase kCoreJsonCases[] = {
   LUMICE_MISSING_KEY_ROW(R"({"render":[{}]})", s.renderer.opacity, RenderConfig{}.opacity),
   LUMICE_MISSING_KEY_ROW(R"({"render":[{}]})", s.renderer.exposure_offset, RenderConfig{}.exposure_offset),
   LUMICE_MISSING_KEY_ROW(kCoreCrystal, s.crystals.at(0).name, CrystalConfig{}.name),
-  LUMICE_MISSING_KEY_ROW(kCoreCrystal, s.crystals.at(0).type, CrystalConfig{}.type),
 
   // The next three rows expect CORE's default, not the GUI struct's, and say where core states it.
   // On this path the struct that owns the field and the struct that owns the WIRE FORMAT are not
@@ -214,8 +228,9 @@ const MissingKeyCase kCoreJsonCases[] = {
   LUMICE_MISSING_KEY_ROW(kCoreFilter, s.filters.at(0).sym_b, false),
   LUMICE_MISSING_KEY_ROW(kCoreFilter, s.filters.at(0).sym_d, false),
   LUMICE_MISSING_KEY_ROW(R"({"render":[{}]})", s.renderer.visible, kVisibleUpper),
-  LUMICE_MISSING_KEY_ROW(R"({"crystal":[{"id":1}],"scene":{"scattering":[{"prob":0,"entries":[{"crystal":1}]}]}})",
-                         s.layers.at(0).entries.at(0).proportion, EntryCard{}.proportion),
+  LUMICE_MISSING_KEY_ROW(
+      R"({"crystal":[{"id":1,"type":"prism"}],"scene":{"scattering":[{"prob":0,"entries":[{"crystal":1}]}]}})",
+      s.layers.at(0).entries.at(0).proportion, EntryCard{}.proportion),
 
   LUMICE_MISSING_KEY_ROW(kCoreFilter, s.filters.at(0).name, FilterConfig{}.name),
   LUMICE_MISSING_KEY_ROW(kCoreFilter, s.filters.at(0).action, FilterConfig{}.action),
@@ -249,7 +264,7 @@ TEST(DocumentDefaultsChain, GuiNativeAbsentKeyTakesTheOwningStructDefault) {
   // leaves nothing for a default to be read off: the entry is loaded without a filter rather than
   // with a default-constructed one, because a default FilterConfig lowered into the scene would be
   // a term matching every ray, and under filter_out that hides all of them.
-  constexpr const char* kEmptyFilter = R"({"layers":[{"entries":[{"crystal":{},"filter":{}}]}]})";
+  constexpr const char* kEmptyFilter = R"({"layers":[{"entries":[{"crystal":{"type":"prism"},"filter":{}}]}]})";
   GuiState empty_filter;
   ASSERT_TRUE(DeserializeGuiStateJson(kEmptyFilter, empty_filter)) << kEmptyFilter;
   EXPECT_TRUE(empty_filter.filters.empty()) << "an empty filter object became a filter in the pool";
@@ -260,7 +275,8 @@ TEST(DocumentDefaultsChain, GuiNativeAbsentKeyTakesTheOwningStructDefault) {
   // filter naming neither face nor length is the wildcard shape, and
   // FromLegacyEntryExit now answers it the same way FromLegacyRaypath answers an empty
   // raypath_text — no filter enters the pool for it.
-  constexpr const char* kEmptyEeFilter = R"({"layers":[{"entries":[{"crystal":{},"filter":{"type":"entry_exit"}}]}]})";
+  constexpr const char* kEmptyEeFilter =
+      R"({"layers":[{"entries":[{"crystal":{"type":"prism"},"filter":{"type":"entry_exit"}}]}]})";
   GuiState empty_ee_filter;
   ASSERT_TRUE(DeserializeGuiStateJson(kEmptyEeFilter, empty_ee_filter)) << kEmptyEeFilter;
   EXPECT_TRUE(empty_ee_filter.filters.empty())

--- a/test/composition-correctness/gui/test_document_defaults_chain.cpp
+++ b/test/composition-correctness/gui/test_document_defaults_chain.cpp
@@ -201,9 +201,12 @@ constexpr const char* kCoreFilter = R"({"crystal":[{"id":1,"type":"prism"}],"fil
 constexpr const char* kCoreComplex = R"({"crystal":[{"id":1,"type":"prism"}],
         "filter":[{"id":1,"type":"raypath","raypath":[3,5]},{"id":2,"type":"complex","composition":[[1]]}],
         "scene":{"scattering":[{"entries":[{"crystal":1,"filter":2}]}]}})";
+// The class states a `color`, and has to, for the same reason every crystal above states a `type`:
+// a colourless class is refused outright rather than given a default colour, so the rows below would
+// have no `raypath_color.at(0)` to read a default off.
 constexpr const char* kCoreColor =
     R"({"crystal":[{"id":1,"type":"prism"}],"scene":{"scattering":[{"entries":[{"crystal":1}]}]},
-        "raypath_color":{"classes":[{"match":[{"crystal":1}]}]}})";
+        "raypath_color":{"classes":[{"color":[1,0,0],"match":[{"crystal":1}]}]}})";
 
 const MissingKeyCase kCoreJsonCases[] = {
   LUMICE_MISSING_KEY_ROW(R"({"scene":{}})", s.sim.max_hits, SimConfig{}.max_hits),

--- a/test/composition-correctness/gui/test_document_defaults_chain.cpp
+++ b/test/composition-correctness/gui/test_document_defaults_chain.cpp
@@ -66,7 +66,11 @@ constexpr const char* kSun = R"({"sun":{}})";
 constexpr const char* kSim = R"({"sim":{}})";
 constexpr const char* kRenderer = R"({"renderer":{}})";
 constexpr const char* kCrystal = R"({"layers":[{"entries":[{"crystal":{}}]}]})";
-constexpr const char* kFilter = R"({"layers":[{"entries":[{"crystal":{},"filter":{}}]}]})";
+// The filter document carries a raypath, and it has to. A filter object that names no rule at all
+// is not loaded as a filter with default fields — it is loaded as no filter, so there would be no
+// `s.filters.at(0)` for the rows below to read a default off. That disposition is a row of its own
+// (kEmptyFilter, in the test body) rather than a silent property of this constant.
+constexpr const char* kFilter = R"({"layers":[{"entries":[{"crystal":{},"filter":{"raypath_text":"3-5"}}]}]})";
 constexpr const char* kEeFilter = R"({"layers":[{"entries":[{"crystal":{},"filter":{"type":"entry_exit"}}]}]})";
 
 const MissingKeyCase kGuiNativeCases[] = {
@@ -146,9 +150,12 @@ const MissingKeyCase kGuiNativeCases[] = {
   LUMICE_MISSING_KEY_ROW(kFilter, s.filters.at(0).sym_p, FilterConfig{}.sym_p),
   LUMICE_MISSING_KEY_ROW(kFilter, s.filters.at(0).sym_b, FilterConfig{}.sym_b),
   LUMICE_MISSING_KEY_ROW(kFilter, s.filters.at(0).sym_d, FilterConfig{}.sym_d),
-  // No `type` and no `raypath_text`: the legacy arm must reconstruct FilterConfig's default
-  // 1-row / 1-factor empty-raypath SoP. Compared whole, not just by its text.
-  LUMICE_MISSING_KEY_ROW(kFilter, s.filters.at(0).param == FilterConfig{}.param, true),
+  // No `type`: the legacy arm reads the document as a raypath, so the text it does carry survives.
+  // (What happens when it carries no text either is the kEmptyFilter row in the test body — that
+  // one is not a "missing key takes the struct default" statement at all, which is why it is not
+  // here: the answer is that there is no filter to read a default off.)
+  LUMICE_MISSING_KEY_ROW(kFilter, s.filters.at(0).param.size(), 1u),
+  LUMICE_MISSING_KEY_ROW(kFilter, s.filters.at(0).param.at(0).text, std::string("3-5")),
   // Guard row, deliberately first of the EE group: EntryExitParamsValue() asserts on the wrong
   // variant arm, so a `type` that stopped selecting the EE arm would otherwise surface as a
   // bad_variant_access rather than as the plain statement that the arm is wrong.
@@ -229,6 +236,18 @@ TEST(DocumentDefaultsChain, GuiNativeAbsentKeyTakesTheOwningStructDefault) {
     }
     c.check(loaded);
   }
+
+  // The one filter key whose absence does NOT take the owning struct default, stated here because
+  // this is the file a reader comes to with the question. A `filter` object naming no rule at all
+  // leaves nothing for a default to be read off: the entry is loaded without a filter rather than
+  // with a default-constructed one, because a default FilterConfig lowered into the scene would be
+  // a term matching every ray, and under filter_out that hides all of them.
+  constexpr const char* kEmptyFilter = R"({"layers":[{"entries":[{"crystal":{},"filter":{}}]}]})";
+  GuiState empty_filter;
+  ASSERT_TRUE(DeserializeGuiStateJson(kEmptyFilter, empty_filter)) << kEmptyFilter;
+  EXPECT_TRUE(empty_filter.filters.empty()) << "an empty filter object became a filter in the pool";
+  EXPECT_FALSE(empty_filter.layers.at(0).entries.at(0).filter_id.has_value())
+      << "the entry was given a filter the document did not describe";
 }
 
 TEST(DocumentDefaultsChain, CoreJsonAbsentKeyTakesTheOwningStructDefault) {

--- a/test/composition-correctness/gui/test_document_defaults_chain.cpp
+++ b/test/composition-correctness/gui/test_document_defaults_chain.cpp
@@ -330,7 +330,7 @@ TEST(DocumentDefaultsChain, TypelessAxisSlotLoadsAsTheStructDefaultAndIsAnnounce
             { "face_distance", { 1, 1, 1, 1, 1, 1 } },
             { "axis", axis } } });
     root["filter"] = nlohmann::json::array();
-    root["scene"]["light_source"] = { { "altitude", 20.0 }, { "diameter", 0.5 } };
+    root["scene"]["light_source"] = { { "altitude", 20.0 }, { "diameter", 0.5 }, { "spectrum", "D65" } };
     root["scene"]["ray_num"] = 1000;
     root["scene"]["max_hits"] = 8;
     root["scene"]["scattering"] = nlohmann::json::array(
@@ -368,7 +368,7 @@ TEST(DocumentDefaultsChain, TypelessAxisSlotLoadsAsTheStructDefaultAndIsAnnounce
     "crystal": [{"id": 1, "type": "Prism", "height": 1.0, "face_distance": [1,1,1,1,1,1]}],
     "filter": [],
     "scene": {
-      "light_source": {"altitude": 20.0, "diameter": 0.5}, "ray_num": 1000, "max_hits": 8,
+      "light_source": {"altitude": 20.0, "diameter": 0.5, "spectrum": "D65"}, "ray_num": 1000, "max_hits": 8,
       "scattering": [
         {"prob": 0.5, "entries": [{"crystal": 1, "proportion": 100.0}]},
         {"entries": [{"crystal": 1, "proportion": 100.0}]}

--- a/test/composition-correctness/gui/test_document_defaults_chain.cpp
+++ b/test/composition-correctness/gui/test_document_defaults_chain.cpp
@@ -71,7 +71,12 @@ constexpr const char* kCrystal = R"({"layers":[{"entries":[{"crystal":{}}]}]})";
 // `s.filters.at(0)` for the rows below to read a default off. That disposition is a row of its own
 // (kEmptyFilter, in the test body) rather than a silent property of this constant.
 constexpr const char* kFilter = R"({"layers":[{"entries":[{"crystal":{},"filter":{"raypath_text":"3-5"}}]}]})";
-constexpr const char* kEeFilter = R"({"layers":[{"entries":[{"crystal":{},"filter":{"type":"entry_exit"}}]}]})";
+// entry_text carries a real value: an entry_exit filter naming neither face nor length is now the
+// wildcard shape (FromLegacyEntryExit) and does not become a filter in the pool at all — that
+// disposition is its own row below (kEmptyEeFilter, in the test body), same as kEmptyFilter for the
+// raypath arm above it.
+constexpr const char* kEeFilter =
+    R"({"layers":[{"entries":[{"crystal":{},"filter":{"type":"entry_exit","entry_text":"2"}}]}]})";
 
 const MissingKeyCase kGuiNativeCases[] = {
   // -- root-level GuiState fields; the parent object is the document root, always present --
@@ -159,8 +164,10 @@ const MissingKeyCase kGuiNativeCases[] = {
   // Guard row, deliberately first of the EE group: EntryExitParamsValue() asserts on the wrong
   // variant arm, so a `type` that stopped selecting the EE arm would otherwise surface as a
   // bad_variant_access rather than as the plain statement that the arm is wrong.
+  // entry_text itself is not tested for its own missing-key default here (mirrors kFilter/raypath_text
+  // above it): entry_text is kEeFilter's anchor predicate, so its absence is the kEmptyEeFilter row
+  // in the test body instead, not a "missing key takes the struct default" statement.
   LUMICE_MISSING_KEY_ROW(kEeFilter, s.filters.at(0).IsEntryExit(), true),
-  LUMICE_MISSING_KEY_ROW(kEeFilter, s.filters.at(0).EntryExitParamsValue().entry_text, EntryExitParams{}.entry_text),
   LUMICE_MISSING_KEY_ROW(kEeFilter, s.filters.at(0).EntryExitParamsValue().exit_text, EntryExitParams{}.exit_text),
   LUMICE_MISSING_KEY_ROW(kEeFilter, s.filters.at(0).EntryExitParamsValue().length_mode, EntryExitParams{}.length_mode),
   LUMICE_MISSING_KEY_ROW(kEeFilter, s.filters.at(0).EntryExitParamsValue().min_len, EntryExitParams{}.min_len),
@@ -247,6 +254,18 @@ TEST(DocumentDefaultsChain, GuiNativeAbsentKeyTakesTheOwningStructDefault) {
   ASSERT_TRUE(DeserializeGuiStateJson(kEmptyFilter, empty_filter)) << kEmptyFilter;
   EXPECT_TRUE(empty_filter.filters.empty()) << "an empty filter object became a filter in the pool";
   EXPECT_FALSE(empty_filter.layers.at(0).entries.at(0).filter_id.has_value())
+      << "the entry was given a filter the document did not describe";
+
+  // Symmetric with kEmptyFilter above, but for the entry_exit legacy arm: a `type":"entry_exit"`
+  // filter naming neither face nor length is the wildcard shape, and
+  // FromLegacyEntryExit now answers it the same way FromLegacyRaypath answers an empty
+  // raypath_text — no filter enters the pool for it.
+  constexpr const char* kEmptyEeFilter = R"({"layers":[{"entries":[{"crystal":{},"filter":{"type":"entry_exit"}}]}]})";
+  GuiState empty_ee_filter;
+  ASSERT_TRUE(DeserializeGuiStateJson(kEmptyEeFilter, empty_ee_filter)) << kEmptyEeFilter;
+  EXPECT_TRUE(empty_ee_filter.filters.empty())
+      << "an entry_exit filter naming neither face nor length became a filter in the pool";
+  EXPECT_FALSE(empty_ee_filter.layers.at(0).entries.at(0).filter_id.has_value())
       << "the entry was given a filter the document did not describe";
 }
 

--- a/test/composition-correctness/gui/test_document_roundtrip_chain.cpp
+++ b/test/composition-correctness/gui/test_document_roundtrip_chain.cpp
@@ -413,6 +413,59 @@ TEST(DocumentRoundtripChain, ANonUniformShapeDistIsDowngradedAndCountedAndAUnifo
   }
 }
 
+// The second loader downgrade that is announced rather than silent: a filter the file described no
+// rule for is loaded as no filter at all.
+//
+// Dropping it is the right disposition — the alternative, a filter that matches everything, hides
+// every ray under filter_out — but it is still a document arriving different from how it was
+// written, and the user's own copy of the file still says otherwise. The counter is what turns that
+// into a notice. Its three properties are the same three the shape-distribution counter has, and
+// they fail in the same three ways: never counting makes the change invisible, never clearing makes
+// the notice permanent, and counting documents that were loaded faithfully trains the user to
+// dismiss it.
+TEST(DocumentRoundtripChain, AFilterWithNoRuleInItIsDroppedAndCounted) {
+  struct Case {
+    const char* name;
+    const char* doc;
+    int expected_count;
+  };
+  const char* kPrism = R"("crystal": {"type": "prism", "shape": {"height": 1.0}}, "proportion": 100.0)";
+  const std::string kEmptySummands =
+      std::string(R"({"layers": [{"prob": 0.0, "entries": [{)") + kPrism + R"(, "filter": {"summands": []}}]}]})";
+  const std::string kNoRaypathText =
+      std::string(R"({"layers": [{"prob": 0.0, "entries": [{)") + kPrism + R"(, "filter": {"type": "raypath"}}]}]})";
+  const std::string kTwoOfThem = std::string(R"({"layers": [{"prob": 0.0, "entries": [{)") + kPrism +
+                                 R"(, "filter": {"summands": []}}, {)" + kPrism +
+                                 R"(, "filter": {"type": "raypath"}}]}]})";
+  const std::string kRealFilter =
+      std::string(R"({"layers": [{"prob": 0.0, "entries": [{)") + kPrism + R"(, "filter": {"summands": ["3-5"]}}]}]})";
+  const std::string kNoFilterKey = std::string(R"({"layers": [{"prob": 0.0, "entries": [{)") + kPrism + R"(}]}]})";
+
+  const Case kCases[] = {
+    { "an empty summands array", kEmptySummands.c_str(), 1 },
+    { "a legacy form with no raypath text", kNoRaypathText.c_str(), 1 },
+    // Per filter, not per document: a file with two of them has to say so, or the notice
+    // under-reports exactly when there is most to report.
+    { "two of them in one document", kTwoOfThem.c_str(), 2 },
+    // The other half of the claim: a document that was loaded faithfully is not counted.
+    { "a filter that does state a rule", kRealFilter.c_str(), 0 },
+    { "an entry with no filter at all", kNoFilterKey.c_str(), 0 },
+  };
+
+  for (const Case& c : kCases) {
+    TakeFilterNoPredicateDowngradeCount();  // discard anything a previous case in this binary left
+    GuiState loaded;
+    if (!DeserializeGuiStateJson(c.doc, loaded)) {
+      ADD_FAILURE() << c.name << ": the document failed to deserialize";
+      continue;  // no load to count; the rest still get checked
+    }
+    EXPECT_EQ(TakeFilterNoPredicateDowngradeCount(), c.expected_count)
+        << c.name << ": the document was changed on load with nothing to report it, or the reverse";
+    EXPECT_EQ(TakeFilterNoPredicateDowngradeCount(), 0)
+        << c.name << ": the counter did not clear on read, so a notice would never go away";
+  }
+}
+
 // E1 — sync_group on the crystal kind whose slots the probe sweep structurally cannot reach, with
 // the emitted KEY NAMES asserted rather than only the round trip.
 //
@@ -563,10 +616,13 @@ TEST(DocumentRoundtripChain, LegacyRaypathSplitsIntoOneRowPerSegment) {
     { "single-segment", "3-5", 1, "3-5" },
     { "two-segments", "3-5; 1-3", 2, "3-5" },
     { "three-segments", "3-5;1-3;4-6", 3, "3-5" },
-    // The empty case is not "no rows": FilterConfig's own default is a single row holding an
-    // empty RaypathParams, and the translator has to produce that same degenerate shape or a
-    // filter-less document becomes a document with a zero-row filter, which is not a valid state.
-    { "empty-is-one-degenerate-row", "", 1, "" },
+    // The empty case is zero rows, and zero rows is a valid filter — it is the one that says
+    // nothing, which the commit path reads as "no filter". The translator used to produce a single
+    // row holding an empty RaypathParams here, on the reading that a filter-less document must not
+    // become a zero-row filter. That row is not filter-less: it carries a factor, which makes it
+    // the editor's match-all, so a legacy file naming no raypath at all came back as a filter that
+    // matches everything — and under filter_out, one that excludes every ray.
+    { "empty-is-no-rows", "", 0, "" },
   };
 
   for (const LegacyRaypathCase& c : kCases) {

--- a/test/composition-correctness/gui/test_filter_reconstruct_chain.cpp
+++ b/test/composition-correctness/gui/test_filter_reconstruct_chain.cpp
@@ -60,7 +60,7 @@ std::string CoreDocWithFilters(const std::string& filter_array, int main_id) {
   return R"({"crystal": [{"id": 1, "type": "Prism", "height": 1.0, "face_distance": [1,1,1,1,1,1]}],
              "filter": )" +
          filter_array + R"(,
-             "scene": {"light_source": {"altitude": 20.0, "diameter": 0.5}, "ray_num": 1000, "max_hits": 8,
+             "scene": {"light_source": {"altitude": 20.0, "diameter": 0.5, "spectrum": "D65"}, "ray_num": 1000, "max_hits": 8,
                        "scattering": [{"prob": 1.0, "entries": [{"crystal": 1, "proportion": 100.0, "filter": )" +
          std::to_string(main_id) + R"(}]}]}})";
 }

--- a/test/composition-correctness/gui/test_json_document_contract_chain.cpp
+++ b/test/composition-correctness/gui/test_json_document_contract_chain.cpp
@@ -178,6 +178,120 @@ TEST(JsonImportContractChain, AJsonImportDoesNotInheritAnEarlierReadsDowngrade) 
 }
 
 // ---------------------------------------------------------------------------------------------
+// (4) The other half of the same import contract: a document core would REJECT outright.
+//
+// The three cases above are about a document core accepts and the GUI cannot hold as written — a
+// capability downgrade. These are the opposite shape: a field core requires (`.at(key)`, which
+// throws) that the document does not carry at all. The GUI used to read every one of them with
+// `.value(key, default)`, which cannot tell "absent" from "present and equal to the default", so a
+// malformed document opened as a silently invented one.
+//
+// The disposition is per-field, and it is not uniformly "drop it": where the missing field is a
+// discriminant selecting how the REST of the unit is read, or where no value of its type is the
+// neutral one, the unit it belongs to is dropped rather than guessed. Where the field lives in a
+// singleton scope with no collection to drop from, the value stays as it was and only the silence
+// ends. Either way the report goes out through the channel the import already had.
+// ---------------------------------------------------------------------------------------------
+
+namespace {
+
+// A crystal object the caller shapes, wired into an otherwise complete document with a single
+// scattering entry referencing crystal id 1. `%s` is the whole crystal object.
+std::string DocWithCrystals(const std::string& crystals_json) {
+  return std::string(R"({
+    "crystal": )") +
+         crystals_json + R"(,
+    "filter": [],
+    "scene": {"light_source": {"type": "sun", "altitude": 20, "spectrum": "D65"},
+              "ray_num": 1000, "max_hits": 8,
+              "scattering": [{"prob": 1.0, "entries": [{"crystal": 0, "proportion": 1.0}]}]},
+    "render": [{"id": 1, "lens": {"type": "linear", "fov": 60}, "resolution": [64, 64]}]
+  })";
+}
+
+}  // namespace
+
+// D-1, the case the ruling puts in its own severity band: `id` is the key of the map crystals are
+// collected into, so an absent one is not a guessed value, it is a collision. Two crystals that both
+// omit `id` both land on key 0 and the second silently destroys the first — an existing crystal the
+// document DID state is gone, and a later Save-As freezes the loss.
+//
+// The two crystals are made distinguishable by height on purpose: the surviving slot's height is
+// what says WHICH of the two won, and the assertion that it is neither of them is what says the
+// question no longer has an answer because neither was accepted.
+TEST(JsonImportContractChain, TwoCrystalsMissingIdDoNotSilentlyCollide) {
+  const std::string doc = DocWithCrystals(R"([
+    {"type": "prism", "shape": {"height": 2.0, "face_distance": [1, 1, 1, 1, 1, 1]}},
+    {"type": "prism", "shape": {"height": 5.0, "face_distance": [1, 1, 1, 1, 1, 1]}}
+  ])");
+
+  ClearImportComplexFilterWarning();
+  GuiState scratch;
+  ASSERT_TRUE(DeserializeFromJson(doc, scratch)) << "the document still loads; only the two crystals are refused";
+
+  const std::string warning = PeekImportComplexFilterWarning();
+  EXPECT_FALSE(warning.empty()) << "two crystals collided on one map key and the user was told nothing";
+  EXPECT_NE(warning.find("id"), std::string::npos) << "must name the field that was missing, got: " << warning;
+
+  ASSERT_EQ(scratch.crystals.size(), 1u) << "the entry's fallback slot, and nothing else";
+  const float center = scratch.crystals.at(0).height.center;
+  EXPECT_FLOAT_EQ(center, CrystalConfig{}.height.center)
+      << "the surviving crystal is one of the two the document wrote (height " << center
+      << "), so one of them was silently overwritten by the other";
+  ClearImportComplexFilterWarning();
+}
+
+// D-2: `type` is the discriminant — it decides whether `shape.*` is read as a prism's keys or a
+// pyramid's. Reading it with a default picks one of the two geometries on the user's behalf, and
+// "prism" is not the neutral answer, it is a specific crystal.
+TEST(JsonImportContractChain, AJsonCrystalMissingTypeIsDroppedNotAssumedPrism) {
+  const std::string doc = DocWithCrystals(R"([
+    {"id": 0, "shape": {"height": 5.0, "face_distance": [1, 1, 1, 1, 1, 1]}}
+  ])");
+
+  ClearImportComplexFilterWarning();
+  GuiState scratch;
+  ASSERT_TRUE(DeserializeFromJson(doc, scratch));
+
+  const std::string warning = PeekImportComplexFilterWarning();
+  EXPECT_FALSE(warning.empty()) << "a crystal with no `type` was assumed to be a prism, silently";
+  EXPECT_NE(warning.find("type"), std::string::npos) << "must name the field that was missing, got: " << warning;
+
+  ASSERT_EQ(scratch.crystals.size(), 1u);
+  EXPECT_FLOAT_EQ(scratch.crystals.at(0).height.center, CrystalConfig{}.height.center)
+      << "the refused crystal was loaded anyway, as a prism nobody asked for";
+  ClearImportComplexFilterWarning();
+}
+
+// The same refusal, reached through the OTHER caller of the shared crystal parse: the GUI-native
+// .lmc v2 form inlines its crystal in the entry and carries no `id`, so D-1 does not apply there —
+// but D-2 does, and it arrives by inheriting the shared function's new return type rather than by a
+// second edit. That inheritance is exactly the kind of path that gets assumed rather than checked,
+// which is why it is pinned here: the refusal must land on the same default slot an entry with no
+// inline crystal at all gets, not on a half-built one.
+TEST(JsonImportContractChain, ALmcInlineCrystalMissingTypeFallsBackToADefaultSlot) {
+  const std::string lmc = R"({
+    "layers": [{"prob": 1.0, "entries": [
+      {"crystal": {"shape": {"height": 5.0, "face_distance": [1, 1, 1, 1, 1, 1]}}, "proportion": 1.0}
+    ]}]
+  })";
+
+  ClearImportComplexFilterWarning();
+  GuiState scratch;
+  ASSERT_TRUE(DeserializeGuiStateJson(lmc, scratch));
+
+  ASSERT_EQ(scratch.layers.size(), 1u);
+  ASSERT_EQ(scratch.layers.at(0).entries.size(), 1u);
+  ASSERT_EQ(scratch.crystals.size(), 1u) << "the entry still needs a valid pool slot to point at";
+  EXPECT_EQ(scratch.layers.at(0).entries.at(0).crystal_id, 0);
+  EXPECT_FLOAT_EQ(scratch.crystals.at(0).height.center, CrystalConfig{}.height.center)
+      << "the inline crystal was accepted as a prism instead of refused";
+  EXPECT_NE(PeekImportComplexFilterWarning().find("type"), std::string::npos)
+      << "got: " << PeekImportComplexFilterWarning();
+  ClearImportComplexFilterWarning();
+}
+
+// ---------------------------------------------------------------------------------------------
 // The export half of the same contract: what the GUI is allowed to write over.
 //
 // Import degrades in memory; export is where that degraded copy can reach the disk. The four cases

--- a/test/composition-correctness/gui/test_json_document_contract_chain.cpp
+++ b/test/composition-correctness/gui/test_json_document_contract_chain.cpp
@@ -63,9 +63,36 @@ std::string UniformHeightDoc() {
 
 // A file that removes itself, so a failing assertion cannot leave the temp directory seeded for
 // the next run.
+//
+// Ownership is spelled out rather than left to the optimiser. The first version declared only the
+// destructor and returned a NAMED local from WriteTempFile below, which made correctness depend on
+// NRVO — an optional elision, not a guarantee. Where the compiler took it (clang/gcc) the file
+// survived; where it did not (MSVC) the source object was destroyed on return and deleted the
+// fixture before the case could read it, so seven cases failed on Windows alone with
+// `premise: the fixture was written`. Moving now transfers the duty and clears the source, so a
+// moved-from object's destructor is a no-op no matter what the compiler elides.
 struct TempFile {
   std::filesystem::path path;
+
+  TempFile() = default;
+  explicit TempFile(std::filesystem::path p) : path(std::move(p)) {}
+  TempFile(const TempFile&) = delete;
+  TempFile& operator=(const TempFile&) = delete;
+  TempFile(TempFile&& other) noexcept : path(std::move(other.path)) { other.path.clear(); }
+  TempFile& operator=(TempFile&& other) noexcept {
+    if (this != &other) {
+      std::error_code ec;
+      std::filesystem::remove(path, ec);
+      path = std::move(other.path);
+      other.path.clear();
+    }
+    return *this;
+  }
+
   ~TempFile() {
+    if (path.empty()) {
+      return;  // moved-from: the duty went with the path
+    }
     std::error_code ec;
     std::filesystem::remove(path, ec);  // best-effort: a teardown failure must not fail the case
   }
@@ -73,8 +100,10 @@ struct TempFile {
 
 TempFile WriteTempFile(const char* name, const std::string& text) {
   TempFile f{ std::filesystem::temp_directory_path() / name };
-  std::ofstream out(f.path, std::ios::binary);
-  out << text;
+  {
+    std::ofstream out(f.path, std::ios::binary);
+    out << text;
+  }  // closed before the handle leaves this scope, so the caller reads a flushed file
   return f;
 }
 

--- a/test/composition-correctness/gui/test_json_document_contract_chain.cpp
+++ b/test/composition-correctness/gui/test_json_document_contract_chain.cpp
@@ -291,6 +291,65 @@ TEST(JsonImportContractChain, ALmcInlineCrystalMissingTypeFallsBackToADefaultSlo
   ClearImportComplexFilterWarning();
 }
 
+// D-5: a shape scalar written as a distribution object with no `type`. Core requires it there
+// (Distribution::from_json), and the axis half of that same core rule is already reported by
+// ParseAxisDist — the shape half sat silent in the same file, which is the shape of "fixed one of
+// the two places" this case exists to close.
+//
+// The disposition here is NOT the refusal the crystal keys above get: `type` on a distribution is a
+// field of ShapeDist with a documented default, and the ruling puts this one on the same footing as
+// its axis twin — load at that default, and say so. What changes is only the silence.
+TEST(JsonImportContractChain, AJsonShapeDistMissingTypeLoadsAtNoRandomAndWarns) {
+  const std::string doc = DocWithCrystals(R"([
+    {"id": 0, "type": "prism",
+     "shape": {"height": 2.0, "face_distance": [{"mean": 2.0, "std": 0.1}, 1, 1, 1, 1, 1]}}
+  ])");
+
+  ClearImportComplexFilterWarning();
+  GuiState scratch;
+  ASSERT_TRUE(DeserializeFromJson(doc, scratch));
+  ASSERT_EQ(scratch.crystals.size(), 1u) << "premise: the crystal itself was accepted";
+
+  const ShapeDist& fd0 = scratch.crystals.at(0).face_distance[0];
+  EXPECT_EQ(fd0.type, ShapeDist{}.type) << "the value loads at the owning struct's default, unchanged by this fix";
+  EXPECT_FLOAT_EQ(fd0.center, 2.0f) << "the `mean` the document did state must survive";
+
+  const std::string warning = PeekImportComplexFilterWarning();
+  EXPECT_FALSE(warning.empty()) << "the shape half of the rule stayed silent while the axis half reports";
+  EXPECT_NE(warning.find("type"), std::string::npos) << "must name the field that was missing, got: " << warning;
+  EXPECT_NE(warning.find("face_distance"), std::string::npos)
+      << "must name WHICH slot was rewritten, the way the axis twin does, got: " << warning;
+  ClearImportComplexFilterWarning();
+}
+
+// The one shape scalar deliberately left out of the rule above, and the contrast is the point: on
+// the core side `prism_h` is still a hard requirement whose disposition is being settled there, so
+// changing what the GUI makes of a typeless `prism_h` object now would move a value core has not
+// finished defining. It keeps today's answer, silently, until that lands.
+//
+// Asserted as a negative rather than trusted: the exception lives in one boolean argument at one
+// call site, which is exactly the kind of thing that gets flipped by a later tidy-up with nothing
+// failing.
+TEST(JsonImportContractChain, AJsonPrismHMissingTypeStaysSilentUnlikeOtherShapeDists) {
+  const std::string doc = DocWithCrystals(R"([
+    {"id": 0, "type": "pyramid",
+     "shape": {"prism_h": {"mean": 2.0, "std": 0.1}, "face_distance": [1, 1, 1, 1, 1, 1]}}
+  ])");
+
+  ClearImportComplexFilterWarning();
+  GuiState scratch;
+  ASSERT_TRUE(DeserializeFromJson(doc, scratch));
+  ASSERT_EQ(scratch.crystals.size(), 1u) << "premise: the crystal itself was accepted";
+
+  const ShapeDist& prism_h = scratch.crystals.at(0).prism_h;
+  EXPECT_EQ(prism_h.type, ShapeDist{}.type) << "the value it loads at is unchanged from before this fix";
+  EXPECT_FLOAT_EQ(prism_h.center, 2.0f);
+
+  EXPECT_EQ(PeekImportComplexFilterWarning().find("prism_h"), std::string::npos)
+      << "prism_h is held out of the rule until core settles it; got: " << PeekImportComplexFilterWarning();
+  ClearImportComplexFilterWarning();
+}
+
 // ---------------------------------------------------------------------------------------------
 // The export half of the same contract: what the GUI is allowed to write over.
 //

--- a/test/composition-correctness/gui/test_json_document_contract_chain.cpp
+++ b/test/composition-correctness/gui/test_json_document_contract_chain.cpp
@@ -1,10 +1,11 @@
-// Composition chain: what importing a core JSON is allowed to touch.
+// Composition chain: what a core JSON document on disk is allowed to have done to it.
 //
-// Units in the chain: app (DoOpen) × file_io (DeserializeFromJson / ParseShapeDist / the
-// downgrade counters) × gui_state.
+// Units in the chain: app (DoOpen / RequestConfigJsonExport) × file_io (DeserializeFromJson /
+// ParseShapeDist / the downgrade counters / ConfigJsonExportNeedsOverwriteConfirm) × gui_state.
 //
 // The GUI's expressive power is strictly smaller than the core config JSON's, so an import
-// degrades — and the owner ruling is that the degradation is confined to the copy in memory:
+// degrades — and the owner ruling is that the degradation is confined to the copy in memory,
+// with the export at the bottom of this file as the one deliberate way back out to disk:
 //
 //   (1) The source file is not rewritten. Nothing enforces that today except that no one has
 //       written the line yet, which is not a guarantee; a later "normalize the config on load and
@@ -174,6 +175,91 @@ TEST(JsonImportContractChain, AJsonImportDoesNotInheritAnEarlierReadsDowngrade) 
   EXPECT_TRUE(PeekImportComplexFilterWarning().empty())
       << "this document degraded nothing; the notice describes an earlier read: " << PeekImportComplexFilterWarning();
   ClearImportComplexFilterWarning();
+}
+
+// ---------------------------------------------------------------------------------------------
+// The export half of the same contract: what the GUI is allowed to write over.
+//
+// Import degrades in memory; export is where that degraded copy can reach the disk. The four cases
+// below pin the decision RequestConfigJsonExport makes — write, or ask first — and both answers to
+// the question it raises. They stop at the state and the bytes: that a modal is actually rendered
+// for the pending flag is a proposition about the frame loop, and lives in gui_test
+// (file_ops/exporting_over_an_existing_config_asks_before_overwriting).
+// ---------------------------------------------------------------------------------------------
+
+namespace {
+
+// Distinguishable from anything the export could produce, so "unchanged" is checkable by content.
+constexpr const char* kExistingContent = "{\"not\": \"written by the gui\"}\n";
+constexpr const char* kExportedContent = "{\"exported\": true}\n";
+
+}  // namespace
+
+// Nothing at the target: the export is not a destructive act, and asking would be noise.
+TEST(ConfigJsonExportContractChain, ExportingToAFreshPathWritesWithoutAsking) {
+  const TempFile target{ std::filesystem::temp_directory_path() / "lumice_export_contract_fresh.json" };
+  std::error_code ec;
+  std::filesystem::remove(target.path, ec);
+  CancelPendingConfigJsonExport();
+  g_show_export_overwrite_confirm_popup = false;
+
+  RequestConfigJsonExport(target.path, kExportedContent);
+
+  EXPECT_FALSE(g_show_export_overwrite_confirm_popup) << "nothing was there to lose; the prompt is noise";
+  EXPECT_EQ(ReadAllBytes(target.path), kExportedContent);
+}
+
+// Something at the target: hold everything, ask, and — the part that matters — leave the file alone
+// while the question is open.
+TEST(ConfigJsonExportContractChain, ExportingOverAnExistingFileAsksBeforeWriting) {
+  const TempFile target = WriteTempFile("lumice_export_contract_existing.json", kExistingContent);
+  CancelPendingConfigJsonExport();
+  g_show_export_overwrite_confirm_popup = false;
+
+  RequestConfigJsonExport(target.path, kExportedContent);
+
+  EXPECT_TRUE(g_show_export_overwrite_confirm_popup) << "the overwrite happened without asking";
+  EXPECT_EQ(g_pending_export_json_path, target.path);
+  EXPECT_EQ(ReadAllBytes(target.path), kExistingContent) << "the file was written before the user answered";
+
+  CancelPendingConfigJsonExport();
+  g_show_export_overwrite_confirm_popup = false;
+}
+
+// Answering yes writes what was held, not what the state happens to say now.
+TEST(ConfigJsonExportContractChain, ConfirmingWritesTheHeldDocumentAndClearsThePending) {
+  const TempFile target = WriteTempFile("lumice_export_contract_confirm.json", kExistingContent);
+  CancelPendingConfigJsonExport();
+  g_show_export_overwrite_confirm_popup = false;
+  RequestConfigJsonExport(target.path, kExportedContent);
+  ASSERT_TRUE(g_show_export_overwrite_confirm_popup) << "premise: the prompt was raised";
+
+  ConfirmPendingConfigJsonExport();
+
+  EXPECT_EQ(ReadAllBytes(target.path), kExportedContent);
+  EXPECT_TRUE(g_pending_export_json_path.empty()) << "a resolved export must not stay pending";
+  EXPECT_TRUE(g_pending_export_json_content.empty());
+}
+
+// Answering no leaves the document exactly as it was — the whole reason the prompt exists.
+TEST(ConfigJsonExportContractChain, CancellingLeavesTheExistingFileUntouched) {
+  const TempFile target = WriteTempFile("lumice_export_contract_cancel.json", kExistingContent);
+  CancelPendingConfigJsonExport();
+  g_show_export_overwrite_confirm_popup = false;
+  RequestConfigJsonExport(target.path, kExportedContent);
+  ASSERT_TRUE(g_show_export_overwrite_confirm_popup) << "premise: the prompt was raised";
+  g_show_export_overwrite_confirm_popup = false;  // the render call would consume it
+
+  CancelPendingConfigJsonExport();
+
+  EXPECT_EQ(ReadAllBytes(target.path), kExistingContent);
+  EXPECT_TRUE(g_pending_export_json_path.empty());
+  EXPECT_TRUE(g_pending_export_json_content.empty());
+
+  // A cancelled export must stay cancelled: confirming afterwards has nothing held and must not
+  // fall back on some other path (the empty one, or the last one written).
+  ConfirmPendingConfigJsonExport();
+  EXPECT_EQ(ReadAllBytes(target.path), kExistingContent);
 }
 
 }  // namespace lumice::gui

--- a/test/composition-correctness/gui/test_json_document_contract_chain.cpp
+++ b/test/composition-correctness/gui/test_json_document_contract_chain.cpp
@@ -241,6 +241,19 @@ TEST(ConfigJsonExportContractChain, ConfirmingWritesTheHeldDocumentAndClearsTheP
   EXPECT_TRUE(g_pending_export_json_content.empty());
 }
 
+// What the prompt says is the point of asking. "A file already exists — overwrite?" is a question
+// about a filename, and answering it yes is not the acknowledgement the ruling asks for: the user
+// has to be told that what goes back is only the part of that document the GUI can express. Pinned
+// because wording is exactly the kind of thing a later tidy-up shortens into a generic prompt, with
+// nothing failing.
+TEST(ConfigJsonExportContractChain, TheOverwritePromptSaysWhatIsLost) {
+  const std::string text = kExportOverwriteWarningText;
+  EXPECT_NE(text.find("lost"), std::string::npos) << "must say something is lost, got: " << text;
+  EXPECT_NE(text.find("cannot represent"), std::string::npos)
+      << "must say WHAT is lost — what the GUI cannot represent — not merely that a file changes: " << text;
+  EXPECT_NE(text.find(".lmc"), std::string::npos) << "must name the lossless alternative, got: " << text;
+}
+
 // Answering no leaves the document exactly as it was — the whole reason the prompt exists.
 TEST(ConfigJsonExportContractChain, CancellingLeavesTheExistingFileUntouched) {
   const TempFile target = WriteTempFile("lumice_export_contract_cancel.json", kExistingContent);

--- a/test/composition-correctness/gui/test_json_document_contract_chain.cpp
+++ b/test/composition-correctness/gui/test_json_document_contract_chain.cpp
@@ -26,6 +26,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
@@ -496,6 +497,24 @@ namespace {
 constexpr const char* kExistingContent = "{\"not\": \"written by the gui\"}\n";
 constexpr const char* kExportedContent = "{\"exported\": true}\n";
 
+// Read back a file THE EXPORT WROTE, with line endings normalised to LF.
+//
+// `ExportConfigJson` opens its stream in text mode (`file_io.cpp`, since 3bf557fd 2026-03-19 —
+// unlike SaveLmcFile, which is explicitly binary), so on Windows the runtime translates the `\n`
+// this file hands it into `\r\n` and a byte compare against the literal fails there and only
+// there. That translation is not what these two cases are about: their proposition is that the
+// content the GUI was handed is the content that landed on disk, and the line ending is an
+// incidental of the platform's text mode.
+//
+// ⛔ Deliberately NOT used by the "source file untouched" cases below. There the byte comparison
+// IS the proposition, and it is a comparison of one file against its own earlier bytes — both
+// sides written by this file in binary, so no translation is in play to paper over.
+std::string ReadAllBytesLf(const std::filesystem::path& path) {
+  std::string s = ReadAllBytes(path);
+  s.erase(std::remove(s.begin(), s.end(), '\r'), s.end());
+  return s;
+}
+
 }  // namespace
 
 // Nothing at the target: the export is not a destructive act, and asking would be noise.
@@ -509,7 +528,7 @@ TEST(ConfigJsonExportContractChain, ExportingToAFreshPathWritesWithoutAsking) {
   RequestConfigJsonExport(target.path, kExportedContent);
 
   EXPECT_FALSE(g_show_export_overwrite_confirm_popup) << "nothing was there to lose; the prompt is noise";
-  EXPECT_EQ(ReadAllBytes(target.path), kExportedContent);
+  EXPECT_EQ(ReadAllBytesLf(target.path), kExportedContent);
 }
 
 // Something at the target: hold everything, ask, and — the part that matters — leave the file alone
@@ -539,7 +558,7 @@ TEST(ConfigJsonExportContractChain, ConfirmingWritesTheHeldDocumentAndClearsTheP
 
   ConfirmPendingConfigJsonExport();
 
-  EXPECT_EQ(ReadAllBytes(target.path), kExportedContent);
+  EXPECT_EQ(ReadAllBytesLf(target.path), kExportedContent);
   EXPECT_TRUE(g_pending_export_json_path.empty()) << "a resolved export must not stay pending";
   EXPECT_TRUE(g_pending_export_json_content.empty());
 }

--- a/test/composition-correctness/gui/test_json_document_contract_chain.cpp
+++ b/test/composition-correctness/gui/test_json_document_contract_chain.cpp
@@ -209,6 +209,27 @@ std::string DocWithCrystals(const std::string& crystals_json) {
   })";
 }
 
+// A complete, well-formed document apart from the one part the caller replaces. Every other field
+// the parse touches is stated, so a warning that appears can only be about the part under test —
+// the notice channel appends, so a document malformed in two places would let a row pass on the
+// wrong message.
+std::string DocWithParts(const char* light_source_json, const char* render_json, const char* extra_root_json) {
+  return std::string(R"({
+    "crystal": [{"id": 0, "type": "prism", "shape": {"height": 2.0, "face_distance": [1, 1, 1, 1, 1, 1]}}],
+    "filter": [],
+    "scene": {"light_source": )") +
+         light_source_json + R"(,
+              "ray_num": 1000, "max_hits": 8,
+              "scattering": [{"prob": 1.0, "entries": [{"crystal": 0, "proportion": 1.0}]}]},
+    "render": )" +
+         render_json + extra_root_json + R"(
+  })";
+}
+
+constexpr const char* kWellFormedLightSource = R"({"type": "sun", "altitude": 20, "spectrum": "D65"})";
+constexpr const char* kWellFormedRender =
+    R"([{"id": 1, "lens": {"type": "linear", "fov": 60}, "resolution": [64, 64]}])";
+
 }  // namespace
 
 // D-1, the case the ruling puts in its own severity band: `id` is the key of the map crystals are
@@ -347,6 +368,86 @@ TEST(JsonImportContractChain, AJsonPrismHMissingTypeStaysSilentUnlikeOtherShapeD
 
   EXPECT_EQ(PeekImportComplexFilterWarning().find("prism_h"), std::string::npos)
       << "prism_h is held out of the rule until core settles it; got: " << PeekImportComplexFilterWarning();
+  ClearImportComplexFilterWarning();
+}
+
+// D-4: `spectrum` is the key that decides how the rest of that object reads — a string names one of
+// the built-in spectra, an array is a discrete custom one. Absent, there is nothing to discriminate
+// on, and D65 is not the neutral answer to "which spectrum": it is a specific one, picked for the
+// user out of a document that declined to say.
+//
+// `light_source` is a singleton, so there is no collection to drop this from and no downstream
+// fallback to hand it to; what the ruling's "refuse" buys here is therefore the report, not a
+// different value. The loaded spectrum stays exactly what it is today — the silence is what ends.
+TEST(JsonImportContractChain, AJsonLightSourceMissingSpectrumWarnsAndKeepsDefault) {
+  const std::string doc = DocWithParts(R"({"type": "sun", "altitude": 20})", kWellFormedRender, "");
+
+  ClearImportComplexFilterWarning();
+  GuiState scratch;
+  ASSERT_TRUE(DeserializeFromJson(doc, scratch));
+
+  EXPECT_EQ(scratch.sun.spectrum_index, SunConfig{}.spectrum_index) << "the value it loads at is unchanged";
+  EXPECT_FLOAT_EQ(scratch.sun.altitude, 20.0f) << "premise: the light_source object was read at all";
+
+  const std::string warning = PeekImportComplexFilterWarning();
+  EXPECT_FALSE(warning.empty()) << "a spectrum was chosen for the user and never mentioned";
+  EXPECT_NE(warning.find("spectrum"), std::string::npos) << "must name the field, got: " << warning;
+  ClearImportComplexFilterWarning();
+}
+
+// D-6: same shape as D-4 one level over — `lens.type` selects the whole projection branch the
+// preview inverts, and `linear` is one specific projection rather than an absence of one. Also a
+// singleton (the GUI keeps a single renderer), so again the value stays and the silence goes.
+//
+// `fov` beside it deliberately gets no such treatment: core itself reads that one as optional, so
+// its absence is a document saying nothing, not a document being malformed.
+TEST(JsonImportContractChain, AJsonRenderLensMissingTypeWarnsAndKeepsLinear) {
+  const std::string doc =
+      DocWithParts(kWellFormedLightSource, R"([{"id": 1, "lens": {"fov": 60}, "resolution": [64, 64]}])", "");
+
+  ClearImportComplexFilterWarning();
+  GuiState scratch;
+  ASSERT_TRUE(DeserializeFromJson(doc, scratch));
+
+  EXPECT_EQ(scratch.renderer.lens_type, RenderConfig{}.lens_type) << "the value it loads at is unchanged";
+  EXPECT_FLOAT_EQ(scratch.renderer.fov, 60.0f) << "premise: the lens object was read at all";
+
+  const std::string warning = PeekImportComplexFilterWarning();
+  EXPECT_FALSE(warning.empty()) << "a projection was chosen for the user and never mentioned";
+  EXPECT_NE(warning.find("lens"), std::string::npos) << "must name the object, got: " << warning;
+  ClearImportComplexFilterWarning();
+}
+
+// D-7: a colour class with no colour. No colour is the neutral one — black and white both read as
+// deliberate choices in a composite, and a class whose colour is undefined has no rendering meaning
+// at all — so the class goes rather than getting one assigned. The file already drops whole filters
+// and whole colour refs it cannot express; this is that same move one level out.
+//
+// The z_order assertion is the second half, and it is not incidental: z_order must be a compact
+// permutation of [0, size) over the vector that actually holds the classes, so assigning it from the
+// SOURCE array index — correct only while nothing is ever dropped — would punch a hole in that
+// invariant the moment dropping became possible. Hence the surviving class is the second one, and
+// its expected z_order is 0 rather than merely "non-negative".
+TEST(JsonImportContractChain, AJsonColorClassMissingColorIsDroppedNotDefaultColored) {
+  const std::string doc = DocWithParts(kWellFormedLightSource, kWellFormedRender, R"(,
+    "raypath_color": {"mode": "painter", "classes": [
+      {"match": [{"crystal": 0, "layer": 0}]},
+      {"color": [0.25, 0.5, 0.75], "match": [{"crystal": 0, "layer": 0}]}
+    ]})");
+
+  ClearImportComplexFilterWarning();
+  GuiState scratch;
+  ASSERT_TRUE(DeserializeFromJson(doc, scratch));
+
+  ASSERT_EQ(scratch.raypath_color.size(), 1u) << "the colourless class was kept and given a colour nobody chose";
+  EXPECT_FLOAT_EQ(scratch.raypath_color.at(0).color[0], 0.25f) << "the survivor is the class that HAD a colour";
+  EXPECT_EQ(scratch.raypath_color.at(0).z_order, 0)
+      << "z_order came from the source array index, so dropping a class left a hole in a range that "
+         "must be a compact permutation of [0, size)";
+
+  const std::string warning = PeekImportComplexFilterWarning();
+  EXPECT_FALSE(warning.empty()) << "a colour class was dropped and the user was told nothing";
+  EXPECT_NE(warning.find("color"), std::string::npos) << "must name the field, got: " << warning;
   ClearImportComplexFilterWarning();
 }
 

--- a/test/composition-correctness/gui/test_json_import_contract_chain.cpp
+++ b/test/composition-correctness/gui/test_json_import_contract_chain.cpp
@@ -1,0 +1,179 @@
+// Composition chain: what importing a core JSON is allowed to touch.
+//
+// Units in the chain: app (DoOpen) × file_io (DeserializeFromJson / ParseShapeDist / the
+// downgrade counters) × gui_state.
+//
+// The GUI's expressive power is strictly smaller than the core config JSON's, so an import
+// degrades — and the owner ruling is that the degradation is confined to the copy in memory:
+//
+//   (1) The source file is not rewritten. Nothing enforces that today except that no one has
+//       written the line yet, which is not a guarantee; a later "normalize the config on load and
+//       write it back" would destroy a document the user never asked to change, and every existing
+//       test would still pass.
+//   (2) The imported .json is not the save target. Save writes .lmc — the format that CAN carry
+//       the whole GUI state — through the Save-As dialog, rather than overwriting the source with
+//       a lossy re-emission.
+//   (3) What WAS degraded reaches the user. The counter that records it is process-wide and
+//       take-on-read, so this is two propositions, not one: the load must report its own
+//       downgrades, and it must not report someone else's.
+//
+// Case (3) is why the drain discipline is pinned in both directions here. The .lmc branch has
+// carried a pre-load drain + post-load take since it was written; the .json branch had neither,
+// so its downgrades were invisible — and a post-load take added without the matching pre-load
+// drain would have made it worse than silent, attributing MakeNewDocumentState's read of the
+// user's personal defaults to whatever document happened to be opened next.
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <system_error>
+
+#include "gui/app.hpp"
+#include "gui/file_io.hpp"
+#include "gui/gui_state.hpp"
+
+namespace lumice::gui {
+namespace {
+
+// A core JSON whose crystal height is a gauss distribution: a document the GUI cannot edit as
+// written, and therefore one whose import degrades. The `%s` stand-in is the height value.
+std::string DocWithHeight(const char* height_json) {
+  return std::string(R"({
+    "crystal": [{"id": 1, "type": "prism", "shape": {"height": )") +
+         height_json + R"(, "face_distance": [1, 1, 1, 1, 1, 1]}}],
+    "filter": [],
+    "scene": {"light_source": {"type": "sun", "altitude": 20, "spectrum": "D65"},
+              "ray_num": 1000, "max_hits": 8,
+              "scattering": [{"prob": 1.0, "entries": [{"crystal": 1, "proportion": 1.0}]}]},
+    "render": [{"id": 1, "lens": {"type": "linear", "fov": 60}, "resolution": [64, 64]}]
+  })";
+}
+
+// Degrades on the way in (gauss → uniform); loads with nothing to report.
+std::string GaussHeightDoc() {
+  return DocWithHeight(R"({"type": "gauss", "mean": 2.0, "std": 0.3})");
+}
+std::string UniformHeightDoc() {
+  return DocWithHeight(R"({"type": "uniform", "mean": 2.0, "std": 0.3})");
+}
+
+// A file that removes itself, so a failing assertion cannot leave the temp directory seeded for
+// the next run.
+struct TempFile {
+  std::filesystem::path path;
+  ~TempFile() {
+    std::error_code ec;
+    std::filesystem::remove(path, ec);  // best-effort: a teardown failure must not fail the case
+  }
+};
+
+TempFile WriteTempFile(const char* name, const std::string& text) {
+  TempFile f{ std::filesystem::temp_directory_path() / name };
+  std::ofstream out(f.path, std::ios::binary);
+  out << text;
+  return f;
+}
+
+// Bytes, not a parse: the proposition is that the file on disk is the same file, which a
+// re-parse-and-compare would happily miss for any rewrite that is semantically equivalent.
+std::string ReadAllBytes(const std::filesystem::path& path) {
+  std::ifstream in(path, std::ios::binary);
+  return std::string((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+}
+
+// The GUI keeps the imported crystal's height distribution here regardless of how the document
+// spelled it; the type is what the downgrade rewrites.
+const ShapeDist& ImportedHeight() {
+  return g_state.crystals.at(0).height;
+}
+
+}  // namespace
+
+// (1) Owner principle 2, as a falsifiable guard rather than a comment.
+//
+// The premise assertions are the load-bearing half: a byte comparison over an import that did not
+// actually degrade proves nothing about the case the principle is about. So the case first shows
+// the document really was rewritten in memory (gauss became uniform), and only then that the bytes
+// behind it were left alone.
+TEST(JsonImportContractChain, ImportingAJsonThatDegradesLeavesTheSourceFileByteIdentical) {
+  const TempFile doc = WriteTempFile("lumice_json_import_contract_writeback.json", GaussHeightDoc());
+  const std::string before = ReadAllBytes(doc.path);
+  ASSERT_FALSE(before.empty()) << "premise: the fixture was written";
+
+  ClearImportComplexFilterWarning();
+  DoOpen(doc.path);
+
+  ASSERT_FALSE(g_state.crystals.empty()) << "premise: the document imported at all";
+  ASSERT_EQ(ImportedHeight().type, ShapeDistType::kUniform)
+      << "premise: this document degrades on import — without that the guard below covers nothing";
+  EXPECT_FLOAT_EQ(ImportedHeight().center, 2.0f) << "the degradation keeps the value, only the family changes";
+
+  EXPECT_EQ(ReadAllBytes(doc.path), before)
+      << "the import rewrote its own source file: a degradation is allowed to change the copy in "
+         "memory, never the document the user opened";
+}
+
+// (2) The imported .json is not the save target (app.cpp: current_file_path.clear() on the import
+// branch). The .lmc control beside it is what stops "clear the path on every open" from passing —
+// that would satisfy the .json half while breaking Save for the format that CAN hold the state.
+//
+// Only the recorded target is asserted, not the dialog that follows from it: PerformSave()'s
+// empty-path branch calls ShowSaveDialog(), a native NFD dialog that blocks and cannot be driven
+// from a windowless test. That branch therefore has no automated regression cover — a known,
+// deliberate gap recorded here rather than papered over, since the two halves of this proposition
+// are pinned unevenly.
+TEST(JsonImportContractChain, AnImportedJsonIsNotTheSaveTarget) {
+  const TempFile json_doc = WriteTempFile("lumice_json_import_contract_target.json", UniformHeightDoc());
+  ClearImportComplexFilterWarning();
+  DoOpen(json_doc.path);
+  EXPECT_TRUE(g_state.current_file_path.empty())
+      << "an imported .json became the save target, so Save would overwrite it with a lossy "
+         "re-emission instead of writing a .lmc";
+
+  const TempFile lmc_doc{ std::filesystem::temp_directory_path() / "lumice_json_import_contract_target.lmc" };
+  ASSERT_TRUE(SaveLmcFile(lmc_doc.path, g_state, g_preview, /*save_texture=*/false));
+  DoOpen(lmc_doc.path);
+  EXPECT_EQ(g_state.current_file_path, lmc_doc.path) << "a .lmc open must still set the save target";
+}
+
+// (3a) The import reports its own downgrade. Before this was wired, ParseShapeDist counted the
+// gauss→uniform rewrite and the .json branch simply never read the counter, so the user was told
+// nothing at all.
+TEST(JsonImportContractChain, ADowngradeDuringJsonImportReachesTheUser) {
+  const TempFile doc = WriteTempFile("lumice_json_import_contract_notice.json", GaussHeightDoc());
+  ClearImportComplexFilterWarning();
+  DoOpen(doc.path);
+
+  const std::string warning = PeekImportComplexFilterWarning();
+  EXPECT_FALSE(warning.empty()) << "the shape-distribution downgrade was performed but never surfaced";
+  EXPECT_NE(warning.find("uniform"), std::string::npos) << "must name what happened, got: " << warning;
+  ClearImportComplexFilterWarning();
+}
+
+// (3b) …and only its own. The counter is process-wide and take-on-read, so anything that ran the
+// deserializer earlier — MakeNewDocumentState reading the user's personal defaults is the real
+// instance, and is unreachable from here — leaves a count that a bare post-load take would hand to
+// this document. Seeding it through a direct DeserializeFromJson reproduces exactly that state.
+//
+// This is the case that fails for an AC4 fix that adds the post-load take without the pre-load
+// drain: the import below degrades nothing, and must therefore say nothing.
+TEST(JsonImportContractChain, AJsonImportDoesNotInheritAnEarlierReadsDowngrade) {
+  GuiState scratch;
+  ASSERT_TRUE(DeserializeFromJson(GaussHeightDoc(), scratch)) << "premise: the seeding read succeeds";
+  ASSERT_EQ(scratch.crystals.at(0).height.type, ShapeDistType::kUniform)
+      << "premise: the seeding read left a downgrade count behind";
+
+  const TempFile doc = WriteTempFile("lumice_json_import_contract_carryover.json", UniformHeightDoc());
+  ClearImportComplexFilterWarning();
+  DoOpen(doc.path);
+
+  ASSERT_EQ(ImportedHeight().type, ShapeDistType::kUniform);
+  EXPECT_TRUE(PeekImportComplexFilterWarning().empty())
+      << "this document degraded nothing; the notice describes an earlier read: " << PeekImportComplexFilterWarning();
+  ClearImportComplexFilterWarning();
+}
+
+}  // namespace lumice::gui

--- a/test/composition-correctness/gui/test_legacy_document_chain.cpp
+++ b/test/composition-correctness/gui/test_legacy_document_chain.cpp
@@ -197,19 +197,27 @@ const LegacyDocCase kGuiNativeCases[] = {
       EXPECT_EQ(f.EntryExitParamsValue().exit_text, std::string("4"));
     } },
 
-  // The Direction filter type was removed from the GUI. A file still carrying one must degrade to a
-  // filter that matches everything rather than to a filter that matches nothing — and the crystal
-  // beside it, which is fine, must survive either way.
-  { "removed direction filter degrades to an empty raypath",
+  // The Direction filter type was removed from the GUI. No reader here can turn a file still
+  // carrying one into a predicate, so the entry degrades to having no filter — and the crystal
+  // beside it, which is fine, survives.
+  //
+  // The degradation used to be "a filter holding an empty raypath", chosen so the entry let
+  // everything through rather than nothing. It let everything through only under filter_in: the
+  // same shape is the editor's match-all, and match-all under filter_out excludes every ray. Having
+  // no filter is the disposition that is harmless under both, and it is indistinguishable from the
+  // old one in the filter_in picture this case was written about.
+  { "removed direction filter degrades to no filter at all",
     R"({"schema_version": 2, "layers": [{"prob": 0.0, "entries": [{
         "crystal": {"type": "prism", "shape": {"height": 1.0}}, "proportion": 100.0,
         "filter": {"type": "direction", "action": "filter_in", "az": 30.0, "el": 15.0}}]}]})",
     [](const GuiState& s) {
       ASSERT_EQ(s.layers.at(0).entries.size(), 1u);
-      ASSERT_TRUE(s.layers[0].entries[0].filter_id.has_value());
-      const FilterConfig& f = s.filters.at(*s.layers[0].entries[0].filter_id);
-      EXPECT_TRUE(f.IsRaypath());
-      EXPECT_TRUE(f.RaypathText().empty());
+      EXPECT_FALSE(s.layers[0].entries[0].filter_id.has_value());
+      EXPECT_TRUE(s.filters.empty());
+      // The crystal is the other half of the claim: degrading the filter must not take the entry's
+      // crystal with it.
+      ASSERT_EQ(s.crystals.size(), 1u);
+      EXPECT_EQ(s.crystals.at(0).type, CrystalType::kPrism);
     } },
 };
 

--- a/test/composition-correctness/gui/test_scene_commit_chain.cpp
+++ b/test/composition-correctness/gui/test_scene_commit_chain.cpp
@@ -624,6 +624,10 @@ TEST(SceneCommitChain, AFilterReadFromAFileWithNoPredicateInItCommitsAsNoFilter)
     { "legacy filter with no raypath_text", R"({"type": "raypath", "action": "filter_out"})" },
     { "filter object with nothing in it", R"({"action": "filter_out"})" },
     { "removed direction filter", R"({"type": "direction", "action": "filter_out", "az": 30.0, "el": 15.0})" },
+    // Same γ-class question as the raypath row above, on the entry_exit arm instead:
+    // FromLegacyEntryExit used to build the single-row match-all shape even when
+    // entry_text/exit_text/length were all absent.
+    { "legacy entry_exit filter naming neither face nor length", R"({"type": "entry_exit", "action": "filter_out"})" },
   };
 
   // The baseline this is compared against: the same document with no `filter` key on the entry.

--- a/test/composition-correctness/gui/test_scene_commit_chain.cpp
+++ b/test/composition-correctness/gui/test_scene_commit_chain.cpp
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include "gui/app.hpp"
+#include "gui/color_window.hpp"
 #include "gui/crystal_preview.hpp"
 #include "gui/file_io.hpp"
 #include "gui/gui_state.hpp"
@@ -596,6 +597,120 @@ TEST(SceneCommitChain, AFilterOutRowLeftBlankDoesNotExcludeEveryRay) {
   EXPECT_EQ(filters[0]["type"].get<std::string>(), "raypath");
   EXPECT_EQ(filters[0]["action"].get<std::string>(), "filter_out");
   EXPECT_EQ(filters[0]["raypath"], nlohmann::json({ 3, 5 }));
+}
+
+// The same statement, made about the OTHER way a filter enters the document: off disk.
+//
+// The three cases above are all about a filter the user built in the editor, where the blank rows
+// carry no factor at all and the expansion drops them. A filter read from a `.lmc` reaches the same
+// question by a different route and used to answer it differently: when the file said nothing a
+// reader could turn into a predicate, the parser wrote a 1-row / 1-factor SoP holding an empty
+// raypath — a row that DOES carry a factor, which is the editor's match-all, which under filter_out
+// excludes every ray and renders a black frame.
+//
+// Each row below is a distinct branch of that parser, not a restatement: an empty `summands` array
+// (the v3 shape), a legacy filter whose `raypath_text` key is absent, a filter object with nothing
+// in it at all, and a `direction` filter — a type the GUI removed, so no reader can produce a
+// predicate from it either. All four are the same γ-class question (450.2 adjudication 5: illegal
+// input in the GUI's own format, with no core semantics to align to) and take the same answer
+// (adjudication 6: drop the predicate, do not pick a value for it).
+TEST(SceneCommitChain, AFilterReadFromAFileWithNoPredicateInItCommitsAsNoFilter) {
+  struct Case {
+    const char* name;
+    const char* filter_json;
+  };
+  const Case kCases[] = {
+    { "v3 empty summands array", R"({"summands": [], "action": "filter_out"})" },
+    { "legacy filter with no raypath_text", R"({"type": "raypath", "action": "filter_out"})" },
+    { "filter object with nothing in it", R"({"action": "filter_out"})" },
+    { "removed direction filter", R"({"type": "direction", "action": "filter_out", "az": 30.0, "el": 15.0})" },
+  };
+
+  // The baseline this is compared against: the same document with no `filter` key on the entry.
+  // Asserted as equality with that scene rather than as a list of properties, so "no filter" cannot
+  // quietly become a third state that merely looks empty from the angles a property list checks.
+  const std::string kDocPrefix =
+      R"({"schema_version": 3, "layers": [{"prob": 0.0, "entries": [{
+          "crystal": {"type": "prism", "shape": {"height": 1.0, "face_distance": [1,1,1,1,1,1]}},
+          "proportion": 100.0)";
+  const std::string kDocSuffix = R"(}]}]})";
+
+  GuiState without;
+  ASSERT_TRUE(DeserializeGuiStateJson(kDocPrefix + kDocSuffix, without)) << "the no-filter baseline did not load";
+  ASSERT_FALSE(without.layers.at(0).entries.at(0).filter_id.has_value());
+  const nlohmann::json baseline = CommitSceneJson(without);
+  ASSERT_FALSE(baseline.is_null()) << "the no-filter baseline did not commit";
+
+  for (const Case& c : kCases) {
+    GuiState loaded;
+    const std::string doc = kDocPrefix + R"(, "filter": )" + c.filter_json + kDocSuffix;
+    if (!DeserializeGuiStateJson(doc, loaded)) {
+      ADD_FAILURE() << c.name << ": the document did not load at all";
+      continue;  // nothing to inspect for this case; the rest still get checked
+    }
+    if (loaded.layers.size() != 1u || loaded.layers.at(0).entries.size() != 1u) {
+      ADD_FAILURE() << c.name << ": the document did not load as one layer of one entry";
+      continue;  // no entry to inspect for this case; the rest still get checked
+    }
+
+    // The document side: the entry points at no filter, and no filter was put in the pool for it.
+    EXPECT_FALSE(loaded.layers[0].entries[0].filter_id.has_value())
+        << c.name << ": the entry was given a filter the file did not describe";
+    EXPECT_TRUE(loaded.filters.empty()) << c.name << ": a filter with no predicate in it entered the pool";
+
+    // The simulator side: the scene is the one the file describes, which is the one with no filter.
+    const nlohmann::json scene = CommitSceneJson(loaded);
+    if (scene.is_null()) {
+      ADD_FAILURE() << c.name << ": the loaded document did not commit at all";
+      continue;  // no scene to read for this case; the rest still get checked
+    }
+    for (const nlohmann::json& jf : scene["filter"]) {
+      EXPECT_NE(jf.value("type", std::string{}), std::string("none"))
+          << c.name << ": filter_out was handed a match-all term — every ray is excluded: " << jf.dump();
+    }
+    EXPECT_TRUE(scene["filter"].empty()) << c.name << ": " << scene["filter"].dump();
+    EXPECT_EQ(scene["scene"]["scattering"], baseline["scene"]["scattering"])
+        << c.name << ": the entry landed in a third state, neither a filter nor the absence of one";
+  }
+}
+
+// The sentinel for the shape that keeps coming back: a filter in the pool that states nothing, with
+// an entry pointing at it.
+//
+// Every path that builds one has been closed — the editor strips blank rows before committing, and
+// the loader now returns no filter rather than an empty one — so this state is not reachable from
+// the product today. It is pinned anyway, because "not reachable" is a fact about the current set of
+// construction sites and the shape's whole history is of being reconstructed at a new one. What is
+// asserted is that the CONSUMERS are safe if it ever is: neither of them may read "says nothing" as
+// "matches everything". If a fourth construction site appears, that is a bug about the entry
+// pointing at a filter it should not; it must not also be a black frame.
+TEST(SceneCommitChain, APoolFilterStatingNothingIsNeverReadAsMatchAll) {
+  SeedOneEntryDocument();
+  ASSERT_TRUE(g_state.layers.at(0).entries.at(0).filter_id.has_value())
+      << "the seeded document has no filter to empty out";
+  g_state.filters[0] = FilterConfig{};  // states nothing, and the entry still points at it
+  g_state.filters[0].action = 1;        // filter_out — the action under which match-all hides all
+  ASSERT_TRUE(g_state.filters[0].param.empty()) << "a default FilterConfig is no longer the empty statement";
+
+  // Consumer 1, the commit path: no term matching every ray reaches the scene, and the entry
+  // commits with nothing attached.
+  const nlohmann::json scene = CommitSceneJson(g_state);
+  ASSERT_FALSE(scene.is_null()) << "the document did not commit at all";
+  for (const nlohmann::json& jf : scene["filter"]) {
+    EXPECT_NE(jf.value("type", std::string{}), std::string("none"))
+        << "filter_out was handed a match-all term — every ray is excluded: " << jf.dump();
+  }
+  EXPECT_TRUE(scene["filter"].empty()) << scene["filter"].dump();
+  EXPECT_FALSE(scene["scene"]["scattering"][0]["entries"][0].contains("filter"))
+      << scene["scene"]["scattering"][0]["entries"][0].dump();
+
+  // Consumer 2, the color-class import: the same filter read as color refs must produce no ref
+  // rather than one whose match_all is set — that flag is this consumer's spelling of the same
+  // "matches everything" the term above would have been.
+  int skipped = 0;
+  const ColorClassConfig cls = BuildClassFromFilter(0, 0, g_state.filters[0], skipped);
+  EXPECT_TRUE(cls.match.empty()) << "a filter that states nothing was imported as " << cls.match.size() << " ref(s)";
+  EXPECT_EQ(skipped, 0) << "nothing was there to skip";
 }
 
 }  // namespace

--- a/test/gui/functional/test_edit_modal.cpp
+++ b/test/gui/functional/test_edit_modal.cpp
@@ -2123,7 +2123,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
                      "sync_group": {"height": 1, "face_distance": [1,0,0,0,0,0]}}}
         ],
         "scene": {
-          "light_source": {"altitude": 20.0, "diameter": 0.5},
+          "light_source": {"altitude": 20.0, "diameter": 0.5, "spectrum": "D65"},
           "ray_num": 1000,
           "max_hits": 8,
           "scattering": [

--- a/test/gui/functional/test_file_ops.cpp
+++ b/test/gui/functional/test_file_ops.cpp
@@ -23,8 +23,11 @@
 
 #include <chrono>
 #include <cstdio>
+#include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <string>
+#include <system_error>
 #include <thread>
 #include <vector>
 
@@ -802,6 +805,58 @@ void RegisterFileOpsTests(ImGuiTestEngine* engine) {
       // And it stays closed: the trigger is the queued message, not a flag that survives the modal.
       ctx->Yield(4);
       IM_CHECK(!ImGui::IsPopupOpen("Import Warning"));
+    };
+  }
+
+  // Exporting the config over a file that already exists asks first, and the answer decides what is
+  // on disk. Both answers are driven through the real modal because that is the only thing a
+  // composition test cannot say: RequestConfigJsonExport raising a flag proves nothing if no frame
+  // renders the prompt, and an export that quietly never happens looks the same to the user as one
+  // that silently overwrote their config — the two failures this case separates.
+  //
+  // Whether a given path needs confirming at all, and what "confirm" writes, is settled in
+  // composition-correctness/gui/test_json_document_contract_chain.cpp; the export is requested here
+  // directly through the same entry point the file dialog uses, since the dialog itself blocks.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "file_ops", "exporting_over_an_existing_config_asks_before_overwriting");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+
+      const std::filesystem::path path = GuiTestTempPath("export_overwrite_confirm.json");
+      const char* const kExisting = "{\"not\": \"written by the gui\"}\n";
+      const char* const kExported = "{\"exported\": true}\n";
+      const auto write_existing = [&] {
+        std::ofstream out(path, std::ios::binary);
+        out << kExisting;
+      };
+      const auto read_back = [&] {
+        std::ifstream in(path, std::ios::binary);
+        return std::string((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+      };
+
+      // Cancel: the prompt appears, and the document it was protecting is still there afterwards.
+      write_existing();
+      gui::RequestConfigJsonExport(path, kExported);
+      ctx->Yield(2);
+      IM_CHECK(ImGui::IsPopupOpen("Overwrite Config File"));
+      ctx->ItemClick("Overwrite Config File/Cancel");
+      ctx->Yield(2);
+      IM_CHECK(!ImGui::IsPopupOpen("Overwrite Config File"));
+      IM_CHECK_STR_EQ(read_back().c_str(), kExisting);
+
+      // Overwrite: the same prompt, the other button, and the export actually lands. Without this
+      // half, a prompt whose confirm branch does nothing would read as the feature working.
+      gui::RequestConfigJsonExport(path, kExported);
+      ctx->Yield(2);
+      IM_CHECK(ImGui::IsPopupOpen("Overwrite Config File"));
+      ctx->ItemClick("Overwrite Config File/Overwrite");
+      ctx->Yield(2);
+      IM_CHECK(!ImGui::IsPopupOpen("Overwrite Config File"));
+      IM_CHECK_STR_EQ(read_back().c_str(), kExported);
+
+      std::error_code ec;
+      std::filesystem::remove(path, ec);  // best-effort: a teardown failure must not fail the case
     };
   }
 

--- a/test/gui/test_gui_main.cpp
+++ b/test/gui/test_gui_main.cpp
@@ -157,6 +157,11 @@ void ResetTestState() {
   // its modal on top of whatever the next case is driving. Several suites import configurations
   // that queue one as a side effect, which is why this is a reset rather than each case's job.
   gui::ClearImportComplexFilterWarning();
+  // Same shape again, for the export-overwrite prompt: a pending export left unanswered by one
+  // case would raise its modal over the next one, and — worse than a stray warning — the next
+  // case's stray click on "Overwrite" would write a file.
+  gui::g_show_export_overwrite_confirm_popup = false;
+  gui::CancelPendingConfigJsonExport();
   gui::g_server_poller.Stop();  // Stop poller before nulling server
   // task-349.4: Stop() only kPaused the worker — the last published PreviewSnapshot
   // survives (production keeps it on purpose for slider-scrub carry-forward, see
@@ -640,6 +645,11 @@ int main(int argc, char** argv) {
     // a modal already on screen, so the case that opens this one dismisses it through its own OK
     // button — an open modal swallows every subsequent ItemClick in the process.
     gui::RenderImportWarningPopup();
+    // The export-overwrite prompt, mirrored here from the same block of src/gui/main.cpp. A
+    // confirmation modal that only the product's loop renders is a confirmation no test can drive
+    // — and "the prompt never appeared, so the export silently did not happen" is precisely the
+    // failure mode it exists to prevent, so it has to be reachable from here.
+    gui::RenderExportOverwriteConfirmPopup();
     // Mirrors src/gui/main.cpp: a Render*Panel that only the production loop calls is
     // unreachable for every gui_test ("Unable to locate item"), a failure this repo has
     // already paid for twice.

--- a/test/unit-correctness/config/test_json.cpp
+++ b/test/unit-correctness/config/test_json.cpp
@@ -108,6 +108,33 @@ TEST(LightSourceSpectrum, IlluminantRoundTrip) {
   ASSERT_EQ(j_out["spectrum"].get<std::string>(), "D65");
 }
 
+// `spectrum` written as neither a string nor an array is rejected. It used to log an error and
+// carry on, which left `spectrum_` holding its default-constructed alternative: an EMPTY
+// wavelength table, i.e. a light source that emits nothing. Nothing downstream treated that as a
+// failure, so the run proceeded on a scene nobody wrote.
+//
+// Asserting the message, not merely the throw: a scene has one light source, so no caller adds a
+// `crystal[id=N]`-style prefix and the field has to name itself.
+TEST_F(V3TestJson, LightSource_SpectrumInvalidFormatRejected) {
+  for (const nlohmann::json bad : { nlohmann::json(42), nlohmann::json(true), nlohmann::json(nullptr) }) {
+    SCOPED_TRACE(bad.dump());
+    auto j = config_json_;
+    j.at("scene").at("light_source").at("spectrum") = bad;
+
+    try {
+      (void)j.get<ConfigManager>();
+      FAIL() << "expected std::invalid_argument for a spectrum that is neither a string nor an array";
+    } catch (const std::invalid_argument& e) {
+      const std::string msg = e.what();
+      EXPECT_NE(msg.find("light_source.spectrum"), std::string::npos) << msg;  // which field
+      EXPECT_NE(msg.find(bad.dump()), std::string::npos) << msg;               // what arrived
+      // Both legal ways to write it — the migration guidance, not decoration.
+      EXPECT_NE(msg.find("\"D65\""), std::string::npos) << msg;
+      EXPECT_NE(msg.find("\"wavelength\""), std::string::npos) << msg;
+    }
+  }
+}
+
 
 // =============== SPD Query ===============
 TEST(IlluminantSpd, D65At560nm) {
@@ -285,6 +312,54 @@ TEST_F(V3TestJson, Crystal_ShapeScalarObjectMissingTypeRejected) {
     // one it is on. The generic form still shows both legal ways to write it, which is the part
     // that has to be there.
     EXPECT_NE(msg.find("\"type\": \"gauss\""), std::string::npos) << msg;
+  }
+}
+
+// A `type` that names neither crystal kind is rejected. It used to log an error and carry on with
+// `param_` left default-constructed — so a config asking for a gauss-height prism got a plain
+// 1.0-height one, and the only trace was a log line no caller treated as a failure.
+TEST_F(V3TestJson, Crystal_UnknownTypeValueRejected) {
+  auto j = config_json_;
+  j.at("crystal")[1].at("type") = "cube";
+
+  try {
+    (void)j.get<ConfigManager>();
+    FAIL() << "expected std::invalid_argument for an unknown crystal type";
+  } catch (const std::invalid_argument& e) {
+    const std::string msg = e.what();
+    EXPECT_NE(msg.find("crystal[id=2]"), std::string::npos) << msg;  // which crystal (outer wrap)
+    EXPECT_NE(msg.find("\"cube\""), std::string::npos) << msg;       // what arrived
+    // Both legal values — the migration guidance, not decoration.
+    EXPECT_NE(msg.find("\"prism\""), std::string::npos) << msg;
+    EXPECT_NE(msg.find("\"pyramid\""), std::string::npos) << msg;
+  }
+}
+
+// A distribution slot that is neither a number nor an object is rejected. It used to log an error
+// and leave `dist` holding whatever the destination already carried, so the written value vanished
+// without any downstream treating it as a failure.
+//
+// The axis slots (zenith/azimuth/roll) share this rejection: ParseAxisSlot's own narrowing only
+// covers "object with no type" and forwards everything else to the same Distribution::from_json.
+// So this is pinned once, on a shape scalar, rather than repeated per slot — same reasoning as
+// Crystal_ShapeScalarObjectMissingTypeRejected above.
+TEST_F(V3TestJson, Crystal_ShapeScalarNeitherNumberNorObjectRejected) {
+  for (const nlohmann::json bad : { nlohmann::json("tall"), nlohmann::json(true), nlohmann::json({ 1, 2, 3 }) }) {
+    SCOPED_TRACE(bad.dump());
+    auto j = config_json_;
+    j.at("crystal")[1].at("shape").at("height") = bad;
+
+    try {
+      (void)j.get<ConfigManager>();
+      FAIL() << "expected std::invalid_argument for a shape.height that is neither number nor object";
+    } catch (const std::invalid_argument& e) {
+      const std::string msg = e.what();
+      EXPECT_NE(msg.find("crystal[id=2]"), std::string::npos) << msg;  // which crystal (outer wrap)
+      EXPECT_NE(msg.find(bad.dump()), std::string::npos) << msg;       // what arrived
+      // No slot name: this layer serves every distribution in the document and does not know which
+      // one it is on. The generic form still shows both legal ways to write it.
+      EXPECT_NE(msg.find("\"type\": \"gauss\""), std::string::npos) << msg;
+    }
   }
 }
 

--- a/test/unit-correctness/gui/test_filter_sop_grammar.cpp
+++ b/test/unit-correctness/gui/test_filter_sop_grammar.cpp
@@ -204,6 +204,18 @@ TEST(FilterSopAc1, FromLegacyEntryExitIsSingleRowAllModes) {
   }
 }
 
+// A wildcard EE (no entry, no exit, no length constraint) states no predicate at all, and
+// FromLegacyEntryExit now answers that the same way FromLegacyRaypath answers an empty
+// raypath_text above ("" -> {} case): zero rows, which is "no filter" in the type's own
+// vocabulary. It used to produce the single-row match-all shape unconditionally — a legacy .lmc's
+// entry_exit filter naming neither face nor length came back as a filter matching everything, and
+// under filter_out that excluded every ray.
+TEST(FilterSopAc1, FromLegacyEntryExitIsEmptyWhenNothingIsStated) {
+  EXPECT_TRUE(FromLegacyEntryExit(Ee("")).empty());
+  // A length constraint alone is still a real predicate, not the wildcard shape.
+  EXPECT_FALSE(FromLegacyEntryExit(Ee("", "", /*mode=*/1, /*min_len=*/2, /*max_len=*/2)).empty());
+}
+
 // ===========================================================================
 // AC2 — operator== sensitivity (AS-DESIGNED semantics)
 // ===========================================================================

--- a/test/unit-correctness/gui/test_filter_sop_grammar.cpp
+++ b/test/unit-correctness/gui/test_filter_sop_grammar.cpp
@@ -129,9 +129,11 @@ TEST(FilterSopAc1, FromLegacyRaypathFansOutToOneRowPerSegment) {
   const Case kCases[] = {
     { "3-5; 1-3", { "3-5", "1-3" } },
     { "3-5", { "3-5" } },
-    // Empty legacy raypath -> the "no filter" degenerate SoP: 1 row holding 1 empty raypath factor,
-    // which is the FilterConfig default state. Zero rows is not a valid filter.
-    { "", { "" } },
+    // Empty legacy raypath -> zero rows, which is "no filter" said in the type's own vocabulary and
+    // is also the FilterConfig default. It used to produce one row holding one empty raypath factor
+    // instead; that row is not "no filter" but the editor's match-all, and a filter_out entry
+    // wearing it excludes every ray.
+    { "", {} },
   };
   for (const Case& c : kCases) {
     SumOfProducts sop = FromLegacyRaypath(Rp(c.text));
@@ -293,12 +295,23 @@ TEST(FilterSopAc2, FilterConfigFieldSensitivity) {
 
 // --- default construction + compat accessors (data-model contract) ---------
 
-TEST(FilterSopModel, DefaultIsEmptyRaypathNoFilter) {
+// A default-constructed FilterConfig states nothing, and "nothing" is the empty SoP rather than a
+// row that happens to say everything.
+//
+// The distinction is the whole point. This used to default to one row holding one empty raypath
+// factor, on the reading that "empty raypath ≡ no filter" — true in pre-variant builds, false since
+// a factor with empty text became the editor's match-all. Under that default a FilterConfig nobody
+// filled in commits as core's `none`, which under filter_out excludes every ray. The compat
+// accessors are asserted to agree: a filter that says nothing is not a degenerate single factor, so
+// IsRaypath()/IsEntryExit() — questions about WHICH single factor it is — are both false.
+TEST(FilterSopModel, DefaultIsEmptySopNoFilter) {
   FilterConfig f;
-  EXPECT_TRUE(f.IsDegenerateSingleFactor());
-  EXPECT_TRUE(f.IsRaypath());
+  EXPECT_TRUE(f.param.empty());
+  EXPECT_FALSE(f.IsDegenerateSingleFactor());
+  EXPECT_FALSE(f.IsRaypath());
   EXPECT_FALSE(f.IsEntryExit());
-  EXPECT_TRUE(f.RaypathText().empty());
+  // RaypathText() / DegenerateFactor() are deliberately NOT called: they assert on a non-degenerate
+  // SoP, and this state is the reason that assert exists.
 }
 
 TEST(FilterSopModel, SetRaypathCompatWriter) {


### PR DESCRIPTION
以 core 为参照系统性清理「GUI 加载它表达不了 / 非法的输入时，替用户静默挑一个语义」这类隐患。

立项时只记录了 2 个实例；按「先普查再处置」的顺序做下来，查出 **7 条**，code-review 又挖出第 8 条——
而且形态不是零散缺陷，是**两个解析器的结构性不对称**：core 把大量字段声明为必填（`.at()`，缺失即抛），
GUI 几乎一律 `contains()` / `.value(k, default)` 守卫后静默取默认 ⇒ GUI 静默接受一大类 core 会拒绝的文档。

## 最说明问题的一条

`ParseAxisDist` 对「分布对象缺 `type`」响亮降级并写明理由；**同一个文件里的 `ParseShapeDist`
对同一输入形态静默取默认**。而 core 的 `Distribution::from_json` 注释逐字声明两者同属一条规则
（"one entry point, one rule"，且点名 shape scalars 在范围内）——core 已经统一，GUI 只统一了一半。

## 改了什么

- **GUI 侧**：晶体缺 `id`/`type`、pyramid 缺 `prism_h`、`light_source.spectrum` 缺失、
  `shape.*` 分布对象缺 `type`、`render.lens.type` 缺失、颜色类缺 `color` —— 逐条按判据处置；
  「没有规则的 filter」不再被读成 match-all（`filter_out` 下会全黑）。
- **core 侧**（单独 commit `c49d1c5e`，便于独立回退）：三处「记了 `LOG_ERROR` 却照常解析」
  改为真的拒绝——未知 crystal type / 非法 spectrum 格式 / 无法识别的 distribution。
  ⚠️ 这是**用户可见的接受面变化**：CLI 会开始拒绝今天能跑的畸形配置。
  仓内语料实测零命中（71 篇 json + C++/Python 内嵌语料，0/0/0），野外用户手写 json 不可知。
- **契约**：降级只改内存副本、不回写源文件；导出覆盖已存在的 config JSON 须显式确认；
  加载期降级信息接进既有 Downgrade / surfacing 通道。

## 判据

`判别式 ∧ 无中性元 ⇒ 拒绝`。「以 core 的实现为准」在讨论中被降格为口语化说法——
core 与 GUI 都对齐到判据，而不是 GUI 单方面对齐 core（core 那三处正是据此修的）。

## 验证

- 六轮 code-review 全部 APPROVE，0 Critical / 0 Major
- 每条修复都有红态探针：先钉住今天的静默行为，再修，确认由红转绿
- rebase 到 main 顶端后完整重建 + `./scripts/test.sh quick`：三层全 PASS，gui_test 287/287

## ⚠️ 已知边界

- **7 条是下界**：扫描器有四条已知盲区（尤其 `switch` 的 `default:` 完全未覆盖）；
  第 8 条正是由 code-review 而非普查发现的。⛔ 不应理解为「该类问题已清零」。
- 后续建议：在 `composition-correctness/gui` 落一条 parity 测试，
  不变量＝**「core 拒绝 ⇒ GUI 不得*静默*接受」**（不是「接受面一致」——那会把有意保留的
  更宽松行为报成假阳）。零新增基建：`composition_correctness_test` 已同时链两侧。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
