### PR TITLE
fix(build): 让 CMP0091 真正生效，Windows 发布产物链接静态 CRT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ env:
 
   # Platform support decisions (2026-03):
   #   - Only CLI and GUI executables are published; shared library publishing is deferred.
+  #     This line is what makes the MSVC static-CRT (/MT) choice safe, so changing it means
+  #     re-reading the CRT reasoning in the top-level CMakeLists.txt MSVC block first: the
+  #     shared flavor deliberately stays on the dynamic CRT, because a static CRT gives a
+  #     DLL its own environment block and swallows variables the host process sets after
+  #     loading it.
   #   - linux-arm64: GUI OFF — ARM runner GPU/display support not verified.
   #   - macOS Intel: excluded — GitHub Actions dropped macos-13 runners (2025).
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,8 +42,45 @@ if(MINGW)
   add_link_options(-static)
 endif()
 
-# MSVC: use static CRT (/MT) so distributed .exe doesn't require vcruntime DLLs.
+# MSVC: use the static CRT (/MT) so a distributed .exe runs on a machine that has
+# no VC++ Redistributable installed. The dynamic CRT's worst failure mode — several
+# modules each holding their own CRT heap, one module freeing a pointer another
+# allocated — does not apply to what this repo actually ships: the release workflow
+# publishes only the CLI and GUI executables (no shared library), and the C API pairs
+# every allocation with its own release entry point (Acquire/Release, Create/Destroy,
+# CompositionReleaseClauses) rather than handing raw pointers to a caller's free().
+# Revisit this choice if that changes — publishing a DLL for third-party consumers is
+# the trigger, not a version bump.
+#
+# The two policy lines are load-bearing, not boilerplate:
+#   - CMP0091 (the policy that makes CMAKE_MSVC_RUNTIME_LIBRARY mean anything) arrived
+#     in CMake 3.15. Below the cmake_minimum_required set at the top of this file it
+#     defaults to OLD, and CMake then ignores the variable *silently* — no warning, no
+#     error, just /MD in the compile command. Setting the variable alone is not enough.
+#   - CMAKE_POLICY_DEFAULT_CMP0091 covers scopes created later. A function records the
+#     policy stack in effect where it was *defined*, and cmake/CPM.cmake declares its own
+#     (lower) cmake_minimum_required at the top, so CPMAddPackage and the
+#     add_subdirectory it performs run with CMP0091 unset. Without this line the
+#     third-party dependency scopes keep /MD and mix with a /MT main build.
+# Both must precede include(cmake/CPM.cmake) and every add_subdirectory below.
+#
+# When you touch these lines, verify the *artifact*, not the intent: check that the
+# generated build.ninja compile FLAGS say /MT (dependencies included, not just this
+# project's own sources) and that dumpbin /dependents on the produced .exe lists no
+# MSVCP140.dll / VCRUNTIME140.dll / VCRUNTIME140_1.dll. This block was inert for a long
+# time precisely because it was only ever read, never measured. If some target ever needs
+# a per-target MSVC_RUNTIME_LIBRARY override, add it in one named block per build unit
+# (one here after all CPMAddPackage calls, one in test/CMakeLists.txt) instead of
+# scattering set_target_properties calls, so a reader can still answer "who decides this
+# target's CRT" from a single place.
 if(MSVC)
+  if(POLICY CMP0091)
+    cmake_policy(SET CMP0091 NEW)
+    set(CMAKE_POLICY_DEFAULT_CMP0091 NEW)
+  else()
+    message(WARNING "CMake <3.15 does not know CMP0091; MSVC runtime library selection is "
+                    "ignored and this build will link the DYNAMIC CRT (/MD) instead of /MT.")
+  endif()
   set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,15 +114,19 @@ endif()
 # LUMICE_MSVC_STATIC_CRT is the single answer to "is this build using the static CRT",
 # for anything downstream that has to agree with it (see test/CMakeLists.txt). It is
 # deliberately the *measured* answer, not the intended one.
+# Both languages are checked, not just CXX. CMP0091 bakes into CMAKE_<LANG>_FLAGS_<CONFIG>
+# per language, so a regression that reaches only one of them — a future CMake version
+# difference, or someone overriding CMAKE_C_FLAGS_RELEASE — would otherwise slip past a
+# CXX-only check, and the C-only dependencies (glad) would quietly link the other CRT.
 set(LUMICE_MSVC_STATIC_CRT OFF)
 if(MSVC AND NOT BUILD_SHARED_LIBS)
-  if("${CMAKE_CXX_FLAGS_RELEASE} ${CMAKE_CXX_FLAGS_DEBUG} ${CMAKE_CXX_FLAGS_RELWITHDEBINFO} ${CMAKE_CXX_FLAGS_MINSIZEREL}"
+  if("${CMAKE_CXX_FLAGS_RELEASE} ${CMAKE_CXX_FLAGS_DEBUG} ${CMAKE_CXX_FLAGS_RELWITHDEBINFO} ${CMAKE_CXX_FLAGS_MINSIZEREL} ${CMAKE_C_FLAGS_RELEASE} ${CMAKE_C_FLAGS_DEBUG} ${CMAKE_C_FLAGS_RELWITHDEBINFO} ${CMAKE_C_FLAGS_MINSIZEREL}"
      MATCHES "[-/]M[DT]")
     message(WARNING "MSVC runtime library selection is not in effect: a runtime flag is "
                     "baked into the per-config compiler flags, so CMAKE_MSVC_RUNTIME_LIBRARY "
                     "is ignored and this build will link the DYNAMIC CRT and depend on the "
                     "VC++ Redistributable (CMake <3.15, a CMP0091 call moved after project(), "
-                    "or overridden CMAKE_CXX_FLAGS_<CONFIG>).")
+                    "or overridden CMAKE_C_FLAGS_<CONFIG> / CMAKE_CXX_FLAGS_<CONFIG>).")
   else()
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
     set(LUMICE_MSVC_STATIC_CRT ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,17 +139,33 @@ if(MSVC AND NOT BUILD_SHARED_LIBS)
     # units disagree, which is not something to report as either answer confidently, so it
     # takes the conservative one.
     set(LUMICE_MSVC_STATIC_CRT ON)
+    set(LUMICE_BAKED_CRT_SAW_STATIC OFF)
+    set(LUMICE_BAKED_CRT_SAW_DYNAMIC OFF)
     foreach(LUMICE_BAKED_CRT_FLAG IN LISTS LUMICE_BAKED_CRT_FLAGS)
       if(NOT LUMICE_BAKED_CRT_FLAG MATCHES "MT$")
         set(LUMICE_MSVC_STATIC_CRT OFF)
+        set(LUMICE_BAKED_CRT_SAW_DYNAMIC ON)
+      else()
+        set(LUMICE_BAKED_CRT_SAW_STATIC ON)
       endif()
     endforeach()
+    # string(CONCAT), not set(), so the result is ONE string: it is expanded inside a quoted
+    # message() argument below, where a multi-element list would render its separators.
     if(LUMICE_MSVC_STATIC_CRT)
-      set(LUMICE_BAKED_CRT_DESCRIPTION "the STATIC CRT, through those flags rather than "
-                                       "through CMAKE_MSVC_RUNTIME_LIBRARY")
+      string(CONCAT LUMICE_BAKED_CRT_DESCRIPTION
+             "the STATIC CRT, through those flags rather than "
+             "through CMAKE_MSVC_RUNTIME_LIBRARY")
+    elseif(LUMICE_BAKED_CRT_SAW_STATIC AND LUMICE_BAKED_CRT_SAW_DYNAMIC)
+      # Worth its own wording: this is not "the build fell back to /MD", it is compilation
+      # units disagreeing with each other, which surfaces at link time as LNK1319/LNK2038.
+      # Sending the reader looking for "why did it all become dynamic" would be the wrong
+      # search.
+      string(CONCAT LUMICE_BAKED_CRT_DESCRIPTION
+             "a MIX of static and dynamic CRT flags across compilation units, which will "
+             "fail at link time (LNK1319/LNK2038) rather than produce a working binary")
     else()
-      set(LUMICE_BAKED_CRT_DESCRIPTION "the DYNAMIC CRT and depend on the VC++ "
-                                       "Redistributable")
+      string(CONCAT LUMICE_BAKED_CRT_DESCRIPTION
+             "the DYNAMIC CRT and depend on the VC++ Redistributable")
     endif()
     set(LUMICE_BAKED_CRT_FLAGS_SEEN ${LUMICE_BAKED_CRT_FLAGS})
     list(REMOVE_DUPLICATES LUMICE_BAKED_CRT_FLAGS_SEEN)
@@ -157,7 +173,7 @@ if(MSVC AND NOT BUILD_SHARED_LIBS)
     message(WARNING "MSVC runtime library selection is not in effect: a runtime flag "
                     "(${LUMICE_BAKED_CRT_FLAGS_SEEN}) is baked into the per-config compiler flags, "
                     "so CMAKE_MSVC_RUNTIME_LIBRARY is ignored and this build will link "
-                    ${LUMICE_BAKED_CRT_DESCRIPTION} " (CMake <3.15, a CMP0091 call moved "
+                    "${LUMICE_BAKED_CRT_DESCRIPTION}" " (CMake <3.15, a CMP0091 call moved "
                     "after project(), or overridden CMAKE_C_FLAGS_<CONFIG> / "
                     "CMAKE_CXX_FLAGS_<CONFIG>).")
   else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,28 +65,41 @@ if(MINGW)
   add_link_options(-static)
 endif()
 
-# MSVC: use the static CRT (/MT) so a distributed .exe runs on a machine that has
-# no VC++ Redistributable installed. The dynamic CRT's worst failure mode — several
-# modules each holding their own CRT heap, one module freeing a pointer another
-# allocated — does not apply to what this repo actually ships: the release workflow
-# publishes only the CLI and GUI executables (no shared library), and the C API pairs
-# every allocation with its own release entry point (Acquire/Release, Create/Destroy,
-# CompositionReleaseClauses) rather than handing raw pointers to a caller's free().
-# Revisit this choice if that changes — publishing a DLL for third-party consumers is
-# the trigger, not a version bump.
+# MSVC: the executables this repo distributes link the static CRT (/MT) so they run on
+# a machine with no VC++ Redistributable installed. The shared-library flavor keeps the
+# dynamic CRT (/MD), and that split is the whole point rather than an oversight:
+#
+#   - The release workflow publishes only the CLI and GUI executables. For those, a
+#     private CRT is exactly what is wanted, and the dynamic CRT's worst failure mode
+#     (several modules each holding their own CRT state) cannot arise in a single
+#     self-contained process.
+#   - A DLL is the opposite case: it is loaded into someone else's process, and a static
+#     CRT gives it a *private copy of the CRT state* — its own heap, and its own
+#     environment block. The environment half is not theoretical here. It was measured:
+#     with /MT, a LUMICE_* variable the host process sets after loading the library is
+#     invisible to getenv() inside it, because the library's CRT snapshotted the
+#     environment when it initialized. The whole CUDA parity suite, which selects the
+#     backend exactly that way, silently ran on the CPU path instead and failed 11/11;
+#     the same suite passes with /MD. Sharing the host's CRT is the correct behavior for
+#     a library, so this is the answer, not a workaround.
+#
+# So: the trigger for revisiting is a change to what gets *published*, not a CMake or
+# compiler version bump.
 #
 # The setting below only means something if CMP0091 is NEW; that is arranged before
-# project() at the top of this file, where the reasoning lives.
+# project() at the top of this file, where the reasoning lives. When CMP0091 is not in
+# effect, CMake's own default is the dynamic CRT, which is why only the static-CRT
+# branch has to check that the abstraction actually works.
 #
-# The guard here checks the state that actually decides the outcome rather than the
-# policy's nominal value: under CMP0091 NEW, CMake puts no runtime-library flag in the
-# per-config flag defaults and adds it from the abstraction instead. A runtime flag
-# sitting in those defaults therefore means the abstraction is being ignored and this
-# build links the dynamic CRT no matter what the line below says — whether because the
-# CMake in use predates 3.15, because someone moved the policy call below project()
-# (that regression is not hypothetical), or because the flags were overridden on the
-# command line. Asking cmake_policy(GET) instead would not catch any of those: it
-# reports NEW happily while the baked flags win.
+# That check reads the state which actually decides the outcome rather than the policy's
+# nominal value: under CMP0091 NEW, CMake puts no runtime-library flag in the per-config
+# flag defaults and adds it from the abstraction instead. A runtime flag sitting in those
+# defaults therefore means the abstraction is being ignored and this build links the
+# dynamic CRT no matter what the line below says — whether because the CMake in use
+# predates 3.15, because someone moved the policy call below project() (that regression
+# is not hypothetical), or because the flags were overridden on the command line. Asking
+# cmake_policy(GET) instead would not catch any of those: it reports NEW happily while
+# the baked flags win.
 #
 # When you touch this, verify the *artifact*, not the intent: check that the generated
 # build.ninja compile FLAGS carry the static-CRT flag (dependencies included, not just
@@ -97,16 +110,23 @@ endif()
 # (one here after all CPMAddPackage calls, one in test/CMakeLists.txt) instead of
 # scattering set_target_properties calls, so a reader can still answer "who decides this
 # target's CRT" from a single place.
-if(MSVC)
+#
+# LUMICE_MSVC_STATIC_CRT is the single answer to "is this build using the static CRT",
+# for anything downstream that has to agree with it (see test/CMakeLists.txt). It is
+# deliberately the *measured* answer, not the intended one.
+set(LUMICE_MSVC_STATIC_CRT OFF)
+if(MSVC AND NOT BUILD_SHARED_LIBS)
   if("${CMAKE_CXX_FLAGS_RELEASE} ${CMAKE_CXX_FLAGS_DEBUG} ${CMAKE_CXX_FLAGS_RELWITHDEBINFO} ${CMAKE_CXX_FLAGS_MINSIZEREL}"
      MATCHES "[-/]M[DT]")
     message(WARNING "MSVC runtime library selection is not in effect: a runtime flag is "
                     "baked into the per-config compiler flags, so CMAKE_MSVC_RUNTIME_LIBRARY "
-                    "is ignored and this build will link whichever CRT that flag names "
-                    "(CMake <3.15, a CMP0091 call moved after project(), or overridden "
-                    "CMAKE_CXX_FLAGS_<CONFIG>).")
+                    "is ignored and this build will link the DYNAMIC CRT and depend on the "
+                    "VC++ Redistributable (CMake <3.15, a CMP0091 call moved after project(), "
+                    "or overridden CMAKE_CXX_FLAGS_<CONFIG>).")
+  else()
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    set(LUMICE_MSVC_STATIC_CRT ON)
   endif()
-  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()
 
 include(CheckIPOSupported)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,15 +118,48 @@ endif()
 # per language, so a regression that reaches only one of them — a future CMake version
 # difference, or someone overriding CMAKE_C_FLAGS_RELEASE — would otherwise slip past a
 # CXX-only check, and the C-only dependencies (glad) would quietly link the other CRT.
+#
+# Two things about reading this check's result. It is only trustworthy on a FRESH cache:
+# these are CACHE variables, so once a configure has baked a runtime flag into them, a
+# reconfigure in the same build directory reuses the stale value and the check reports on
+# that rather than on what this file now does — deleting the build tree (or at least
+# CMakeCache.txt) is part of verifying it. And when it does find a baked flag, it reads
+# WHICH one: the usual failure bakes the dynamic flag, but an explicit
+# -DCMAKE_CXX_FLAGS_RELEASE=/MT bakes the static one, and in that case the build really is
+# static even though the abstraction is being bypassed. Reporting OFF there would push
+# gtest to the opposite CRT and produce the very LNK1319 mismatch this variable exists to
+# prevent, so the answer follows the measurement in both directions.
 set(LUMICE_MSVC_STATIC_CRT OFF)
 if(MSVC AND NOT BUILD_SHARED_LIBS)
-  if("${CMAKE_CXX_FLAGS_RELEASE} ${CMAKE_CXX_FLAGS_DEBUG} ${CMAKE_CXX_FLAGS_RELWITHDEBINFO} ${CMAKE_CXX_FLAGS_MINSIZEREL} ${CMAKE_C_FLAGS_RELEASE} ${CMAKE_C_FLAGS_DEBUG} ${CMAKE_C_FLAGS_RELWITHDEBINFO} ${CMAKE_C_FLAGS_MINSIZEREL}"
-     MATCHES "[-/]M[DT]")
-    message(WARNING "MSVC runtime library selection is not in effect: a runtime flag is "
-                    "baked into the per-config compiler flags, so CMAKE_MSVC_RUNTIME_LIBRARY "
-                    "is ignored and this build will link the DYNAMIC CRT and depend on the "
-                    "VC++ Redistributable (CMake <3.15, a CMP0091 call moved after project(), "
-                    "or overridden CMAKE_C_FLAGS_<CONFIG> / CMAKE_CXX_FLAGS_<CONFIG>).")
+  string(REGEX MATCHALL "[-/]M[DT]"
+         LUMICE_BAKED_CRT_FLAGS
+         "${CMAKE_CXX_FLAGS_RELEASE} ${CMAKE_CXX_FLAGS_DEBUG} ${CMAKE_CXX_FLAGS_RELWITHDEBINFO} ${CMAKE_CXX_FLAGS_MINSIZEREL} ${CMAKE_C_FLAGS_RELEASE} ${CMAKE_C_FLAGS_DEBUG} ${CMAKE_C_FLAGS_RELWITHDEBINFO} ${CMAKE_C_FLAGS_MINSIZEREL}")
+  if(LUMICE_BAKED_CRT_FLAGS)
+    # Static only if EVERY baked flag is the static one; a mix means different translation
+    # units disagree, which is not something to report as either answer confidently, so it
+    # takes the conservative one.
+    set(LUMICE_MSVC_STATIC_CRT ON)
+    foreach(LUMICE_BAKED_CRT_FLAG IN LISTS LUMICE_BAKED_CRT_FLAGS)
+      if(NOT LUMICE_BAKED_CRT_FLAG MATCHES "MT$")
+        set(LUMICE_MSVC_STATIC_CRT OFF)
+      endif()
+    endforeach()
+    if(LUMICE_MSVC_STATIC_CRT)
+      set(LUMICE_BAKED_CRT_DESCRIPTION "the STATIC CRT, through those flags rather than "
+                                       "through CMAKE_MSVC_RUNTIME_LIBRARY")
+    else()
+      set(LUMICE_BAKED_CRT_DESCRIPTION "the DYNAMIC CRT and depend on the VC++ "
+                                       "Redistributable")
+    endif()
+    set(LUMICE_BAKED_CRT_FLAGS_SEEN ${LUMICE_BAKED_CRT_FLAGS})
+    list(REMOVE_DUPLICATES LUMICE_BAKED_CRT_FLAGS_SEEN)
+    string(REPLACE ";" " " LUMICE_BAKED_CRT_FLAGS_SEEN "${LUMICE_BAKED_CRT_FLAGS_SEEN}")
+    message(WARNING "MSVC runtime library selection is not in effect: a runtime flag "
+                    "(${LUMICE_BAKED_CRT_FLAGS_SEEN}) is baked into the per-config compiler flags, "
+                    "so CMAKE_MSVC_RUNTIME_LIBRARY is ignored and this build will link "
+                    ${LUMICE_BAKED_CRT_DESCRIPTION} " (CMake <3.15, a CMP0091 call moved "
+                    "after project(), or overridden CMAKE_C_FLAGS_<CONFIG> / "
+                    "CMAKE_CXX_FLAGS_<CONFIG>).")
   else()
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
     set(LUMICE_MSVC_STATIC_CRT ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,29 @@ if(APPLE AND NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
   set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0" CACHE STRING "Minimum macOS version")
 endif()
 
+# CMP0091 decides whether CMAKE_MSVC_RUNTIME_LIBRARY (set in the MSVC block further
+# down, with the reasoning for the /MT choice) means anything at all. It has to be
+# decided HERE, before project(): project() enables the C/CXX languages, and that is
+# when CMake either bakes a runtime-library flag into the CMAKE_<LANG>_FLAGS_<CONFIG>
+# defaults (OLD) or leaves them alone and honors the abstraction instead (NEW).
+# Setting the policy after project() is measurably too late — the flags are already
+# baked and the whole block silently does nothing.
+#   - if(POLICY ...) guard: below CMake 3.15 this policy does not exist, and
+#     cmake_policy(SET) on an unknown id is a hard configure error, not a no-op. The
+#     silent-/MD case that leaves is caught by the MSVC block's check further down.
+#   - CMAKE_POLICY_DEFAULT_CMP0091 covers scopes created later. A function records the
+#     policy stack in effect where it was defined, and cmake/CPM.cmake declares its own
+#     (lower) cmake_minimum_required at the top, so CPMAddPackage and the
+#     add_subdirectory it performs would otherwise run with CMP0091 unset and the
+#     third-party dependencies would keep the dynamic CRT while this project uses the
+#     static one. Both must precede include(cmake/CPM.cmake) and every add_subdirectory.
+# This is deliberately not gated on MSVC: neither line exists as a variable before
+# project(), and both are inert on every non-MSVC toolchain.
+if(POLICY CMP0091)
+  cmake_policy(SET CMP0091 NEW)
+  set(CMAKE_POLICY_DEFAULT_CMP0091 NEW)
+endif()
+
 project(Lumice VERSION 4.4.2)
 
 set(CMAKE_VERBOSE_MAKEFILE OFF)
@@ -52,21 +75,22 @@ endif()
 # Revisit this choice if that changes — publishing a DLL for third-party consumers is
 # the trigger, not a version bump.
 #
-# The two policy lines are load-bearing, not boilerplate:
-#   - CMP0091 (the policy that makes CMAKE_MSVC_RUNTIME_LIBRARY mean anything) arrived
-#     in CMake 3.15. Below the cmake_minimum_required set at the top of this file it
-#     defaults to OLD, and CMake then ignores the variable *silently* — no warning, no
-#     error, just /MD in the compile command. Setting the variable alone is not enough.
-#   - CMAKE_POLICY_DEFAULT_CMP0091 covers scopes created later. A function records the
-#     policy stack in effect where it was *defined*, and cmake/CPM.cmake declares its own
-#     (lower) cmake_minimum_required at the top, so CPMAddPackage and the
-#     add_subdirectory it performs run with CMP0091 unset. Without this line the
-#     third-party dependency scopes keep /MD and mix with a /MT main build.
-# Both must precede include(cmake/CPM.cmake) and every add_subdirectory below.
+# The setting below only means something if CMP0091 is NEW; that is arranged before
+# project() at the top of this file, where the reasoning lives.
 #
-# When you touch these lines, verify the *artifact*, not the intent: check that the
-# generated build.ninja compile FLAGS say /MT (dependencies included, not just this
-# project's own sources) and that dumpbin /dependents on the produced .exe lists no
+# The guard here checks the state that actually decides the outcome rather than the
+# policy's nominal value: under CMP0091 NEW, CMake puts no runtime-library flag in the
+# per-config flag defaults and adds it from the abstraction instead. A runtime flag
+# sitting in those defaults therefore means the abstraction is being ignored and this
+# build links the dynamic CRT no matter what the line below says — whether because the
+# CMake in use predates 3.15, because someone moved the policy call below project()
+# (that regression is not hypothetical), or because the flags were overridden on the
+# command line. Asking cmake_policy(GET) instead would not catch any of those: it
+# reports NEW happily while the baked flags win.
+#
+# When you touch this, verify the *artifact*, not the intent: check that the generated
+# build.ninja compile FLAGS carry the static-CRT flag (dependencies included, not just
+# this project's own sources) and that dumpbin /dependents on the produced .exe lists no
 # MSVCP140.dll / VCRUNTIME140.dll / VCRUNTIME140_1.dll. This block was inert for a long
 # time precisely because it was only ever read, never measured. If some target ever needs
 # a per-target MSVC_RUNTIME_LIBRARY override, add it in one named block per build unit
@@ -74,12 +98,13 @@ endif()
 # scattering set_target_properties calls, so a reader can still answer "who decides this
 # target's CRT" from a single place.
 if(MSVC)
-  if(POLICY CMP0091)
-    cmake_policy(SET CMP0091 NEW)
-    set(CMAKE_POLICY_DEFAULT_CMP0091 NEW)
-  else()
-    message(WARNING "CMake <3.15 does not know CMP0091; MSVC runtime library selection is "
-                    "ignored and this build will link the DYNAMIC CRT (/MD) instead of /MT.")
+  if("${CMAKE_CXX_FLAGS_RELEASE} ${CMAKE_CXX_FLAGS_DEBUG} ${CMAKE_CXX_FLAGS_RELWITHDEBINFO} ${CMAKE_CXX_FLAGS_MINSIZEREL}"
+     MATCHES "[-/]M[DT]")
+    message(WARNING "MSVC runtime library selection is not in effect: a runtime flag is "
+                    "baked into the per-config compiler flags, so CMAKE_MSVC_RUNTIME_LIBRARY "
+                    "is ignored and this build will link whichever CRT that flag names "
+                    "(CMake <3.15, a CMP0091 call moved after project(), or overridden "
+                    "CMAKE_CXX_FLAGS_<CONFIG>).")
   endif()
   set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,13 +1,19 @@
 # ==================================================================================================
 # Google Test
-# gtest_force_shared_crt drives GoogleTest's own pre-CMP0091 mechanism: it rewrites
-# /MD into /MT in the compiler flags itself and knows nothing about
-# CMAKE_MSVC_RUNTIME_LIBRARY. It has to agree with the CRT this project selects (see the
-# MSVC block in the top-level CMakeLists.txt) or gtest links against a different CRT than
-# everything it is linked into. It was ON back when the whole project effectively built
-# /MD; OFF is the value that matches /MT, and is also GoogleTest's own default. Kept
-# explicit rather than deleted so the coupling stays visible at the point it applies.
-set(gtest_force_shared_crt OFF CACHE BOOL "" FORCE)
+# gtest_force_shared_crt drives GoogleTest's own pre-CMP0091 mechanism: it rewrites the
+# dynamic-CRT flag into the static one in the inherited compiler flags itself, and knows
+# nothing about CMAKE_MSVC_RUNTIME_LIBRARY. It has to agree with the CRT this build
+# actually selected or gtest links against a different CRT than everything it is linked
+# into — which surfaces as LNK2038/LNK1319 at link time, not as anything readable here.
+# Hence it follows LUMICE_MSVC_STATIC_CRT (set in the top-level CMakeLists.txt, where the
+# CRT choice and its reasoning live) rather than restating the condition: this variable
+# reports what the build measured, so the two cannot drift apart. Kept explicit rather
+# than deleted so the coupling stays visible at the point it applies.
+if(LUMICE_MSVC_STATIC_CRT)
+  set(gtest_force_shared_crt OFF CACHE BOOL "" FORCE)
+else()
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+endif()
 CPMAddPackage(
   NAME GTest
   URL https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,13 @@
 # ==================================================================================================
 # Google Test
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+# gtest_force_shared_crt drives GoogleTest's own pre-CMP0091 mechanism: it rewrites
+# /MD into /MT in the compiler flags itself and knows nothing about
+# CMAKE_MSVC_RUNTIME_LIBRARY. It has to agree with the CRT this project selects (see the
+# MSVC block in the top-level CMakeLists.txt) or gtest links against a different CRT than
+# everything it is linked into. It was ON back when the whole project effectively built
+# /MD; OFF is the value that matches /MT, and is also GoogleTest's own default. Kept
+# explicit rather than deleted so the coupling stays visible at the point it applies.
+set(gtest_force_shared_crt OFF CACHE BOOL "" FORCE)
 CPMAddPackage(
   NAME GTest
   URL https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz


### PR DESCRIPTION
## 问题

`CMakeLists.txt` 第一行是 `cmake_minimum_required(VERSION 3.14)`，而 CMP0091（MSVC 运行时库选择）是 CMake **3.15** 引入的。低于 3.15 时该 policy 默认停在 `OLD`，`CMAKE_MSVC_RUNTIME_LIBRARY` 被**完全忽略且不发任何警告**。

后果：那行 `set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded...")` 从未生效过。Windows 产物实际链接 `/MD`，`dumpbin /dependents` 坐实依赖 `MSVCP140.dll` / `VCRUNTIME140.dll` / `VCRUNTIME140_1.dll` —— 与紧邻的注释声明的「分发不依赖 vcruntime DLL」意图相反，分发的 exe 在未装 VC++ Redistributable 的机器上无法启动。

## 改动

- `cmake_policy(SET CMP0091 NEW)` + `CMAKE_POLICY_DEFAULT_CMP0091 NEW` 移到 `project()` **之前**（CMP0091 的硬约束），后者覆盖 CPM 引入的第三方依赖作用域。
- 新增 `LUMICE_MSVC_STATIC_CRT` 作为单一派生真源。**它的取值来自实测烘焙进 per-config flags 的 runtime 标志**（`string(REGEX MATCHALL)` 收集 `/MT`、`/MD` 的实际出现），而不是 policy 的名义返回值 —— 本次缺陷的根源正是「读意图不读产物」，所以闸本身必须读产物。覆盖 C 与 CXX 两个变量组（只测 CXX 会放过「仅 C 侧退回 OLD」，纯 C 的第三方依赖如 glad 正走这条路）。全 `/MT` 判 `ON`；全 `/MD` 或**混合**判 `OFF`（保守值），混合态单独给一条文案指向 LNK1319/LNK2038，避免把读者引去查「为什么整体退回 /MD」这个错误方向。
- `test/CMakeLists.txt` 的 `gtest_force_shared_crt` 改为跟随 `LUMICE_MSVC_STATIC_CRT`，不再复述条件（防「主工程 /MD × gtest -MT」的 LNK1319 重演）。
- `.github/workflows/release.yml`：在「只发布 CLI/GUI 可执行文件」那行下方加注释指回 CRT 说明，使发布策略侧也能看见这层耦合（原本是单向指涉）。
- CMake 注释补齐**为什么**选 `/MT`、为什么 DLL 必须留 `/MD`、CMP0091 为何必须在 `project()` 之前、改这里要核验产物而非意图。本次的根源教训就是「做法留下了、理由没留下」，只补做法等于留下同一个坑。

## 按 `BUILD_SHARED_LIBS` 分档：静态 `/MT`，DLL 保持 `/MD`

实施中实测发现 `/MT` 对 shared flavor 是**真回归**：静态 CRT 让 DLL 持有私有 CRT 环境块，宿主进程运行期写入的 `LUMICE_*` 环境变量对 DLL 内 `std::getenv` 不可见。隔离性对照只差这一个变量 —— `/MT` 下 CUDA parity 11 红，`/MD` 下 11 绿。这不只影响测试：`LUMICE_TRACE_BACKEND` 等 A 类运行期开关走的正是同一条 `getenv` 路径。

因此 `BUILD_SHARED_LIBS=OFF`（release 实际发布的 CLI/GUI 可执行文件）用 `/MT`，`ON`（DLL）保持 `/MD`。这不是同一次链接内部分 target 混用（那会 LNK2038），而是两次独立构建各自内部完全一致。

## 验证

Windows（CUDA 参照机，两个 flavor 各自清空 build 树后重 configure）：

| 配置 | `build.ninja` FLAGS | 结果 |
|---|---|---|
| static + CUDA + TEST + GUI | `MD=0 / MT=270` | CONFIGURE/BUILD/INSTALL exit 0；ctest 7/7；CLI 冒烟 exit 0；`dumpbin /dependents` 无 `MSVCP140` / `VCRUNTIME140*`（`api-ms-win-crt-*` 亦一并消失） |
| shared + CUDA + TEST | `MD=132 / MT=0` | CONFIGURE/BUILD exit 0；CUDA parity battery 11 passed |

- 全量日志 `LNK4098\|LNK2038\|LNK1319` 命中数 = 0。
- `cuda_trace_backend.cu.obj` 的 FLAGS 实测含 `-Xcompiler=-MT` —— nvcc host 侧**跟随** CMP0091，原先「CUDA 链可能不跟随」的猜测被实测推翻。
- macOS：`./scripts/test.sh quick` => `RESULT: PASS`（含 gui_test 287/287）；非 MSVC 分支两个 flavor configure 均 exit 0、零 warning。

## 已知边界

- `cmake_minimum_required` 的名义下限仍是 3.14。本仓无 CI job pin CMake 版本；若某 runner 低于 3.15，新闸会在 configure 阶段**显式告警**而非静默失效 —— 这是本次修复的主要保障，但仍未建自动化门禁。
- 顺带发现（正交，未在本 PR 处理）：`doc/gpu-remote-cuda-build-testing.md` §3 的 Windows parity recipe 实测不可行（Python 3.8+ 的 `ctypes.CDLL` 在 Windows 不再搜索 PATH，需把 `cudart64_12.dll` 复制到 DLL 同目录）。照可行做法跑通后，CUDA parity battery 在 Windows 上是第一次真正跑通。已记入 backlog。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
