### PR TITLE
feat(gui): 晶体卡新增「参与仿真」toggle，替代把权重拖到 0

### DIFF
--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -1622,7 +1622,13 @@ ScenePtr BuildScene(const GuiState& state, SceneIntent intent, FilterOverflowInf
         cid = it_c->second;
       }
       dst_layer.entries[k].crystal_id = cid;
-      dst_layer.entries[k].proportion = entry.proportion;
+      // enabled=false is translated here — the single GUI->core assembly point — into the
+      // proportion=0 the engine already handles (trace_backend.hpp: such a (layer, ci) never
+      // reaches MakeCrystal). entry.proportion itself is left alone, so the user's stored weight
+      // survives a disable/enable round trip. Both SceneIntents get the same translation: a
+      // scene exported for the CLI must reproduce what the preview actually renders, and the core
+      // JSON schema has no "enabled" key, so proportion=0 is the only faithful expression of it.
+      dst_layer.entries[k].proportion = entry.enabled ? entry.proportion : 0.0f;
 
       if (entry.filter_id.has_value()) {
         int fpool = *entry.filter_id;
@@ -2498,6 +2504,7 @@ std::string SerializeGuiStateJson(const GuiState& state) {
       json je;
       je["crystal"] = SerializeCrystal(state.crystals[entry.crystal_id], ser_crystal_id++);
       je["proportion"] = entry.proportion;
+      je["enabled"] = entry.enabled;
       if (entry.filter_id.has_value()) {
         je["filter"] = SerializeFilterForGui(state.filters[*entry.filter_id], ser_filter_id++);
       }
@@ -2621,6 +2628,9 @@ bool DeserializeGuiStateJson(const std::string& json_str, GuiState& state) {
             state.crystals.emplace_back();
           }
           entry.proportion = je.value("proportion", EntryCard{}.proportion);
+          // Absent key = a document written before the toggle existed; those entries all
+          // participated, which is exactly EntryCard{}.enabled.
+          entry.enabled = je.value("enabled", EntryCard{}.enabled);
           if (je.contains("filter") && !je["filter"].is_null()) {
             // nullopt = the file's filter object stated no predicate, so the entry gets no filter
             // and nothing enters the pool (NoFilterIfNoPredicate). Same end state as an entry whose
@@ -2681,6 +2691,10 @@ bool DeserializeGuiStateJson(const std::string& json_str, GuiState& state) {
               state.crystals.emplace_back();
             }
             entry.proportion = je.value("proportion", EntryCard{}.proportion);
+            // Same backward-compatible default as the v2 branch above. Both read paths must be
+            // patched together: a document reaching the GUI through only one of them would
+            // silently lose the toggle state.
+            entry.enabled = je.value("enabled", EntryCard{}.enabled);
             int filter_id = je.value("filter_id", -1);
             if (filter_id >= 0 && filter_map.count(filter_id)) {
               auto it = filter_id_to_pool.find(filter_id);

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -766,26 +766,41 @@ struct FilterConfig {
 // entries sharing the same crystal_id automatically observe pool mutations on
 // the next render, no mirror logic needed.
 //
-// operator== compares ids + proportion only (intentional: pool contents are
-// compared via the pool itself in ConfigSnapshot/round-trip tests). Adding a
-// field here requires updating operator== too.
+// operator== compares ids + proportion + enabled only (intentional: pool
+// contents are compared via the pool itself in ConfigSnapshot/round-trip
+// tests). Adding a field here requires updating operator== too.
 struct EntryCard {
   int crystal_id = 0;
   std::optional<int> filter_id;
   float proportion = 100.0f;
 
+  // "Participates in the simulation" toggle. GUI-only concept: it never
+  // crosses the C API — BuildScene translates enabled=false into the
+  // proportion=0 the engine already understands, leaving `proportion` itself
+  // untouched so the user's weight survives a disable/enable round trip.
+  //
+  // Semantics are "exclude, then re-run", NOT display-time subtraction: the
+  // excluded crystal's share of the fixed total ray count is redistributed to
+  // its siblings by PartitionCrystalRayNum, so the remaining crystals get more
+  // samples (less noise, and auto-EV brightness moves with it). This is why the
+  // card's toggle must not reuse the Colors panel's eye glyph, which does mean
+  // display-time subtraction.
+  bool enabled = true;
+
   friend bool operator==(const EntryCard& a, const EntryCard& b) {
-    return a.crystal_id == b.crystal_id && a.filter_id == b.filter_id && a.proportion == b.proportion;
+    return a.crystal_id == b.crystal_id && a.filter_id == b.filter_id && a.proportion == b.proportion &&
+           a.enabled == b.enabled;
   }
   friend bool operator!=(const EntryCard& a, const EntryCard& b) { return !(a == b); }
 };
 // Apple Silicon + libc++ only. New EntryCard layout (post ID-pool migration):
-// int crystal_id (4) + optional<int> filter_id (8) + float proportion (4) = 16 bytes.
+// int crystal_id (4) + optional<int> filter_id (8) + float proportion (4)
+// + bool enabled (1, padded to 4) = 20 bytes.
 // Pinning the Apple build catches accidental field additions during local dev;
 // Linux/Windows CI still compiles the struct.
 #if defined(__APPLE__) && defined(__aarch64__)
-static_assert(sizeof(EntryCard) == 16,
-              "EntryCard size changed (check id fields / proportion / operator== for new fields)");
+static_assert(sizeof(EntryCard) == 20,
+              "EntryCard size changed (check id fields / proportion / enabled / operator== for new fields)");
 #endif
 
 struct Layer {
@@ -882,6 +897,19 @@ constexpr float kProbZeroEps = 0.005f;
 constexpr float kDefaultContinuationProb = 0.8f;
 inline bool IsProbZero(float p) {
   return p < kProbZeroEps;
+}
+
+// True when the layer has entries but every one of them is toggled out of the
+// simulation, i.e. the layer contributes nothing. Kept as a free function (same
+// pattern as IsProbZero above) so the panel's warning predicate is testable
+// without an ImGui context: the warning itself is drawn with TextColored, which
+// IsItemHovered/ItemExists cannot reach from a gui_test.
+//
+// An empty layer is deliberately NOT "all disabled" — it has no toggles in it,
+// so the "you turned everything off" message would be misleading.
+inline bool AllEntriesDisabled(const Layer& layer) {
+  return !layer.entries.empty() &&
+         std::all_of(layer.entries.begin(), layer.entries.end(), [](const EntryCard& e) { return !e.enabled; });
 }
 
 struct GuiState {

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -1064,8 +1064,12 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
   // number — and the thumbnail corner is the only always-free real estate on the card that does
   // not push the right column's four rows out of their shared three-column alignment.
   {
+    // "###" and not "##": the visible glyph flips with the state, and with "##" the id hashes the
+    // whole label, so the button would become a different widget the instant it is clicked —
+    // losing ImGui's active-id continuity and leaving no stable path for a test to address. Same
+    // reasoning as the defaults panel's state-dependent cells.
     char toggle_id[48];
-    snprintf(toggle_id, sizeof(toggle_id), "%s##enabled_%d_%d", entry.enabled ? ICON_FA_TOGGLE_ON : ICON_FA_TOGGLE_OFF,
+    snprintf(toggle_id, sizeof(toggle_id), "%s###enabled_%d_%d", entry.enabled ? ICON_FA_TOGGLE_ON : ICON_FA_TOGGLE_OFF,
              layer_idx, entry_idx);
     constexpr float kTogglePad = 3.0f;
     ImGui::SetCursorScreenPos(ImVec2(thumb_pos.x + kTogglePad, thumb_pos.y + kTogglePad));

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -1039,13 +1039,56 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
   ImDrawList* draw_list = ImGui::GetWindowDrawList();
   auto thumb_tex = g_thumbnail_cache.GetTexture(entry.crystal_id);
   ImVec2 thumb_br(thumb_pos.x + thumb_display_size, thumb_pos.y + thumb_display_size);
+  // An excluded entry draws its thumbnail dimmed so the card reads as "out" at a
+  // glance, from across the panel, without having to find the toggle glyph.
+  const ImU32 thumb_tint = entry.enabled ? IM_COL32(255, 255, 255, 255) : IM_COL32(255, 255, 255, 70);
   if (thumb_tex != 0) {
     // OpenGL texture Y-axis is flipped relative to ImGui: uv0=(0,1) uv1=(1,0)
-    draw_list->AddImage(static_cast<ImTextureID>(thumb_tex), thumb_pos, thumb_br, ImVec2(0, 1), ImVec2(1, 0));
+    draw_list->AddImage(static_cast<ImTextureID>(thumb_tex), thumb_pos, thumb_br, ImVec2(0, 1), ImVec2(1, 0),
+                        thumb_tint);
   } else {
-    draw_list->AddRectFilled(thumb_pos, thumb_br, IM_COL32(60, 60, 60, 255));
+    draw_list->AddRectFilled(thumb_pos, thumb_br,
+                             entry.enabled ? IM_COL32(60, 60, 60, 255) : IM_COL32(45, 45, 45, 255));
   }
   draw_list->AddRect(thumb_pos, thumb_br, IM_COL32(100, 100, 100, 255));
+
+  // ---- Participation toggle (always visible) ----
+  // Semantics: "exclude this crystal, then re-run". Turning it off does NOT subtract this
+  // crystal from the current image — it hands its share of the fixed total ray count back to
+  // its siblings on the next run, so the rest of the scene gets MORE samples. That is a
+  // different operation from the Colors panel's per-component eye, which is display-time
+  // subtraction, so the glyph here deliberately is not an eye.
+  //
+  // Placement: overlaid on the thumbnail's top-left corner. Unlike Delete/Duplicate this is not
+  // a hover-revealed action — "does this card count?" has to be as scannable as the Weight
+  // number — and the thumbnail corner is the only always-free real estate on the card that does
+  // not push the right column's four rows out of their shared three-column alignment.
+  {
+    char toggle_id[48];
+    snprintf(toggle_id, sizeof(toggle_id), "%s##enabled_%d_%d", entry.enabled ? ICON_FA_TOGGLE_ON : ICON_FA_TOGGLE_OFF,
+             layer_idx, entry_idx);
+    constexpr float kTogglePad = 3.0f;
+    ImGui::SetCursorScreenPos(ImVec2(thumb_pos.x + kTogglePad, thumb_pos.y + kTogglePad));
+    if (!entry.enabled) {
+      // Theme-owned disabled tone, not a semantic_colors.hpp grade: "excluded" is a state of
+      // this control, not a judgement about the crystal (see that header's scope note).
+      ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+    }
+    const bool toggle_clicked = ImGui::SmallButton(toggle_id);
+    if (!entry.enabled) {
+      ImGui::PopStyleColor();
+    }
+    if (toggle_clicked) {
+      entry.enabled = !entry.enabled;
+    }
+    if (ImGui::IsItemHovered()) {
+      ImGui::SetTooltip("%s", entry.enabled ?
+                                  "Participating. Click to exclude this crystal from the next run — its share of "
+                                  "the total ray count goes to the other crystals (they get more samples)." :
+                                  "Excluded from the next run. Its Weight is kept and takes effect again when you "
+                                  "turn it back on.");
+    }
+  }
 
   // Right column — layout matches SliderWithInput's three-column model:
   //   [text / slider (text_w)] [Edit button / input (kInputWidth)] [row label (kLabelColWidth)]
@@ -1120,7 +1163,15 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
   ImGui::SetCursorScreenPos(ImVec2(right_x, thumb_pos.y + row_h * 3.0f));
   char prop_label[32];
   snprintf(prop_label, sizeof(prop_label), "Weight##prop_%d_%d", layer_idx, entry_idx);
+  // Greyed out while excluded so it is visible that the number is currently inert — same
+  // disable-when-inert convention as the layer prob slider. BeginDisabled only blocks
+  // interaction; entry.proportion keeps its value, which is what makes the toggle reversible.
+  ImGui::BeginDisabled(!entry.enabled);
   SliderWithInput(prop_label, &entry.proportion, 0.0f, 100.0f, "%.1f");
+  ImGui::EndDisabled();
+  if (!entry.enabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+    ImGui::SetTooltip("Weight is inert while this crystal is excluded. The value is kept.");
+  }
 
   // Hover action buttons: stacked vertically at the right edge of the card —
   // Delete (×) on top, Duplicate (D) below, separated by kHoverBtnGap. Alpha is
@@ -1192,6 +1243,10 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
     EntryCard new_entry;
     new_entry.crystal_id = static_cast<int>(state.crystals.size());
     new_entry.proportion = entry.proportion;
+    // Duplicate builds the clone field-by-field rather than copying the struct, so every
+    // EntryCard field needs a line here. Carrying `enabled` over keeps duplicate a pure clone:
+    // without it, duplicating an excluded card would hand back a participating one.
+    new_entry.enabled = entry.enabled;
     state.crystals.push_back(std::move(cloned_crystal));
     if (cloned_filter.has_value()) {
       new_entry.filter_id = static_cast<int>(state.filters.size());
@@ -1392,6 +1447,19 @@ void RenderLayer(GuiState& state, int layer_idx) {
       if (ImGui::IsItemHovered()) {
         ImGui::SetTooltip("%s", prob_tip);
       }
+    }
+
+    // Every crystal in this layer excluded: the layer contributes nothing to the next run.
+    // Non-blocking on purpose — it is a legitimate transient state while the user toggles cards
+    // one at a time, and the engine already handles it (PartitionCrystalRayNum returns an
+    // all-zero allocation for a zero total; see its AllZeroProportions unit test), so there is
+    // nothing to guard against, only something to point out.
+    if (AllEntriesDisabled(layer)) {
+      // Its own line rather than SameLine on the prob row: that row may already be showing a
+      // CIRCLE_EXCLAMATION for the prob footguns, and two identical glyphs side by side saying
+      // different things is worse than no icon at all.
+      ImGui::TextColored(WarningTextColor(),
+                         ICON_FA_CIRCLE_EXCLAMATION " All crystals excluded — layer produces no rays");
     }
 
     // Render entry cards with deferred deletion

--- a/test/composition-correctness/gui/test_document_roundtrip_chain.cpp
+++ b/test/composition-correctness/gui/test_document_roundtrip_chain.cpp
@@ -123,6 +123,21 @@ const std::vector<FieldProbe>& FieldProbes() {
       // how much of it, which is why nothing on screen says the file came back different.
       [](GuiState& s) { s.layers.at(0).entries.at(0).proportion = 75.0f; },
       [](const GuiState& s) { return std::to_string(s.layers.at(0).entries.at(0).proportion); } },
+    { "entry.enabled",
+      // Whether this entry takes part in the run at all. It is probed alongside a proportion that
+      // is emphatically not zero, because the failure mode is a writer that decides `enabled` is
+      // derivable from the weight: dropping the field then reloads an excluded crystal as a
+      // participating one at full weight, and the run comes back with the crystal the user
+      // switched off. The weight itself must survive the trip untouched — that is what makes the
+      // exclusion reversible.
+      [](GuiState& s) {
+        s.layers.at(0).entries.at(0).enabled = false;
+        s.layers.at(0).entries.at(0).proportion = 42.0f;
+      },
+      [](const GuiState& s) {
+        const EntryCard& e = s.layers.at(0).entries.at(0);
+        return std::string(e.enabled ? "on" : "off") + " @" + std::to_string(e.proportion);
+      } },
     { "sun.custom_spectrum",
       // The discrete spectrum is a list, not a name, and it is the one light-source field whose
       // absence leaves a perfectly valid document that simulates a different colour of sunlight.
@@ -467,6 +482,68 @@ TEST(DocumentRoundtripChain, AFilterWithNoRuleInItIsDroppedAndCounted) {
         << c.name << ": the document was changed on load with nothing to report it, or the reverse";
     EXPECT_EQ(TakeFilterNoPredicateDowngradeCount(), 0)
         << c.name << ": the counter did not clear on read, so a notice would never go away";
+  }
+}
+
+// E1 — a document written before the participation toggle existed loads as participating, on both
+// read paths.
+//
+// The probe sweep above cannot reach this. It writes with SerializeGuiStateJson and reads back with
+// DeserializeGuiStateJson, so both halves are the current version by construction, and the key is
+// always present. What ships is the other direction: every .lmc already on a user's disk is missing
+// this key, and the reader's answer to a missing key decides whether those documents come back
+// intact or with crystals silently switched off. `false` is the value a default-initialised bool
+// would have had, which is why the absent-key answer is worth pinning rather than assuming.
+//
+// Both branches of DeserializeGuiStateJson are exercised, not just the current one. The reader
+// picks its branch on the document's shape — "layers" is the v2 inline form, "crystals" +
+// "scattering" the legacy v1 pool form — and the two parse entries with separate code that shares
+// no helper for this field. A patch applied to one of them alone is green on every test that only
+// feeds the other, and the documents that would lose their toggle state are precisely the older
+// ones, i.e. the ones the compatibility default exists for. Present-key cases are here too: an
+// absent-key default of `true` is also what a reader that ignores the key entirely produces, so
+// without them the two branches would pass while never reading the field at all.
+TEST(DocumentRoundtripChain, AnEntryWithNoEnabledKeyLoadsAsParticipatingOnBothReadPaths) {
+  struct Case {
+    const char* name;
+    std::string doc;
+    bool expect_enabled;
+    float expect_proportion;
+  };
+
+  const char* kPrism = R"("crystal": {"type": "prism", "shape": {"height": 1.0}})";
+  const auto v2 = [&](const char* entry_tail) {
+    return std::string(R"({"layers": [{"prob": 0.0, "entries": [{)") + kPrism + entry_tail + R"(}]}]})";
+  };
+  const auto v1 = [](const char* entry_body) {
+    return std::string(R"({"crystals": [], "scattering": [{"prob": 0.0, "entries": [{)") + entry_body + R"(}]}]})";
+  };
+
+  const Case kCases[] = {
+    { "v2 inline, no enabled key", v2(R"(, "proportion": 42.0)"), true, 42.0f },
+    { "v2 inline, enabled false", v2(R"(, "proportion": 42.0, "enabled": false)"), false, 42.0f },
+    { "v2 inline, enabled true", v2(R"(, "proportion": 42.0, "enabled": true)"), true, 42.0f },
+    { "legacy v1 pool, no enabled key", v1(R"("crystal_id": 0, "proportion": 42.0)"), true, 42.0f },
+    { "legacy v1 pool, enabled false", v1(R"("crystal_id": 0, "proportion": 42.0, "enabled": false)"), false, 42.0f },
+    { "legacy v1 pool, enabled true", v1(R"("crystal_id": 0, "proportion": 42.0, "enabled": true)"), true, 42.0f },
+  };
+
+  for (const Case& c : kCases) {
+    GuiState loaded;
+    if (!DeserializeGuiStateJson(c.doc, loaded)) {
+      ADD_FAILURE() << c.name << ": the document failed to deserialize";
+      continue;  // nothing loaded to inspect; the remaining cases still get checked
+    }
+    if (loaded.layers.size() != 1 || loaded.layers.at(0).entries.size() != 1) {
+      ADD_FAILURE() << c.name << ": expected exactly one layer with one entry";
+      continue;
+    }
+    const EntryCard& e = loaded.layers.at(0).entries.at(0);
+    EXPECT_EQ(e.enabled, c.expect_enabled) << c.name << ": the entry came back with the wrong participation state";
+    // The weight rides along in every case: a reader that decided the two fields were one thing
+    // would satisfy the enabled check above and still lose the number the exclusion has to
+    // preserve.
+    EXPECT_FLOAT_EQ(e.proportion, c.expect_proportion) << c.name << ": the stored weight did not survive the load";
   }
 }
 

--- a/test/composition-correctness/gui/test_scene_commit_chain.cpp
+++ b/test/composition-correctness/gui/test_scene_commit_chain.cpp
@@ -717,5 +717,100 @@ TEST(SceneCommitChain, APoolFilterStatingNothingIsNeverReadAsMatchAll) {
   EXPECT_EQ(skipped, 0) << "nothing was there to skip";
 }
 
+// ---------------------------------------------------------------------------------------------
+// Excluding a crystal is exactly hand-zeroing its weight, and it does not consume the weight.
+
+// The claim the card's participation toggle makes is an equivalence: switching a crystal off and
+// re-running gives the run the user would have got by dragging that crystal's Weight to zero
+// themselves — the operation it replaces. It is asserted at the seam rather than on pixels because
+// that is where it is decidable. BuildScene is the single GUI->core emitter, so two documents that
+// emit the same scene are the same run by construction: the engine is deterministic given the same
+// input and seed, and comparing two rendered images instead would answer a noisier question at far
+// greater cost.
+//
+// The comparison is the WHOLE scene document, not just the one proportion. `enabled` is a GUI-only
+// concept translated at exactly one line, and the failure worth catching is a second translation
+// appearing somewhere else — an excluded entry that also drops its filter, renumbers a crystal id,
+// or vanishes from the scattering list would still satisfy an assertion written on proportion
+// alone, while being a different run.
+//
+// Both intents are compared for the same reason the exposure case above compares both: the export
+// path feeds the CLI, and an exported config that still carries the excluded crystal at full weight
+// reproduces a picture the preview never showed.
+TEST(SceneCommitChain, ExcludingAnEntryCommitsTheSameSceneAsZeroingItsWeightByHand) {
+  // Two entries, not one: with a single entry both arms sum to zero total weight and the scene
+  // would compare equal even if the emitter ignored `enabled` and wrote 42 for it. The sibling is
+  // what makes the excluded entry's committed number observable.
+  const auto seed_two = [](bool use_toggle) {
+    SeedOneEntryDocument();
+    EntryCard sibling = g_state.layers[0].entries[0];
+    sibling.proportion = 58.0f;
+    g_state.layers[0].entries.push_back(sibling);
+    EntryCard& excluded = g_state.layers[0].entries[0];
+    excluded.proportion = use_toggle ? 42.0f : 0.0f;
+    excluded.enabled = use_toggle ? false : true;
+  };
+
+  seed_two(true);
+  const nlohmann::json toggled = CommitSceneJson(g_state);
+  const std::string toggled_export = CoreJson(g_state);
+  // The weight the user typed is still theirs after the commit: BuildScene takes a const GuiState&
+  // and translates on the way out, so turning the crystal back on restores 42 rather than 0. This
+  // is the half of the toggle that the equivalence above cannot show — an emitter that zeroed
+  // entry.proportion in place would pass every assertion below and still destroy the setting.
+  EXPECT_FLOAT_EQ(g_state.layers.at(0).entries.at(0).proportion, 42.0f)
+      << "committing consumed the excluded entry's stored weight";
+  EXPECT_FALSE(g_state.layers.at(0).entries.at(0).enabled) << "committing flipped the toggle back on";
+
+  seed_two(false);
+  const nlohmann::json by_hand = CommitSceneJson(g_state);
+  const std::string by_hand_export = CoreJson(g_state);
+
+  ASSERT_FALSE(toggled.is_null()) << "the document with an excluded entry did not commit at all";
+  ASSERT_FALSE(by_hand.is_null()) << "the hand-zeroed document did not commit at all";
+  EXPECT_FLOAT_EQ(toggled["scene"]["scattering"][0]["entries"][0]["proportion"].get<float>(), 0.0f)
+      << "the excluded entry reached the simulator at its stored weight: "
+      << toggled["scene"]["scattering"][0]["entries"][0].dump();
+  EXPECT_FLOAT_EQ(toggled["scene"]["scattering"][0]["entries"][1]["proportion"].get<float>(), 58.0f)
+      << "excluding one entry rewrote its sibling's weight";
+  EXPECT_EQ(toggled, by_hand) << "excluding a crystal is not the same run as zeroing its weight";
+  EXPECT_EQ(toggled_export, by_hand_export) << "the two are the same run but export as different configs";
+}
+
+// A layer with every crystal excluded is a state the GUI has to survive, not one it has to prevent.
+//
+// The engine already handles it: PartitionCrystalRayNum returns an all-zero allocation for a
+// zero total (its AllZeroProportions unit test pins that), and a zero-proportion entry never
+// reaches MakeCrystal. So the disposition here is a notice, not a guard — and a notice is only
+// honest if the thing it describes actually commits. What this pins is that it does: the commit
+// produces a scene rather than a null, with the layer's entries all at zero.
+//
+// AllEntriesDisabled is checked in the same case because it is the predicate the panel's notice is
+// drawn from, and the notice itself is TextColored, which no gui_test assertion can reach. Its
+// empty-layer answer is pinned too: an empty layer holds no toggles, so reporting "you turned
+// everything off" about it would be a message about something the user never did.
+TEST(SceneCommitChain, ALayerWithEveryCrystalExcludedStillCommits) {
+  SeedOneEntryDocument();
+  EntryCard sibling = g_state.layers[0].entries[0];
+  g_state.layers[0].entries.push_back(sibling);
+  EXPECT_FALSE(AllEntriesDisabled(g_state.layers[0])) << "a fully participating layer reported as all-excluded";
+
+  for (EntryCard& e : g_state.layers[0].entries) {
+    e.enabled = false;
+  }
+  EXPECT_TRUE(AllEntriesDisabled(g_state.layers[0])) << "every entry is excluded and the predicate disagrees";
+
+  const nlohmann::json scene = CommitSceneJson(g_state);
+  ASSERT_FALSE(scene.is_null()) << "a layer with everything excluded refused to commit";
+  const nlohmann::json& entries = scene["scene"]["scattering"][0]["entries"];
+  ASSERT_EQ(entries.size(), 2u) << "the excluded entries were dropped from the scene rather than zeroed";
+  for (const nlohmann::json& je : entries) {
+    EXPECT_FLOAT_EQ(je["proportion"].get<float>(), 0.0f) << je.dump();
+  }
+
+  Layer empty;
+  EXPECT_FALSE(AllEntriesDisabled(empty)) << "a layer with no entries at all was reported as all-excluded";
+}
+
 }  // namespace
 }  // namespace lumice::gui

--- a/test/gui/functional/test_entry_management.cpp
+++ b/test/gui/functional/test_entry_management.cpp
@@ -84,13 +84,15 @@ ImGuiWindow* CardWindow(int index) {
 // draw list rather than submitted as an item — and this stays inside its left edge, clear of the
 // right column's four rows of widgets and of the Delete/Duplicate stack at the card's right edge.
 //
-// Vertically it aims at the thumbnail's lower half rather than a fixed offset from the top. The
-// top-left corner used to be blank and no longer is: the participation toggle is overlaid there,
-// and while it does correctly keep the card's click handler off itself (IsAnyItemHovered), a
-// helper still pointing at that corner reports it as "nothing to click" and silently turns three
-// unrelated cases into a click on the toggle. Anything added to a card's corners in future needs
-// this same second look — the constraint is that the returned point hits no item, and no compiler
-// or gate enforces it.
+// Vertically it takes three quarters of the card's own height, which under the current layout
+// lands in the thumbnail's lower half — the card is the thumbnail plus window padding, so the
+// two are not independent quantities, but neither is the correspondence enforced anywhere. A
+// fixed offset from the top would not do: the top-left corner used to be blank and no longer is,
+// because the participation toggle is overlaid there, and while it does correctly keep the card's
+// click handler off itself (IsAnyItemHovered), a helper still pointing at that corner reports it
+// as "nothing to click" and silently turns three unrelated cases into a click on the toggle.
+// Anything added to a card's corners in future needs this same second look — the constraint is
+// that the returned point hits no item, and no compiler or gate enforces it.
 ImVec2 CardBlankSpot(int index) {
   ImGuiWindow* w = CardWindow(index);
   IM_CHECK_RETV(w != nullptr, ImVec2(0, 0));

--- a/test/gui/functional/test_entry_management.cpp
+++ b/test/gui/functional/test_entry_management.cpp
@@ -80,12 +80,21 @@ ImGuiWindow* CardWindow(int index) {
 //
 // There is no widget there to click, and that is the point of the proposition: RenderEntryCard
 // hit-tests the card rectangle itself so the whole card is a target, and a test that clicked a
-// button instead would not exercise it. 30 px in from the card's left edge is inside the thumbnail,
-// which is drawn rather than submitted as an item.
+// button instead would not exercise it. The thumbnail is the blank half — it is drawn into the
+// draw list rather than submitted as an item — and this stays inside its left edge, clear of the
+// right column's four rows of widgets and of the Delete/Duplicate stack at the card's right edge.
+//
+// Vertically it aims at the thumbnail's lower half rather than a fixed offset from the top. The
+// top-left corner used to be blank and no longer is: the participation toggle is overlaid there,
+// and while it does correctly keep the card's click handler off itself (IsAnyItemHovered), a
+// helper still pointing at that corner reports it as "nothing to click" and silently turns three
+// unrelated cases into a click on the toggle. Anything added to a card's corners in future needs
+// this same second look — the constraint is that the returned point hits no item, and no compiler
+// or gate enforces it.
 ImVec2 CardBlankSpot(int index) {
   ImGuiWindow* w = CardWindow(index);
   IM_CHECK_RETV(w != nullptr, ImVec2(0, 0));
-  return ImVec2(w->Pos.x + 30.0f, w->Pos.y + 20.0f);
+  return ImVec2(w->Pos.x + 30.0f, w->Pos.y + w->Size.y * 0.75f);
 }
 
 // A second entry in layer 0, bound to a pool slot of its own.

--- a/test/gui/functional/test_entry_management.cpp
+++ b/test/gui/functional/test_entry_management.cpp
@@ -42,6 +42,7 @@
 #include <string>
 
 #include "IconsFontAwesome6.h"
+#include "gui/edit_modals.hpp"  // IsEditModalOpen — the toggle must not also trip the card's click handler
 #include "gui/gui_state.hpp"
 #include "imgui_internal.h"  // ImGuiWindow — a card's widgets are not addressable by path; see CardWindow
 #include "test_gui_shared.hpp"
@@ -448,6 +449,68 @@ void RegisterEntryManagementTests(ImGuiTestEngine* engine) {
 
       gui::g_state.crystals[dup_cid].prism_h = 3.7f;
       IM_CHECK_EQ(gui::g_state.crystals[orig_cid].prism_h, 2.5f);
+    };
+  }
+
+  // The participation toggle, driven through the real button, on the two properties that make it a
+  // toggle rather than a shortcut for dragging Weight to zero.
+  //
+  // First: it is reversible. The operation it replaces destroys the number — a user who "excluded" a
+  // crystal by dragging its Weight to 0 has no way back to the share they had chosen, and finds out
+  // only when they try to bring it back. So the weight is read before, between and after, and it has
+  // to be the same 42 every time; a toggle implemented as "write 0, remember nothing" satisfies
+  // every other assertion here and fails exactly this one.
+  //
+  // Second: the button is a real item, which is what keeps the card's own click handler off it. The
+  // card body opens the edit modal on any click that no item claimed (IsAnyItemHovered), and a
+  // toggle drawn with the draw list instead of as a widget would flip the state AND open the modal
+  // over the panel. That is asserted here rather than reasoned about, because the toggle sits on top
+  // of the thumbnail — inside the very rectangle CardBlankSpot uses as "nothing here to click".
+  {
+    ImGuiTest* t =
+        IM_REGISTER_TEST(engine, "entry_management", "the_participation_toggle_flips_without_touching_weight");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      gui::g_state.layers[0].entries[0].proportion = 42.0f;
+      ctx->Yield(2);
+      IM_CHECK(gui::g_state.layers[0].entries[0].enabled);
+
+      ctx->ItemClick("**/###enabled_0_0");
+      ctx->Yield(2);
+      IM_CHECK(!gui::g_state.layers[0].entries[0].enabled);
+      IM_CHECK_EQ(gui::g_state.layers[0].entries[0].proportion, 42.0f);
+      IM_CHECK(!gui::IsEditModalOpen());
+
+      // Back on through the same id: the label's glyph flipped with the state, so a button whose id
+      // hashed its label would no longer be at this path at all.
+      ctx->ItemClick("**/###enabled_0_0");
+      ctx->Yield(2);
+      IM_CHECK(gui::g_state.layers[0].entries[0].enabled);
+      IM_CHECK_EQ(gui::g_state.layers[0].entries[0].proportion, 42.0f);
+      IM_CHECK(!gui::IsEditModalOpen());
+    };
+  }
+
+  // Excluding a crystal is a change to the document, so the run that is on screen no longer matches
+  // it. Pinned through the frame-tail reconcile the same way the duplicate case below is: nothing at
+  // the click site marks anything: the reconciler notices because EntryCard::operator== compares
+  // `enabled`, and an operator that did not would leave the user looking at a stale picture with the
+  // crystal still in it and the GUI reporting everything up to date.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "entry_management", "excluding_a_crystal_marks_the_run_out_of_date");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      gui::g_state.run_intent = gui::RunIntent::kLoaded;
+      gui::g_state.sim_state = gui::GuiState::SimState::kDone;
+      gui::g_state.dirty = false;
+      gui::g_state.last_committed_state = gui::GuiState::ConfigSnapshot::From(gui::g_state);
+      ctx->Yield(2);
+      IM_CHECK(!gui::g_state.dirty);
+
+      ctx->ItemClick("**/###enabled_0_0");
+      ctx->Yield(2);
+      IM_CHECK(!gui::g_state.layers[0].entries[0].enabled);
+      IM_CHECK(gui::g_state.dirty);
     };
   }
 

--- a/test/gui/functional/test_entry_management.cpp
+++ b/test/gui/functional/test_entry_management.cpp
@@ -514,6 +514,36 @@ void RegisterEntryManagementTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // Duplicating an excluded card produces an excluded card.
+  //
+  // Duplicate does not copy the struct — it default-constructs an EntryCard and assigns the fields
+  // it means to carry, one by one — so a field that nobody remembers to list is not copied badly,
+  // it is silently reset to its default. `enabled` defaults to true, which makes the omission read
+  // as "the copy joined the run": the user duplicates a crystal they had switched off, and gets one
+  // that is switched on, at full weight. That is a change to the scene made by an operation whose
+  // whole promise is that it changes nothing but the count.
+  //
+  // Driven through the real button because the field list lives in the click handler; a test
+  // written against a helper would be pinning a copy of the list rather than the list.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "entry_management", "duplicating_an_excluded_card_copies_the_exclusion");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      gui::g_state.layers[0].entries[0].enabled = false;
+      gui::g_state.layers[0].entries[0].proportion = 42.0f;
+      ctx->Yield(2);
+
+      ctx->ItemClick("**/" ICON_FA_COPY "##dup_0_0");
+      ctx->Yield(2);
+
+      IM_CHECK_EQ(static_cast<int>(gui::g_state.layers[0].entries.size()), 2);
+      IM_CHECK(!gui::g_state.layers[0].entries[1].enabled);
+      // The weight rides along the same way it does everywhere else: a clone that kept the
+      // exclusion but reset the weight would come back at 100 the moment it is switched on.
+      IM_CHECK_EQ(gui::g_state.layers[0].entries[1].proportion, 42.0f);
+    };
+  }
+
   // Duplicating a card that carries a filter appends a filter pool slot, which the reconciler reads
   // as a structural change and therefore as grounds to restart the run. Pinned end to end through
   // the real button, because the effect is produced by the frame-tail reconcile rather than by the

--- a/test/gui/references/left_panel_default.jpg
+++ b/test/gui/references/left_panel_default.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:661e60f02064e15bcf6dc2645dd875435c5552ba2c30c1b4a1bb9f79b5598811
-size 18940
+oid sha256:b85478db54d322cf55ced3c5308d8177de74ab91348595512b3c0649ac3c12f9
+size 15862


### PR DESCRIPTION
## 问题

想临时关掉某几个晶体再重跑，今天只能**把权重滑杆拖到 0**——操作别扭，而且会**毁掉用户原本设好的权重值**。

## 语义定死：这是「排除后重跑」，不是成分分解

`PartitionCrystalRayNum(proportions, ray_num, carry)` 把**固定的总光线数**按比例分给各晶体。所以：

| 做法 | 关掉一个晶体之后 |
|---|---|
| **权重归零（本 PR，重跑）** | 它那份光线**重新分给其余晶体** ⇒ 其余晶体采样数变多、噪声变小、自动 EV 下亮度也会动 |
| display-time 减法（**本 PR 不做**） | 纯减法，其余部分一根线都不动 |

⇒ 两条硬要求，均已落地：

1. **图标不复用 Colors 面板的眼睛**。本 PR 用 `ICON_FA_TOGGLE_ON` / `ICON_FA_TOGGLE_OFF`；`ICON_FA_EYE` / `ICON_FA_EYE_SLASH` 仍只出现在 `color_window.cpp`。同一个图标在两处给出不同语义是自找的困惑。
2. 文案 / 注释一律称「排除后重跑」，不称「成分分析」「分解」「隔离」。

> 与 backlog 的「光路成分分析」是两件事，本 PR 未向该方向扩张。

## 改动

- `EntryCard` 新增 `bool enabled = true`（GUI-only，**从不跨 C API**）。`operator==` 与 `sizeof` 的 `static_assert`（16 → 20）同步更新，正是该文件既有注释要求的。
- **`BuildScene` 是唯一折算点**：`enabled=false` 在这里译成引擎早已认识的 `proportion=0`，而 `entry.proportion` **本身不被写** ⇒ 关闭→开启后用户原权重不丢。两个 `SceneIntent` 走同一套折算，导出给 CLI 的场景必须复现预览所见。
- `.lmc` 往返保真：**v2 内联与 legacy v1 两条读路径一起补** `je.value("enabled", true)`——只补一条的话，从另一条进来的文档会静默丢掉 toggle 状态。缺键 = toggle 出现之前写的文档，那些 entry 本来就都参与。

## 全部关掉时

**核实既有行为后决定不加守卫**：`PartitionCrystalRayNum` 在 `total_prop<=0` 时已返回全零分配（其 `AllZeroProportions` 单测钉住这条）。GUI 侧只给一行非阻塞提示——用户逐个 toggle 时这本就是合法的中间态，没有需要拦的东西，只有需要说一声的东西。

## 验证

- 回归覆盖三类：`.lmc` 往返、**折算等价性**（关闭一个晶体 ≡ 手工把它权重设 0）、UI 交互。等价性用例比对的是**整份 scene 文档**而非单个 `proportion` 字段——注释里写明了原因：只断言 `proportion` 的话，一个就地改写 `entry.proportion` 的错误实现会通过全部断言，同时把用户的设定毁掉。
- `./scripts/test.sh quick` → `RESULT: PASS`（297/297，已 rebase 到含 #274 + #275 的 main 后复跑）
- 五道门禁全绿（含 `gui-state-field-tier-registration`）
- tier：`EntryCard` 嵌在 `layers` 内，继承其 `kStructSoft`；tier 表只登记 `GuiState` 顶层字段，故不产生新登记项（兄弟字段 `proportion` 同样未登记）。
- 重拍 `left_panel_default.jpg`（toggle 给晶体卡加了图标）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)