### PR TITLE
fix(test): 把 setenv/unsetenv 的 #ifdef 收敛成一个有名字的 helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,15 @@ CMake build tree is `build/cmake_build/<flavor>/` and compiler output lands in
   (centralized + logged on startup) and test/build infra. All `LUMICE_*` env reads live in
   `src/util/env_knobs.cpp` and are enforced by `scripts/check_policies.py` (CI `policy` job +
   local pre-commit hook, installed via `./scripts/install-hooks.sh`).
+  The **write** side has its own single owner, on the test side only: a test that has to set or
+  clear a variable calls `lumice::test::SetEnvVar` / `UnsetEnvVar` from `test/support/env_var.hpp`,
+  which is the one place in the tree holding the `_WIN32` branch (`_putenv_s` vs POSIX
+  `setenv`/`unsetenv` — MSVC declares neither of the latter two). This is not enforced by a
+  checker, deliberately: a bare `::setenv` is a *compile error* on MSVC, not a silent failure,
+  which is the line the other four gates are drawn on. What it is not, is a compile error you
+  will see — the two CUDA sources that first hit it sat behind `#if LUMICE_CUDA_ENABLED` and the
+  Metal ones behind `#if defined(__APPLE__)`, so the breakage was invisible for three weeks until
+  a Windows host built with both CUDA and `BUILD_TEST` on. `src/` never writes env vars at all.
 - Working-note references: prose in a tracked file must not cite `scratchpad/` artifacts —
   task ids (`task-<name>`, `explore-<name>`, `scrum-<name>`, `chore-<name>`), per-task note
   filenames (`plan.md`, `progress.md`, `SUMMARY.md`), `code-review-0N`, `round-N`, or
@@ -467,9 +476,11 @@ Valuable design/architecture docs live in `doc/` (tracked). Consult the relevant
     `LUMICE_HAS_CUDA` un-skip 闸（须与 `LUMICE_CUDA_ENABLED` **同设**，二者语义不同）、
     parity battery 三文件、验收口径 10/10、「别信 subprocess 自报」纪律，以及 Linux/Windows 两个
     参照机角色各自的 build / parity / 冒烟命令。主机绑定见 `machines.md`。
-    ⚠️ 当前限制：**Windows 侧 `BUILD_TEST=ON` 编译不过**（三处 MSVC 不兼容），故那台只能验编译；
-    成因是主矩阵 Windows job 开 `BUILD_TEST` 但没开 CUDA、CUDA job 开 CUDA 但没开 `BUILD_TEST`，
-    **两半都在、交集为空**。与 `windows-remote-testing.md`（GUI VSync 物理桌面）场景正交。
+    ⚠️ **Windows + CUDA + `BUILD_TEST=ON` 至今没有任何 CI job 走过**——主矩阵 Windows job 开
+    `BUILD_TEST` 但没开 CUDA、CUDA job 开 CUDA 但没开 `BUILD_TEST`，**两半都在、交集为空**。
+    这个缺口一次攒下三处 MSVC 不兼容、三周无信号；它们已修，但缺口本身还在 ⇒ 动 `test/` 或
+    `bench/` 后别拿 mac/Linux 的绿推断 Windows 也绿。
+    与 `windows-remote-testing.md`（GUI VSync 物理桌面）场景正交。
   - `testing-architecture.md` — **authoritative test-organization spec**: verification-purpose primary axis × subsystem tag, seven layers (unit-correctness / golden-analytic / parity-cross-backend / e2e-correctness / performance / gui / regression-sentinel), the "how to add a test" decision tree, cross-cutting rules (perf denominator = legacy CPU; parity metric-masks-bugs battery; reference ownership), and the layer×subsystem physical-layout blueprint. Read before adding or reorganizing any test.
 - **Engineering policy**: `env-var-policy.md` — **环境变量使用策略**: user-facing behavior switches must NOT live only in env vars (they cause silent per-machine drift / undebuggable bugs); use CLI/config/API instead. A-class runtime knobs (`LUMICE_TRACE_BACKEND` + 6 perf knobs, with file:line) vs B-class test/build infra (leave alone); three disposition rules; and the **decision gate to answer before adding any new `getenv`**. Read before introducing a new env knob.
 - Example config: `examples/config_example.json`

--- a/bench/bench_geom_closedform.cpp
+++ b/bench/bench_geom_closedform.cpp
@@ -48,6 +48,13 @@ namespace {
 
 constexpr int kPrismFaces = 6;
 
+// Double-precision pi, local to this file (same treatment as
+// test/golden-analytic/core/test_incidence_sampling_polygon_oracle.cpp). `M_PI` is not portable
+// (MSVC leaves it undefined unless `_USE_MATH_DEFINES` is set before <cmath>), and `math::kPi` is
+// float — 8.7e-8 off, which is three to four orders of magnitude coarser than the 1e-12 / 1e-9
+// geometric slack thresholds every counter below is judged against.
+constexpr double kPiDouble = 3.14159265358979323846;
+
 // ---- closed form, templated on the working precision (Q3) -------------------
 
 template <typename T>
@@ -70,7 +77,7 @@ ClosedFormResult<T> ClosedFormPrism(const float* dist, T feas_tol_rel) {
   T r[kPrismFaces], cs[kPrismFaces], sn[kPrismFaces];
   T scale = 0;
   for (int i = 0; i < kPrismFaces; i++) {
-    const T t = static_cast<T>(i) * static_cast<T>(M_PI) / static_cast<T>(3);
+    const T t = static_cast<T>(i) * static_cast<T>(kPiDouble) / static_cast<T>(3);
     cs[i] = std::cos(t);
     sn[i] = std::sin(t);
     r[i] = k * static_cast<T>(dist[i]);
@@ -274,7 +281,7 @@ SweepStats RunSweep(double sigma, unsigned seed, int samples) {
       bool flagged = false;
       for (int v = 0; v < cf_d.vtx_cnt && !flagged; v++) {
         for (int m = 0; m < kPrismFaces; m++) {
-          const double t = m * M_PI / 3.0;
+          const double t = m * kPiDouble / 3.0;
           const double slack = k * dist[m] - (cf_d.x[v] * std::cos(t) + cf_d.y[v] * std::sin(t));
           if (std::fabs(slack) < 1e-9) {
             continue;  // a defining face of this corner
@@ -450,7 +457,7 @@ ReuseAdjudication RunReuseAdjudication(double sigma, unsigned seed, int samples)
     }
     double r[kPrismFaces], cs[kPrismFaces], sn[kPrismFaces];
     for (int i = 0; i < kPrismFaces; i++) {
-      const double t = i * M_PI / 3.0;
+      const double t = i * kPiDouble / 3.0;
       cs[i] = std::cos(t);
       sn[i] = std::sin(t);
       r[i] = k * static_cast<double>(dist[i]);
@@ -556,7 +563,7 @@ void BM_PyramidSixDirections(benchmark::State& state) {
       // best match against the six fixed directions
       double best = -2.0;
       for (int i = 0; i < kPrismFaces; i++) {
-        const double t = i * M_PI / 3.0;
+        const double t = i * kPiDouble / 3.0;
         best = std::max(best, (nx * std::cos(t) + ny * std::sin(t)) / h);
       }
       worst_dir_err = std::max(worst_dir_err, 1.0 - best);
@@ -984,7 +991,7 @@ void BM_UniformErosionModel(benchmark::State& state) {
       double s_val[kPrismFaces];
       bool ok = true;
       for (int i = 0; i < kPrismFaces && ok; i++) {
-        const double t = i * M_PI / 3.0;
+        const double t = i * kPiDouble / 3.0;
         double g = std::numeric_limits<double>::max();
         double r_prism = std::numeric_limits<double>::max();
         for (int k = 2; k < n; k++) {

--- a/doc/gpu-remote-cuda-build-testing.md
+++ b/doc/gpu-remote-cuda-build-testing.md
@@ -140,15 +140,17 @@
   ⚠️ 长时间构建**别用 `Start-Process` 分离**（实测会静默失败、日志为空）；
   要么同步跑（我方 bash 用后台任务拿 notification），要么用 `schtasks` 建一次性计划任务。
 
-- **⚠️ 当前限制：`BUILD_TEST=ON` 在 Windows + CUDA 下编译不过。**
-  三处 MSVC 不兼容（两个 `test_cuda_*` 用了 POSIX `setenv`/`unsetenv`、一个 bench 文件用了
-  `M_PI`）。**所以这台机器上现在只能构建产物**（`-DBUILD_TEST=OFF -DBUILD_BENCH=OFF`），
-  跑不了 gtest / parity。修复落地后本节应恢复完整流程并删除本段。
-  成因值得记住：Windows 上「带 CUDA 编译测试」这个配置**没有任何 CI job 走过**，
-  而原因不是漏了 Windows，是主矩阵的 Windows job 开了 `BUILD_TEST` 但没开 CUDA、
-  CUDA 编译 job 开了 CUDA 但没开 `BUILD_TEST`——**两半都在，交集为空**。
+- **⚠️ 这条路径至今没有任何 CI job 走过，所以它的红只会在这台机器上出现。**
+  Windows 上「带 CUDA 编译测试」这个配置的覆盖缺口**仍然存在**，而原因不是漏了 Windows：
+  主矩阵的 Windows job 开了 `BUILD_TEST` 但没开 CUDA、CUDA 编译 job 开了 CUDA 但没开
+  `BUILD_TEST`——**两半都在，交集为空**。这个缺口一次攒下三处 MSVC 不兼容
+  （两个 `test_cuda_*` 用 POSIX `setenv`/`unsetenv`、一个 bench 文件用 `M_PI`），
+  三周无信号，直到这台机器第一次以 `BUILD_TEST=ON` + CUDA 构建才炸出来；它们已经修掉
+  （`test/support/env_var.hpp` 是全树唯一持有该 `#ifdef` 的地方），但**攒下它们的缺口没有**。
+  ⇒ 在缺口补上之前，动 `test/` 或 `bench/` 后请在这台机器上真跑一次本节的构建，
+  别把「mac/Linux 绿」当成 Windows 也绿。
 
-- **parity（限制解除后）**：
+- **parity**：
   ```bat
   set LUMICE_HAS_CUDA=1
   set LUMICE_CUDA_ENABLED=1

--- a/doc/machines.md
+++ b/doc/machines.md
@@ -75,10 +75,6 @@
 - ssh 会话**自带管理员令牌**，需要提权的安装可以直接远程执行。
 - ⚠️ `scripts/bench_throughput.py` 的默认二进制探测**不带 `.exe`** 后缀
   ⇒ 在 Windows 上必须显式设 `LUMICE_BENCH_BIN`。
-- ⚠️ **`BUILD_TEST=ON` 目前在 Windows + CUDA 下编译不过**（POSIX `setenv`/`unsetenv` 与
-  `M_PI` 三处 MSVC 不兼容），因此现阶段 Windows 构建须带
-  `-DBUILD_TEST=OFF -DBUILD_BENCH=OFF`。**这是已知的临时状态，不是这台机器的属性**；
-  修复落地后本行应删除。
 
 ## 已知坑（都由一手实测确认）
 

--- a/test/metal_test_helpers.hpp
+++ b/test/metal_test_helpers.hpp
@@ -22,6 +22,7 @@
 #include "config/light_config.hpp"
 #include "config/proj_config.hpp"
 #include "config/render_config.hpp"
+#include "support/env_var.hpp"
 
 namespace lumice {
 namespace metal_test {
@@ -38,10 +39,10 @@ inline bool ShouldSkipMetalTests() {
 // backend to one path. The env var is read per-dispatch in
 // MetalTraceBackend::TraceLayer so toggling between tests is fine.
 inline void ForceHostGenForByteIdentity() {
-  ::setenv("LUMICE_DISABLE_DEVICE_GEN", "1", /*overwrite=*/1);
+  test::SetEnvVar("LUMICE_DISABLE_DEVICE_GEN", "1");
 }
 inline void EnableDeviceGenForStatisticalParity() {
-  ::unsetenv("LUMICE_DISABLE_DEVICE_GEN");
+  test::UnsetEnvVar("LUMICE_DISABLE_DEVICE_GEN");
 }
 
 inline RenderConfig MakeRectangularRender() {

--- a/test/parity-cross-backend/backend/test_cuda_kshape_filter_parity.cpp
+++ b/test/parity-cross-backend/backend/test_cuda_kshape_filter_parity.cpp
@@ -58,7 +58,6 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
-#include <cstdlib>
 #include <utility>
 #include <vector>
 
@@ -70,6 +69,7 @@
 #include "core/backend/cuda_trace_backend.hpp"
 #include "core/backend/trace_backend.hpp"
 #include "cuda_test_helpers.hpp"
+#include "support/env_var.hpp"
 
 namespace lumice {
 namespace {
@@ -132,9 +132,9 @@ Stats ComputeStats(const std::vector<double>& xs) {
 std::pair<size_t, double> RunCudaOnce(const SceneConfig& scene, const RenderConfig& render, uint32_t seed,
                                       size_t ray_count, const char* k_env) {
   if (k_env != nullptr) {
-    ::setenv("LUMICE_GPU_GEOM_CLOCK", k_env, /*overwrite=*/1);
+    test::SetEnvVar("LUMICE_GPU_GEOM_CLOCK", k_env);
   } else {
-    ::unsetenv("LUMICE_GPU_GEOM_CLOCK");
+    test::UnsetEnvVar("LUMICE_GPU_GEOM_CLOCK");
   }
   SessionSpec spec;
   spec.scene = &scene;
@@ -211,7 +211,7 @@ TEST(CudaKShapeFilterParity, KDoesNotBiasEntryExitFilterAdmission_AC1) {
     w_k0.push_back(w0);
     w_k8.push_back(w8);
   }
-  ::unsetenv("LUMICE_GPU_GEOM_CLOCK");
+  test::UnsetEnvVar("LUMICE_GPU_GEOM_CLOCK");
 
   Stats s0 = ComputeStats(w_k0);
   Stats s8 = ComputeStats(w_k8);
@@ -250,7 +250,7 @@ TEST(CudaKShapeFilterParity, KEnabledFilterAdmissionMatchesCpuBallpark_AC1) {
   if (ShouldSkipCudaTests()) {
     GTEST_SKIP() << "no CUDA device enumerated";
   }
-  ::setenv("LUMICE_GPU_GEOM_CLOCK", "8", /*overwrite=*/1);
+  test::SetEnvVar("LUMICE_GPU_GEOM_CLOCK", "8");
 
   auto scene = MakeFilteredStochasticScene(kMaxHits);
   auto render = MakeRenderConfig();
@@ -265,7 +265,7 @@ TEST(CudaKShapeFilterParity, KEnabledFilterAdmissionMatchesCpuBallpark_AC1) {
     w_cuda.push_back(wc);
     w_cpu.push_back(wp);
   }
-  ::unsetenv("LUMICE_GPU_GEOM_CLOCK");
+  test::UnsetEnvVar("LUMICE_GPU_GEOM_CLOCK");
 
   Stats sc = ComputeStats(w_cuda);
   Stats sp = ComputeStats(w_cpu);

--- a/test/parity-cross-backend/backend/test_metal_trace_backend.cpp
+++ b/test/parity-cross-backend/backend/test_metal_trace_backend.cpp
@@ -8,7 +8,6 @@
 #if defined(__APPLE__)
 
 #include <cmath>
-#include <cstdlib>
 #include <cstring>
 #include <set>
 #include <vector>
@@ -20,6 +19,7 @@
 #include "core/backend/trace_backend.hpp"
 #include "core/trace_ops.hpp"
 #include "metal_test_helpers.hpp"
+#include "support/env_var.hpp"
 
 namespace lumice {
 namespace {
@@ -515,7 +515,7 @@ TEST(MetalTraceBackend, KShapePool_DefaultKnobUnsetGivesPCiOne_AC1) {
     GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
   }
   // Guarantee the knob is off for this test (independent of prior test order).
-  ::unsetenv("LUMICE_GPU_GEOM_CLOCK");
+  test::UnsetEnvVar("LUMICE_GPU_GEOM_CLOCK");
 
   auto scene = MakeMetalSceneRandomH(/*max_hits=*/4, /*ms_layers=*/1);
   auto render = MakeRectangularRender();
@@ -544,7 +544,7 @@ TEST(MetalTraceBackend, KShapePool_KEnabledBuildsCeilNciOverKShapes_AC1) {
   if (ShouldSkipMetalTests()) {
     GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
   }
-  ::setenv("LUMICE_GPU_GEOM_CLOCK", "8", /*overwrite=*/1);
+  test::SetEnvVar("LUMICE_GPU_GEOM_CLOCK", "8");
 
   auto scene = MakeMetalSceneRandomH(/*max_hits=*/4, /*ms_layers=*/1);
   auto render = MakeRectangularRender();
@@ -606,7 +606,7 @@ TEST(MetalTraceBackend, KShapePool_KEnabledBuildsCeilNciOverKShapes_AC1) {
   }
 
   backend.EndSession();
-  ::unsetenv("LUMICE_GPU_GEOM_CLOCK");
+  test::UnsetEnvVar("LUMICE_GPU_GEOM_CLOCK");
 }
 
 // K-shape pool driven by config (NOT env): SceneConfig::geom_clock_ is now the
@@ -620,7 +620,7 @@ TEST(MetalTraceBackend, KShapePool_ConfigDrivenKWithoutEnv) {
     GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
   }
   // No env override: the value must come purely from config.
-  ::unsetenv("LUMICE_GPU_GEOM_CLOCK");
+  test::UnsetEnvVar("LUMICE_GPU_GEOM_CLOCK");
 
   auto scene = MakeMetalSceneRandomH(/*max_hits=*/4, /*ms_layers=*/1);
   scene.geom_clock_ = 8;  // config-supplied K
@@ -673,9 +673,9 @@ TEST(MetalTraceBackend, KShapePool_KEnabledSessionRunsAndProducesOutput_AC2) {
 
   auto run_and_get_stats = [&](const char* k_val) {
     if (k_val) {
-      ::setenv("LUMICE_GPU_GEOM_CLOCK", k_val, /*overwrite=*/1);
+      test::SetEnvVar("LUMICE_GPU_GEOM_CLOCK", k_val);
     } else {
-      ::unsetenv("LUMICE_GPU_GEOM_CLOCK");
+      test::UnsetEnvVar("LUMICE_GPU_GEOM_CLOCK");
     }
     MetalTraceBackend backend;
     backend.BeginSession(spec);
@@ -716,7 +716,7 @@ TEST(MetalTraceBackend, KShapePool_KEnabledSessionRunsAndProducesOutput_AC2) {
   EXPECT_GT(w_ratio, 0.2f);
   EXPECT_LT(w_ratio, 5.0f);
 
-  ::unsetenv("LUMICE_GPU_GEOM_CLOCK");
+  test::UnsetEnvVar("LUMICE_GPU_GEOM_CLOCK");
 }
 
 // AC2 statistical gate: with a stochastic h_ distribution, each K=0 session
@@ -742,9 +742,9 @@ TEST(MetalTraceBackend, KShapePool_KEnabledReducesCrossSeedVariance_AC2) {
 
   auto run_batch = [&](const char* k_val, uint32_t seed) -> float {
     if (k_val) {
-      ::setenv("LUMICE_GPU_GEOM_CLOCK", k_val, /*overwrite=*/1);
+      test::SetEnvVar("LUMICE_GPU_GEOM_CLOCK", k_val);
     } else {
-      ::unsetenv("LUMICE_GPU_GEOM_CLOCK");
+      test::UnsetEnvVar("LUMICE_GPU_GEOM_CLOCK");
     }
     MetalTraceBackend backend;
     SessionSpec spec = spec_template;
@@ -810,7 +810,7 @@ TEST(MetalTraceBackend, KShapePool_KEnabledReducesCrossSeedVariance_AC2) {
                                  << " must be < 0.75 × sd(K=0) = " << (0.75 * sd_k0) << " (mean_k0=" << mean_k0
                                  << ", mean_k8=" << mean_k8 << ")";
 
-  ::unsetenv("LUMICE_GPU_GEOM_CLOCK");
+  test::UnsetEnvVar("LUMICE_GPU_GEOM_CLOCK");
 }
 
 // Regression coverage for the "empty batch + K knob enabled + stochastic
@@ -837,7 +837,7 @@ TEST(MetalTraceBackend, KShapePool_EmptyBatchWithKEnabledDoesNotCrash_Regression
   spec.wl = WlParam{ 550.0f, 1.0f };
   spec.seed = 7;
 
-  ::setenv("LUMICE_GPU_GEOM_CLOCK", "8", /*overwrite=*/1);
+  test::SetEnvVar("LUMICE_GPU_GEOM_CLOCK", "8");
 
   MetalTraceBackend backend;
   backend.BeginSession(spec);
@@ -856,7 +856,7 @@ TEST(MetalTraceBackend, KShapePool_EmptyBatchWithKEnabledDoesNotCrash_Regression
          "and the K-shape path partially ran on a zero-ray batch.";
   backend.EndSession();
 
-  ::unsetenv("LUMICE_GPU_GEOM_CLOCK");
+  test::UnsetEnvVar("LUMICE_GPU_GEOM_CLOCK");
 }
 
 // =============================================================================
@@ -893,7 +893,7 @@ TEST(MetalTraceBackend, KShapePool_PathIsLocalWithinPolygonFaceCount_AC1_TestA) 
   if (ShouldSkipMetalTests()) {
     GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
   }
-  ::setenv("LUMICE_GPU_GEOM_CLOCK", "8", /*overwrite=*/1);
+  test::SetEnvVar("LUMICE_GPU_GEOM_CLOCK", "8");
 
   const size_t kMaxHits = 4;
   auto scene = MakeMetalSceneRandomH(/*max_hits=*/kMaxHits, /*ms_layers=*/1);
@@ -1018,7 +1018,7 @@ TEST(MetalTraceBackend, KShapePool_PathIsLocalWithinPolygonFaceCount_AC1_TestA) 
   }
 
   backend.EndSession();
-  ::unsetenv("LUMICE_GPU_GEOM_CLOCK");
+  test::UnsetEnvVar("LUMICE_GPU_GEOM_CLOCK");
 }
 
 TEST(MetalTraceBackend, KShapePool_TransitPicksMultipleShapes_AC1_TestB) {
@@ -1030,7 +1030,7 @@ TEST(MetalTraceBackend, KShapePool_TransitPicksMultipleShapes_AC1_TestB) {
   if (ShouldSkipMetalTests()) {
     GTEST_SKIP() << "LUMICE_SKIP_METAL_TESTS set";
   }
-  ::setenv("LUMICE_GPU_GEOM_CLOCK", "8", /*overwrite=*/1);
+  test::SetEnvVar("LUMICE_GPU_GEOM_CLOCK", "8");
 
   auto scene = MakeMetalSceneRandomH(/*max_hits=*/6, /*ms_layers=*/2);
   auto render = MakeRectangularRender();
@@ -1093,7 +1093,7 @@ TEST(MetalTraceBackend, KShapePool_TransitPicksMultipleShapes_AC1_TestB) {
                                  << " — transit's K-shape pick is not distributing.";
 
   backend.EndSession();
-  ::unsetenv("LUMICE_GPU_GEOM_CLOCK");
+  test::UnsetEnvVar("LUMICE_GPU_GEOM_CLOCK");
 }
 
 }  // namespace

--- a/test/support/env_var.hpp
+++ b/test/support/env_var.hpp
@@ -1,0 +1,60 @@
+#ifndef LUMICE_TEST_SUPPORT_ENV_VAR_HPP_
+#define LUMICE_TEST_SUPPORT_ENV_VAR_HPP_
+
+// Cross-platform environment-variable set/clear for test code — the single place in the tree that
+// owns the `_WIN32` branch behind it.
+//
+// Why a named helper rather than one more `#ifdef` per call site: `setenv` / `unsetenv` are POSIX,
+// not C or C++, and MSVC does not declare them. A bare `::setenv(...)` therefore compiles on mac and
+// Linux and fails to compile on Windows — but only in a build configuration that actually reaches
+// the file. Two CUDA test sources sat behind `#if LUMICE_CUDA_ENABLED` and the Metal ones behind
+// `#if defined(__APPLE__)`, so their bare calls were invisible until a Windows host built with CUDA
+// on and BUILD_TEST on for the first time, three weeks after they landed. Copies of the portability
+// workaround are what let that happen; one owner is what stops it recurring. (Same conclusion as the
+// `no-bare-print` logger exemptions: make the exception a symbol with a name and an owner.)
+//
+// It lives in test/support/ because its consumers already span four CMake targets
+// (unit_correctness_test, parity_test, gui_test, gui_unit_test), all of which carry
+// ${PROJ_TEST_DIR} on their include path, so `#include "support/env_var.hpp"` is one spelling valid
+// in all of them. Nothing here is production code: `src/` reads env vars through
+// src/util/env_knobs.cpp and never writes them.
+//
+// Deliberately two free functions rather than an RAII guard. Most call sites are function-scoped
+// set/clear pairs written inline, and the two places that do want scope semantics want *different*
+// ones — test_c_api.cpp's EnvGuard only has to clear on exit, while
+// user_defaults_test_env.hpp's ScopedNoUserConfigDirEnv has to restore each variable's prior value
+// (or its prior absence). Those two lifetimes stay where they are and compose these calls; folding
+// them into one guard here would be a second, unrelated refactor.
+
+#include <cstdlib>
+
+namespace lumice::test {
+
+// Sets `name` to `value`, overwriting any existing value (POSIX `overwrite=1` semantics).
+inline void SetEnvVar(const char* name, const char* value) {
+#if defined(_WIN32)
+  ::_putenv_s(name, value);
+#else
+  ::setenv(name, value, /*overwrite=*/1);
+#endif
+}
+
+// Removes `name` from the environment, so a subsequent std::getenv(name) returns nullptr.
+//
+// On Windows that is spelled as an assignment of the empty string: the CRT treats `_putenv_s(name,
+// "")` as a deletion, and correspondingly has no way to express "present but empty". Every knob
+// these tests toggle (LUMICE_GPU_GEOM_CLOCK, LUMICE_DISABLE_DEVICE_GEN, LUMICE_TRACE_BACKEND, HOME
+// / XDG_CONFIG_HOME / APPDATA) is read with a presence-or-non-empty test, so the two states are
+// interchangeable for them — but a future caller whose variable must distinguish empty from absent
+// on Windows cannot get that from this function.
+inline void UnsetEnvVar(const char* name) {
+#if defined(_WIN32)
+  ::_putenv_s(name, "");
+#else
+  ::unsetenv(name);
+#endif
+}
+
+}  // namespace lumice::test
+
+#endif  // LUMICE_TEST_SUPPORT_ENV_VAR_HPP_

--- a/test/support/user_defaults_test_env.hpp
+++ b/test/support/user_defaults_test_env.hpp
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "gui/user_defaults.hpp"
+#include "support/env_var.hpp"
 
 namespace gui = lumice::gui;
 
@@ -103,15 +104,11 @@ class ScopedNoUserConfigDirEnv {
   }
 
   static void Apply(const std::string& name, const std::optional<std::string>& value) {
-#if defined(_WIN32)
-    _putenv_s(name.c_str(), value ? value->c_str() : "");
-#else
     if (value) {
-      setenv(name.c_str(), value->c_str(), 1);
+      test::SetEnvVar(name.c_str(), value->c_str());
     } else {
-      unsetenv(name.c_str());
+      test::UnsetEnvVar(name.c_str());
     }
-#endif
   }
 
   std::vector<std::pair<std::string, std::optional<std::string>>> saved_;

--- a/test/unit-correctness/backend/test_cuda_kshape_pool_locality.cpp
+++ b/test/unit-correctness/backend/test_cuda_kshape_pool_locality.cpp
@@ -48,7 +48,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <cstdlib>
 #include <set>
 #include <utility>
 #include <vector>
@@ -62,6 +61,7 @@
 #include "core/exit_seam.hpp"
 #include "core/raypath.hpp"
 #include "cuda_test_helpers.hpp"
+#include "support/env_var.hpp"
 
 namespace lumice {
 namespace {
@@ -101,7 +101,7 @@ TEST(CudaKShapePool, KShapePool_PathIsLocalWithinPolygonFaceCount_AC1) {
   if (ShouldSkipCudaTests()) {
     GTEST_SKIP() << "no CUDA device enumerated";
   }
-  ::setenv("LUMICE_GPU_GEOM_CLOCK", "8", /*overwrite=*/1);
+  test::SetEnvVar("LUMICE_GPU_GEOM_CLOCK", "8");
 
   const size_t kMaxHits = 6;
   auto scene = MakeTwoLayerStochasticScene(kMaxHits);
@@ -193,7 +193,7 @@ TEST(CudaKShapePool, KShapePool_PathIsLocalWithinPolygonFaceCount_AC1) {
   // the task archive.
 
   backend.EndSession();
-  ::unsetenv("LUMICE_GPU_GEOM_CLOCK");
+  test::UnsetEnvVar("LUMICE_GPU_GEOM_CLOCK");
 }
 
 // =============================================================================
@@ -203,7 +203,7 @@ TEST(CudaKShapePool, KShapePool_TransitPicksMultipleShapes_AC1) {
   if (ShouldSkipCudaTests()) {
     GTEST_SKIP() << "no CUDA device enumerated";
   }
-  ::setenv("LUMICE_GPU_GEOM_CLOCK", "8", /*overwrite=*/1);
+  test::SetEnvVar("LUMICE_GPU_GEOM_CLOCK", "8");
 
   const size_t kMaxHits = 6;
   auto scene = MakeTwoLayerStochasticScene(kMaxHits);
@@ -276,7 +276,7 @@ TEST(CudaKShapePool, KShapePool_TransitPicksMultipleShapes_AC1) {
                               << " — transit_multi_ms_kernel K-shape pick is not distributing.";
 
   backend.EndSession();
-  ::unsetenv("LUMICE_GPU_GEOM_CLOCK");
+  test::UnsetEnvVar("LUMICE_GPU_GEOM_CLOCK");
 }
 
 // =============================================================================
@@ -286,7 +286,7 @@ TEST(CudaKShapePool, KShapePool_DefaultKnobUnsetGivesPCiOne_AC2) {
   if (ShouldSkipCudaTests()) {
     GTEST_SKIP() << "no CUDA device enumerated";
   }
-  ::unsetenv("LUMICE_GPU_GEOM_CLOCK");  // isolation from prior test order
+  test::UnsetEnvVar("LUMICE_GPU_GEOM_CLOCK");  // isolation from prior test order
 
   // Single-layer stochastic scene — one (layer, ci) pair. K=0 → P_ci = 1 →
   // pool table has exactly one row, and

--- a/test/unit-correctness/server/test_c_api.cpp
+++ b/test/unit-correctness/server/test_c_api.cpp
@@ -24,6 +24,7 @@
 #include "core/def.hpp"
 #include "include/lumice.h"
 #include "server/c_api_internal.hpp"  // ConfigScratch(+Guard) + ParseConfigString + ConfigToJson (internal)
+#include "support/env_var.hpp"
 
 // Regression guard (task-fix-stats-ray-count-u32-overflow): ray-count fields must be
 // 64-bit so totals > 2^32 never truncate on Windows, where `unsigned long` is 32-bit
@@ -1565,17 +1566,10 @@ TEST_F(ServerLifecycleApi, StressStartStop) {
 // 60s timeout dominates the ~few-seconds expected runtime; on regression the
 // server will sit forever at <1.0 progress with workers idle in config_queue.
 TEST_F(ServerLifecycleApi, ZeroExitBatchNoHang) {
-#ifdef _WIN32
-  ::_putenv_s("LUMICE_TRACE_BACKEND", "cpu_backend");
+  lumice::test::SetEnvVar("LUMICE_TRACE_BACKEND", "cpu_backend");
   struct EnvGuard {
-    ~EnvGuard() { ::_putenv_s("LUMICE_TRACE_BACKEND", ""); }
+    ~EnvGuard() { lumice::test::UnsetEnvVar("LUMICE_TRACE_BACKEND"); }
   } guard;
-#else
-  ::setenv("LUMICE_TRACE_BACKEND", "cpu_backend", 1);
-  struct EnvGuard {
-    ~EnvGuard() { ::unsetenv("LUMICE_TRACE_BACKEND"); }
-  } guard;
-#endif
 
   auto json = MakeBdFilterConfigJson();
   ASSERT_EQ(CommitJsonConfig(server_, json.c_str()), LUMICE_OK);


### PR DESCRIPTION
## 问题

Windows + CUDA 配置下三处 MSVC 不兼容，使 `unit_correctness_test`（1090 cases）、
`parity_test`（13 cases）、`lumice_bench` 三个目标编译失败：

| 文件 | 错误 |
|---|---|
| `test/unit-correctness/backend/test_cuda_kshape_pool_locality.cpp` | `C2039/C3861: 'setenv' / 'unsetenv'` |
| `test/parity-cross-backend/backend/test_cuda_kshape_filter_parity.cpp` | 同上 |
| `bench/bench_geom_closedform.cpp` | `C2065: 'M_PI': undeclared identifier` |

`setenv`/`unsetenv` 是 POSIX 而非 C/C++，MSVC 不声明；`M_PI` 同样是 POSIX 扩展。

**为什么三周没被发现**：两个 CI job 各有一半、交集为空 —— 主矩阵 `windows-2025`
是 `BUILD_TEST=ON` 但 CUDA OFF（`test_cuda_*.cpp` 被 `#if LUMICE_CUDA_ENABLED`
编成空 TU）；`windows-cuda-compile` 是 CUDA ON 但 `BUILD_TEST=OFF`。

## 改动

- 新增 `test/support/env_var.hpp`：`lumice::test::SetEnvVar` / `UnsetEnvVar`，
  **全树唯一**持有该 `_WIN32` 分支的地方。刻意用两个自由函数而非 RAII guard —
  多数调用点是函数作用域内的裸配对调用，而两处已有 RAII 想要的生命周期语义各不相同
  （`EnvGuard` 只需退出时清除，`ScopedNoUserConfigDirEnv` 需恢复每个变量的先前值/先前缺失）。
- 全树 25 处调用点切到该 helper，**无跳过项**：三个阻塞文件 10 处 + Metal 侧 18 处
  （`test_metal_trace_backend.cpp` 16 / `metal_test_helpers.hpp` 2，今天 Apple-only
  打不到但形状相同）+ 消除两份既有手抄（`test_c_api.cpp`、`user_defaults_test_env.hpp`）。
- `bench_geom_closedform.cpp` 改用文件局部 `constexpr double kPiDouble`，
  **不**引入 `_USE_MATH_DEFINES`，也**不**用 `math::kPi`（后者是 `float`，以 double
  读回误差 8.74e-8，而该文件按 1e-12 / 1e-9 容差判定，代入会静默废掉它的全部意义）。
  这与 `test_incidence_sampling_polygon_oracle.cpp:52` 的既有先例一致。
- 顺带删掉三处被本次修复**直接证伪**的 tracked 陈述（`doc/machines.md`、
  `doc/gpu-remote-cuda-build-testing.md`、`AGENTS.md`），其中两处原文即写着
  「修复落地后本行应删除」。**只删被证伪的半句**，保留并强化仍然成立的那半句
  ——「Windows+CUDA+`BUILD_TEST` 的 CI 交集为空、该缺口仍在」。

## 验证

- **home-win（Win11 / MSVC 14.44.35207 / CUDA 12.9）红→绿自证**：同机同命令、
  只差 commit —— 修前 `BUILD_EXIT=1` 且三处错误原样复现，修后 `BUILD_EXIT=0`，
  另附 1090 + 30 个 case 的运行时通过。
  ⚠️ 本 PR 的 CI **无法复核这一条**：Windows 的 CUDA job 仍是 `BUILD_TEST=OFF`，
  正是上面那个尚未修补的缺口。
- mac 本机 `./scripts/test.sh quick` → `RESULT: PASS`（ctest / fast-e2e /
  gui-correctness 三层）。
- 五个 diff-scoped 门禁 + `check_policies.py` + `format.sh --check` 全绿。

## 不在本 PR 范围

CI 组织方式的重新梳理（含「Windows 上到底怎么测」）已由 owner 裁定单独立项，本次
**接受**该覆盖缺口 —— 所以上面那半句警告被刻意保留在文档里。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
