### PR TITLE
docs: make a completeness claim carry the same burden of proof as adding code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -499,3 +499,25 @@ owner already settled. Avoid it:
 - **Think at the architecture level before decomposing into tasks.** The task/scrum
   machinery rewards fast decomposition and immediate action; resist acting on the first
   promising small direction before the architecture-level question is reasoned through.
+- **A completeness claim carries the same burden of proof as adding code.** "Covers all
+  20 panels with zero omissions", "orthogonal", "closed", "every proposition enumerated"
+  read as achievements and pass review unchallenged, while their opposites ("this class is
+  not worth covering", "50 cases is enough here") have to be argued for. That asymmetry is
+  the default state, not a choice anyone makes, so completeness wins every conflict without
+  a single person advocating for it — including conflicts against the task's own declared
+  budget. Measured instance, PR #261: the pre-committed target was −30% de-commented test
+  lines against a baseline of 21,336 pinned by two independent counters
+  (`scripts/count_gui_test_lines.py` and `cloc --by-file`, 52/52 files zero diff). It
+  landed at −8.7%, and the coverage backfill demanded by "20 panels, zero omissions"
+  accounts for 1,000–1,500 lines, roughly a third of the miss — the work shape was spending
+  against the metric the same task had committed to. Escape-defect density over those same
+  files had already been measured before the partition was drawn and spans 8× (47.2 vs 6.2
+  defects per kloc); the equal-weight-per-panel split discarded that measurement.
+  So: when a plan, a scope statement, or a review comment asserts coverage of an enumerated
+  surface, it must say why each member is worth covering. Where a per-member value measure
+  exists or is cheap to obtain (escape-defect density, call-site count, blast radius, user
+  reachability), an equal-weight partition needs a stated reason — "it is the whole set" is
+  not one. This puts the burden of proof on the side that adds and the side that persists,
+  which is where it belongs, and which completeness normally escapes. It is **not** a
+  mandate to cut: whether a leaner suite would have let more defects escape is a
+  counterfactual and untestable. What is required is the justification, not the reduction.


### PR DESCRIPTION
## 背景

复盘 v4.4.1 以来的 25 个 PR 时发现的一个结构性不对称：**完备性词汇在评审里享有默认权威，ROI 词汇没有。**

"零遗漏 / 全覆盖 / 正交 / 闭合" 写进 issue 就是成绩，评审只会问够不够彻底；而 "这类不值得测 / N=50 就够" 需要写论证、需要顶住评审、说不清就被判为偷工。这个方向和"举证责任在增加与存续的一方"是反的，而且它**不需要任何人主动争取——它是默认值**，所以两者冲突时完备性总是不战而胜。

## 实例（PR #261）

不是假设风险，是实测：

| | |
|---|---|
| 事前承诺目标 | 去注释测试行 **−30%**（基线 21,336，`scripts/count_gui_test_lines.py` + `cloc --by-file` 两把独立尺子交叉钉死，52/52 文件零差异）|
| 终值 | **−8.7%** |
| 其中「20 个面板零遗漏」要求的补覆盖 | **1,000–1,500 行 ≈ 缺口的 1/3** |
| 同批文件的逃逸缺陷密度 | **差 8×**（47.2 vs 6.2 缺陷/kloc），**在切分画出来之前就已测好**，被按面板均摊丢弃 |

也就是说：工作形状在花掉同一个任务自己承诺的指标，而做 ROI 分层所需的数据已经付费买到、然后没被使用。

## 本 PR 加的规则

断言覆盖某个枚举面时，须说明每个成员为何值得覆盖。在有（或容易拿到）逐成员价值度量的地方——逃逸缺陷密度、调用点数、影响半径、用户可达性——**等权切分需要给出理由，"因为它是全集"不算理由**。

明确写入了边界：**不是一律砍**。"更精简的套件是否会漏更多缺陷"是反事实、测不了，所以要求的是论证，不是缩减。

## 范围与限制

- 单文件 22 行 prose，`AGENTS.md` 的 Knowledge Base & Working Discipline 段末尾，紧接"先想架构再拆任务"——同一层的约束。
- 引用只用永久锚点（PR 号、`scripts/` 路径、工具名），无 scratchpad 制品，无 axiom ID（后者只存在于私有配置，写进 tracked 文件对他人是悬空引用）。
- ⚠️ **这是软约束，没有门禁执行它。** `check_new_refs.py` 对本次改动报 `0 added prose line(s) scanned`，因为 `AGENTS.md` 在 `EXCLUDED_PATHS` 里（`scripts/check_new_refs.py:101`）——那个绿不构成文本合规的证据。
- 配套的两条有牙齿的机制（放弃清单须活到 closeout、事前指标短 1.5× 时禁止直接收口）涉及 SKILL 改动，owner 决定先观察一段时间，不在本 PR 内。

## 验证

四闸全绿（pre-commit hook 实跑）：policy / new-refs / new-gui-test / loop-fatal-assert。无代码改动，不涉及构建与测试。

**观察期信号**：下一个 plan 里出现"零遗漏 / 全覆盖 / 所有 N 个"时，评审有没有问"为什么这 N 个都值得"。问了说明约定起作用；没问说明它需要变成闸。

🤖 Generated with [Claude Code](https://claude.com/claude-code)