### PR TITLE
feat(gui): Overlay 辅助线组改为 6 列表格形态

### DIFF
--- a/doc/gui-guide.md
+++ b/doc/gui-guide.md
@@ -131,7 +131,9 @@ The lens choice changes the geometry of the projected image dramatically:
 
 ### Overlay
 
-Three independent auxiliary lines on top of the Render Preview: `Horizon`, `Grid`, and `Angular Distance` (iso-angular rings centered on the sun, e.g. the 22° / 46° halos). Each has a colour swatch, separate `Line` and `Label` checkboxes (toggle the projected line and the viewport-edge label independently — line-only, label-only, both, or neither), and an alpha slider. `Angular Distance` can be customised through an `Edit Angles...` popup that supports preset angles (9° / 22° / 28° / 46°) and arbitrary custom angles.
+The auxiliary lines drawn on top of the Render Preview, as one table — every overlay answers the same questions, so they are read as rows rather than as stacked blocks. The columns are: a colour swatch, the name, `Line` and `Label` checkboxes (toggle the projected line and the viewport-edge label independently — line-only, label-only, both, or neither), an `Alpha` cell you drag (click it to type an exact value), and a trailing `⋯` fold for the one field a row has that the others do not.
+
+Four rows: `Horizon`, `Grid`, `Angular Dist.` (iso-angular rings centered on the sun, e.g. the 22° / 46° halos — abbreviated to fit the panel's name column), and `Zenith/Nadir` (pixel-space marker dots, which carry no text label, so their `Label` cell is empty). `Angular Dist.` opens its angle editor behind the fold — preset angles (9° / 22° / 28° / 46°) plus arbitrary custom angles — and it is offered only while the circles are actually being drawn. `Zenith/Nadir` holds its marker radius in pixels behind its own fold.
 
 ## Render Preview
 

--- a/doc/gui-guide_zh.md
+++ b/doc/gui-guide_zh.md
@@ -131,7 +131,9 @@ GUI 需要 display server 和支持 OpenGL 3.2 Core Profile 的 GPU。
 
 ### Overlay（叠加）
 
-Render Preview 上的三组互相独立的辅助线：`Horizon`（地平线）、`Grid`（经纬网格）、`Angular Distance`（以太阳为中心的等角距环，例如 22°/46° 晕环）。每组都有颜色块、`Line` 与 `Label` 双复选框（分别控制线条和边缘标签的显隐，可独立组合 line-only / label-only / 全开 / 全关）、以及 alpha 滑块。`Angular Distance` 还提供 `Edit Angles...` 弹窗，支持 9° / 22° / 28° / 46° 预设角度以及任意自定义角度。
+Render Preview 上的辅助线，以一张表格呈现——每条辅助线回答的是同一组问题，所以它们是表格的行而不是堆叠的区块。列依次为：颜色块、名称、`Line` 与 `Label` 双复选框（分别控制线条和边缘标签的显隐，可独立组合 line-only / label-only / 全开 / 全关）、可拖动的 `Alpha` 单元格（单击即可键入精确值），以及行末的 `⋯` 折叠——里面放的是“只有这一行才有”的那个字段。
+
+共四行：`Horizon`（地平线）、`Grid`（经纬网格）、`Angular Dist.`（以太阳为中心的等角距环，例如 22°/46° 晕环；名称列宽度有限，故缩写）、`Zenith/Nadir`（天顶/天底的像素空间标记点，不带文字标签，因此它的 `Label` 单元格是空的）。`Angular Dist.` 的角度编辑器在折叠里——支持 9° / 22° / 28° / 46° 预设角度以及任意自定义角度——且仅在等角距环确实在绘制时才提供。`Zenith/Nadir` 的标记点半径（像素）则在它自己的折叠里。
 
 ## Render Preview（渲染预览）
 

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -627,6 +627,226 @@ void RenderLeftPanel(float window_height) {
   ImGui::End();
 }
 
+namespace {
+
+// The angle list behind the Angular Dist. row's fold: presets, a custom-angle input, and the
+// current list with per-entry delete.
+//
+// A named function rather than statements inside the row loop. A table row IS a loop body here, so
+// a popup written inline would be built once per row — four popups sharing one name, of which the
+// last one submitted wins. Having exactly one construction site is a property worth being able to
+// check by reading, not by trusting the loop's shape to stay what it is today.
+void RenderSunCirclesAnglePopup() {
+  bool at_limit = SunCirclesAtLimit(g_state.sun_circle_angles.size());
+
+  // Preset buttons
+  const float presets[] = { 9.0f, 22.0f, 28.0f, 46.0f };
+  for (float p : presets) {
+    const bool already = SunCircleAlreadyPresent(g_state.sun_circle_angles, p);
+    char label[16];
+    std::snprintf(label, sizeof(label), "%.0f\xc2\xb0", p);
+    ImGui::BeginDisabled(already || at_limit);
+    if (ImGui::Button(label)) {
+      g_state.sun_circle_angles.push_back(p);
+      std::sort(g_state.sun_circle_angles.begin(), g_state.sun_circle_angles.end());
+    }
+    ImGui::EndDisabled();
+    ImGui::SameLine();
+  }
+  ImGui::NewLine();
+
+  // Custom angle input
+  static float custom_angle = 22.0f;
+  ImGui::PushItemWidth(60.0f);
+  ImGui::InputFloat("##custom_angle", &custom_angle, 0.0f, 0.0f, "%.1f");
+  ImGui::PopItemWidth();
+  ImGui::SameLine();
+  ImGui::BeginDisabled(at_limit);
+  if (ImGui::Button("+##add_circle")) {
+    custom_angle = ClampSunCircleAngle(custom_angle);
+    g_state.sun_circle_angles.push_back(custom_angle);
+    std::sort(g_state.sun_circle_angles.begin(), g_state.sun_circle_angles.end());
+  }
+  ImGui::EndDisabled();
+
+  // Current list with delete buttons
+  ImGui::Separator();
+  int remove_idx = -1;
+  for (int i = 0; i < static_cast<int>(g_state.sun_circle_angles.size()); i++) {
+    ImGui::Text("%.1f\xc2\xb0", g_state.sun_circle_angles[i]);
+    ImGui::SameLine();
+    char del_label[32];
+    std::snprintf(del_label, sizeof(del_label), "x##del_%d", i);
+    if (ImGui::SmallButton(del_label)) {
+      remove_idx = i;
+    }
+  }
+  if (remove_idx >= 0) {
+    g_state.sun_circle_angles.erase(g_state.sun_circle_angles.begin() + remove_idx);
+  }
+}
+
+// The pixel radius behind the Zenith/Nadir row's fold. It is the one field only that row has, and
+// giving it a column of its own would have cost every other row an empty cell (and the name column
+// the width) to say something about one of the four — the fold is what buys "Angular Dist." its
+// uncut name (doc/gui-visual-language.md §4.4).
+void RenderZenithNadirRadiusPopup() {
+  const FieldEditorConstraint zn_r_c = ConstraintFor("overlay_zenith_nadir_radius_px", g_state);
+  SliderWithInput("Radius##zenith_nadir", &g_state.zenith_nadir_radius_px, static_cast<float>(zn_r_c.min_value),
+                  static_cast<float>(zn_r_c.max_value), zn_r_c.fmt, zn_r_c.scale);
+}
+
+// What a row's fold holds, when it holds anything. Two of the four overlays have a field the others
+// do not, and they are not the same field.
+enum class OverlayFold {
+  kNone,
+  kSunCircleAngles,
+  kZenithNadirRadius,
+};
+
+// One auxiliary line, as the table reads it. Every row answers the same questions — colour, name,
+// line, text label, opacity — which is exactly why the table is the right shape for them
+// (doc/gui-visual-language.md §4.4). `label` is null for a row that draws no text label at all;
+// that cell is then left EMPTY rather than filled with a disabled control or an explanatory word,
+// because "this one has no text" is what an empty cell in a labelled column already says.
+struct OverlayRowSpec {
+  const char* name;
+  const char* color_id;
+  float* color;
+  const char* line_id;
+  bool* line;
+  const char* label_id;  // null ⇒ no text label for this overlay; the cell stays empty.
+  bool* label;
+  const char* alpha_id;
+  const char* alpha_field;
+  float* alpha;
+  // Triple hash, unlike every other id above, and not a slip: the fold button's label carries a
+  // visible glyph, and ImGui hashes the WHOLE label for "glyph##suffix" — the id would then contain
+  // the icon codepoint, so renaming the icon would silently rename the item. "###suffix" hashes the
+  // suffix alone. Null for a row with no fold.
+  const char* fold_id;
+  OverlayFold fold;
+};
+
+// The Overlay group: the four auxiliary lines drawn over the preview, as one table.
+//
+// It replaces four stacked two-row blocks that repeated the word "Alpha" four times and anchored
+// their checkboxes at an x computed from the width of the longest name — an arrangement in which
+// adding a name longer than "Angular Distance" silently overlapped the Line column.
+void RenderOverlaysTab() {
+  const OverlayRowSpec rows[] = {
+    { "Horizon", "##horizon_color", g_state.horizon_color, "##horizon_line", &g_state.show_horizon_line,
+      "##horizon_label", &g_state.show_horizon_label, "##horizon_alpha", "overlay_horizon_alpha",
+      &g_state.horizon_alpha, nullptr, OverlayFold::kNone },
+    { "Grid", "##grid_color", g_state.grid_color, "##grid_line", &g_state.show_grid_line, "##grid_label",
+      &g_state.show_grid_label, "##grid_alpha", "overlay_grid_alpha", &g_state.grid_alpha, nullptr,
+      OverlayFold::kNone },
+    // "Angular Dist." rather than the field's full name "Angular Distance": the name column is what
+    // every other column's declared width leaves over, and on this 300 px panel the full spelling is
+    // what the width budget cannot afford. Display string only — no id, no serialization key.
+    { "Angular Dist.", "##sun_circles_color", g_state.sun_circles_color, "##sun_circles_line",
+      &g_state.show_sun_circles_line, "##sun_circles_label", &g_state.show_sun_circles_label, "##sun_circles_alpha",
+      "overlay_sun_circles_alpha", &g_state.sun_circles_alpha, "###sun_circles_fold", OverlayFold::kSunCircleAngles },
+    // The marker pair: pixel-space dots at the zenith and the nadir. No text label — hence a null
+    // label id — and the only row with a radius.
+    { "Zenith/Nadir", "##zenith_nadir_color", g_state.zenith_nadir_color, "##zenith_nadir_line",
+      &g_state.show_zenith_nadir_line, nullptr, nullptr, "##zenith_nadir_alpha", "overlay_zenith_nadir_alpha",
+      &g_state.zenith_nadir_alpha, "###zenith_nadir_fold", OverlayFold::kZenithNadirRadius },
+  };
+
+  const float swatch_w = ImGui::GetFrameHeight();
+  const float check_w = ImGui::GetFrameHeight();
+  const float fold_w = ImGui::GetFrameHeight();
+  // Calibrated against THIS panel's width budget, not carried over from the wider layout this table
+  // was first written for: the right panel is kRightPanelWidth (300 px) wide, which leaves the table
+  // ~274 px, and the fixed columns plus cell padding claim all but ~129 px of it. Anything this
+  // column takes comes straight off the Name column, which is the only stretching one — so this
+  // number is the name column's budget stated from the other side. The arbiter is not this comment
+  // but test_overlay_controls.cpp's the_columns_line_up_and_no_name_is_cut_off: if a font or style
+  // change makes a name overflow, this literal is the one knob to turn.
+  constexpr float kAlphaColWidth = 54.6f;
+
+  // Name is the ONLY stretching column. That is the mechanism behind "the name is not cut off":
+  // every other column states the width it needs, and whatever is left goes to the names — rather
+  // than the names getting what is left over after an x anchor derived from the longest of them.
+  constexpr ImGuiTableFlags kFlags = ImGuiTableFlags_SizingFixedFit | ImGuiTableFlags_RowBg;
+  const ImVec2 outer_size(ImGui::GetContentRegionAvail().x, 0.0f);
+  if (!ImGui::BeginTable("##OverlaysTable", 6, kFlags, outer_size)) {
+    return;
+  }
+  ImGui::TableSetupColumn("##color", ImGuiTableColumnFlags_WidthFixed, swatch_w);
+  ImGui::TableSetupColumn("Overlay", ImGuiTableColumnFlags_WidthStretch);
+  ImGui::TableSetupColumn("Line", ImGuiTableColumnFlags_WidthFixed, std::max(check_w, ImGui::CalcTextSize("Line").x));
+  ImGui::TableSetupColumn("Label", ImGuiTableColumnFlags_WidthFixed, std::max(check_w, ImGui::CalcTextSize("Label").x));
+  ImGui::TableSetupColumn("Alpha", ImGuiTableColumnFlags_WidthFixed, kAlphaColWidth);
+  ImGui::TableSetupColumn("##fold", ImGuiTableColumnFlags_WidthFixed, fold_w);
+  ImGui::TableHeadersRow();
+
+  for (const OverlayRowSpec& row : rows) {
+    ImGui::TableNextRow();
+
+    ImGui::TableSetColumnIndex(0);
+    ImGui::ColorEdit3(row.color_id, row.color, ImGuiColorEditFlags_NoInputs);
+
+    ImGui::TableSetColumnIndex(1);
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted(row.name);
+
+    ImGui::TableSetColumnIndex(2);
+    Checkbox(row.line_id, row.line);
+
+    // Empty cell, on purpose — see OverlayRowSpec::label.
+    if (row.label != nullptr) {
+      ImGui::TableSetColumnIndex(3);
+      Checkbox(row.label_id, row.label);
+    }
+
+    ImGui::TableSetColumnIndex(4);
+    const FieldEditorConstraint alpha_c = ConstraintFor(row.alpha_field, g_state);
+    // A single DragFloat rather than the [slider][input] pair the panel used: the pair needs about
+    // twice this cell's width, and the width it would take comes straight off the name column
+    // (doc/gui-visual-language.md §7 records the cell-sized single control as the verified form).
+    ImGui::SetNextItemWidth(-FLT_MIN);
+    // row.alpha_id already carries its own leading "##" (e.g. "##grid_alpha"); DragFloatField
+    // prepends another "##" itself, so the +2 here skips the one already present — without it the
+    // resolved id would be "####grid_alpha", not the "##grid_alpha" that this table's own gui_test
+    // reference (test_overlay_controls.cpp) and test_defaults_panel.cpp both depend on. Not a typo
+    // — do not "clean up".
+    DragFloatField(row.alpha_id + 2, row.alpha, static_cast<float>(alpha_c.min_value),
+                   static_cast<float>(alpha_c.max_value), alpha_c.fmt, alpha_c.scale);
+
+    if (row.fold == OverlayFold::kNone) {
+      continue;  // Empty fold cell: this overlay has no field the others lack.
+    }
+    ImGui::TableSetColumnIndex(5);
+    // The angle list is offered only while the circles are actually drawn — editing the angles of
+    // something invisible is a control with no feedback. The radius has no such gate: the markers'
+    // own Line checkbox is right there in the same row.
+    const bool circles_shown = g_state.show_sun_circles_line || g_state.show_sun_circles_label;
+    if (row.fold == OverlayFold::kSunCircleAngles && !circles_shown) {
+      continue;
+    }
+    if (ImGui::SmallButton((std::string(ICON_FA_ELLIPSIS) + row.fold_id).c_str())) {
+      ImGui::OpenPopup(row.fold_id);
+    }
+    if (ImGui::IsItemHovered()) {
+      ImGui::SetTooltip(row.fold == OverlayFold::kSunCircleAngles ? "Edit angles" : "Marker radius");
+    }
+    if (ImGui::BeginPopup(row.fold_id)) {
+      if (row.fold == OverlayFold::kSunCircleAngles) {
+        RenderSunCirclesAnglePopup();
+      } else {
+        RenderZenithNadirRadiusPopup();
+      }
+      ImGui::EndPopup();
+    }
+  }
+
+  ImGui::EndTable();
+}
+
+}  // namespace
+
 void RenderRightPanel(GLFWwindow* window, float window_width, float window_height) {
   float panel_height = window_height - kTopBarHeight - kStatusBarHeight;
 
@@ -880,125 +1100,7 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
 
   // ---- Overlay Group ----
   if (ImGui::CollapsingHeader("Overlay", ImGuiTreeNodeFlags_DefaultOpen)) {
-    ImGui::PushItemWidth(-(kLabelColWidth + ImGui::GetStyle().ItemSpacing.x));
-    ImGui::SeparatorText("Auxiliary Lines");
-    // Per-overlay row layout: color picker + name (variable width) + Line / Label
-    // checkboxes anchored at fixed X so the two checkbox columns align across rows
-    // even though the name column has different widths (Horizon / Grid / Angular Distance).
-    // Second row: Alpha slider.
-    const ImGuiStyle& style = ImGui::GetStyle();
-    // Anchor checkbox columns at fixed X derived from the longest overlay name
-    // plus widget metrics. The trailing pad (ItemSpacing.x × 2) protects against
-    // ColorEdit3 / CalcTextSize sub-pixel rounding under HiDPI so the long name
-    // ("Angular Distance") never overlaps the Line checkbox.
-    float color_w = ImGui::GetFrameHeight();                       // ColorEdit3 NoInputs is a frame_h square
-    float name_col_w = ImGui::CalcTextSize("Angular Distance").x;  // widest overlay name
-    float check_box_w = ImGui::GetFrameHeight();                   // checkbox tick area
-    float line_text_w = ImGui::CalcTextSize("Line").x;
-    float line_col_x = color_w + style.ItemSpacing.x + name_col_w + style.ItemSpacing.x * 2.0f;
-    float label_col_x = line_col_x + check_box_w + style.ItemInnerSpacing.x + line_text_w + style.ItemSpacing.x * 2.0f;
-
-    auto overlay_row = [&](const char* name, const char* color_id, float* color, const char* line_id, bool* line_v,
-                           const char* label_id, bool* label_v) {
-      ImGui::ColorEdit3(color_id, color, ImGuiColorEditFlags_NoInputs);
-      ImGui::SameLine();
-      ImGui::TextUnformatted(name);
-      ImGui::SameLine(line_col_x);
-      Checkbox(line_id, line_v);
-      ImGui::SameLine(label_col_x);
-      Checkbox(label_id, label_v);
-    };
-
-    overlay_row("Horizon", "##horizon_color", g_state.horizon_color, "Line##horizon", &g_state.show_horizon_line,
-                "Label##horizon", &g_state.show_horizon_label);
-    const FieldEditorConstraint horizon_a_c = ConstraintFor("overlay_horizon_alpha", g_state);
-    SliderWithInput("Alpha##horizon", &g_state.horizon_alpha, static_cast<float>(horizon_a_c.min_value),
-                    static_cast<float>(horizon_a_c.max_value), horizon_a_c.fmt, horizon_a_c.scale);
-
-    overlay_row("Grid", "##grid_color", g_state.grid_color, "Line##grid", &g_state.show_grid_line, "Label##grid",
-                &g_state.show_grid_label);
-    const FieldEditorConstraint grid_a_c = ConstraintFor("overlay_grid_alpha", g_state);
-    SliderWithInput("Alpha##grid", &g_state.grid_alpha, static_cast<float>(grid_a_c.min_value),
-                    static_cast<float>(grid_a_c.max_value), grid_a_c.fmt, grid_a_c.scale);
-
-    overlay_row("Angular Distance", "##sun_circles_color", g_state.sun_circles_color, "Line##sun_circles",
-                &g_state.show_sun_circles_line, "Label##sun_circles", &g_state.show_sun_circles_label);
-    const FieldEditorConstraint sun_a_c = ConstraintFor("overlay_sun_circles_alpha", g_state);
-    SliderWithInput("Alpha##sun_circles", &g_state.sun_circles_alpha, static_cast<float>(sun_a_c.min_value),
-                    static_cast<float>(sun_a_c.max_value), sun_a_c.fmt, sun_a_c.scale);
-
-    if (g_state.show_sun_circles_line || g_state.show_sun_circles_label) {
-      if (ImGui::Button("Edit Angles...##overlay")) {
-        ImGui::OpenPopup("SunCirclesEdit");
-      }
-      if (ImGui::BeginPopup("SunCirclesEdit")) {
-        bool at_limit = SunCirclesAtLimit(g_state.sun_circle_angles.size());
-
-        // Preset buttons
-        const float presets[] = { 9.0f, 22.0f, 28.0f, 46.0f };
-        for (float p : presets) {
-          const bool already = SunCircleAlreadyPresent(g_state.sun_circle_angles, p);
-          char label[16];
-          std::snprintf(label, sizeof(label), "%.0f\xc2\xb0", p);
-          ImGui::BeginDisabled(already || at_limit);
-          if (ImGui::Button(label)) {
-            g_state.sun_circle_angles.push_back(p);
-            std::sort(g_state.sun_circle_angles.begin(), g_state.sun_circle_angles.end());
-          }
-          ImGui::EndDisabled();
-          ImGui::SameLine();
-        }
-        ImGui::NewLine();
-
-        // Custom angle input
-        static float custom_angle = 22.0f;
-        ImGui::PushItemWidth(60.0f);
-        ImGui::InputFloat("##custom_angle", &custom_angle, 0.0f, 0.0f, "%.1f");
-        ImGui::PopItemWidth();
-        ImGui::SameLine();
-        ImGui::BeginDisabled(at_limit);
-        if (ImGui::Button("+##add_circle")) {
-          custom_angle = ClampSunCircleAngle(custom_angle);
-          g_state.sun_circle_angles.push_back(custom_angle);
-          std::sort(g_state.sun_circle_angles.begin(), g_state.sun_circle_angles.end());
-        }
-        ImGui::EndDisabled();
-
-        // Current list with delete buttons
-        ImGui::Separator();
-        int remove_idx = -1;
-        for (int i = 0; i < static_cast<int>(g_state.sun_circle_angles.size()); i++) {
-          ImGui::Text("%.1f\xc2\xb0", g_state.sun_circle_angles[i]);
-          ImGui::SameLine();
-          char del_label[32];
-          std::snprintf(del_label, sizeof(del_label), "x##del_%d", i);
-          if (ImGui::SmallButton(del_label)) {
-            remove_idx = i;
-          }
-        }
-        if (remove_idx >= 0) {
-          g_state.sun_circle_angles.erase(g_state.sun_circle_angles.begin() + remove_idx);
-        }
-
-        ImGui::EndPopup();
-      }
-    }
-
-    // Zenith / Nadir pixel-space marker. Single line toggle (no label column —
-    // markers don't carry text); radius slider mirrors the per-overlay alpha row.
-    ImGui::ColorEdit3("##zenith_nadir_color", g_state.zenith_nadir_color, ImGuiColorEditFlags_NoInputs);
-    ImGui::SameLine();
-    ImGui::TextUnformatted("Zenith/Nadir");
-    ImGui::SameLine(line_col_x);
-    Checkbox("##zenith_nadir_line", &g_state.show_zenith_nadir_line);
-    const FieldEditorConstraint zn_a_c = ConstraintFor("overlay_zenith_nadir_alpha", g_state);
-    SliderWithInput("Alpha##zenith_nadir", &g_state.zenith_nadir_alpha, static_cast<float>(zn_a_c.min_value),
-                    static_cast<float>(zn_a_c.max_value), zn_a_c.fmt, zn_a_c.scale);
-    const FieldEditorConstraint zn_r_c = ConstraintFor("overlay_zenith_nadir_radius_px", g_state);
-    SliderWithInput("Radius##zenith_nadir", &g_state.zenith_nadir_radius_px, static_cast<float>(zn_r_c.min_value),
-                    static_cast<float>(zn_r_c.max_value), zn_r_c.fmt, zn_r_c.scale);
-
-    ImGui::PopItemWidth();
+    RenderOverlaysTab();
   }
 
   ImGui::End();

--- a/src/gui/gui_constants.hpp
+++ b/src/gui/gui_constants.hpp
@@ -72,6 +72,15 @@ constexpr unsigned long long kMinRaysFloor = 5000;
 constexpr float kLabelColWidth = 70.0f;
 constexpr float kInputWidth = 60.0f;
 
+// Reference drag track length, in pixels: the horizontal distance a DragFloat traverses to
+// cross its whole domain. It is the width SliderWithInput's slider half gets, so a merged
+// single control keeps the same "how far do I have to drag" feel rather than inheriting
+// ImGui's default (range/100, i.e. 100 px for the full domain — more than twice as twitchy).
+// Consumed by DragFloatField (panels.cpp), which derives v_speed = (max - min) / this. In
+// logarithmic mode ImGui divides the delta by the domain size itself, so the same formula
+// lands the same 230 px full-domain traversal there.
+constexpr float kDragTrackReferenceWidth = 230.0f;
+
 // Card thumbnail (offscreen crystal rendering)
 // Currently used for both FBO render resolution and UI display size.
 // If HiDPI support is needed later, split into separate render/display constants.

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -359,6 +359,12 @@ bool DragFloatField(const char* label, float* value, float min_val, float max_va
   const float old_value = *value;
   ImGui::DragFloat(drag_id, value, speed, min_val, max_val, fmt, flags);
 
+  // ImGui does not give DragFloat a resize cursor on its own (unlike a window border or a table
+  // column boundary), so the affordance has to be set explicitly for hover and drag alike.
+  if (ImGui::IsItemHovered() || ImGui::IsItemActive()) {
+    ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
+  }
+
   // Unconditional, and NOT redundant with ImGuiSliderFlags_AlwaysClamp: that flag constrains the
   // values the widget itself produces, and deliberately leaves a value it was handed out of range
   // alone. SliderWithInput ends with exactly this line, and things depend on it — a .lmc written by

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -345,6 +345,32 @@ bool SliderWithInput(const char* label, float* value, float min_val, float max_v
   return *value != old_value;
 }
 
+bool DragFloatField(const char* label, float* value, float min_val, float max_val, const char* fmt, SliderScale scale) {
+  char drag_id[80];
+  snprintf(drag_id, sizeof(drag_id), "##%s", label);
+
+  ImGuiSliderFlags flags = ImGuiSliderFlags_AlwaysClamp;
+  if (scale != SliderScale::kLinear) {
+    flags |= ImGuiSliderFlags_Logarithmic;
+  }
+  // Full domain per kDragTrackReferenceWidth pixels of drag, in both modes: ImGui divides a
+  // logarithmic drag's delta by (max - min) before applying it, which cancels the numerator here.
+  const float speed = (max_val - min_val) / kDragTrackReferenceWidth;
+  const float old_value = *value;
+  ImGui::DragFloat(drag_id, value, speed, min_val, max_val, fmt, flags);
+
+  // Unconditional, and NOT redundant with ImGuiSliderFlags_AlwaysClamp: that flag constrains the
+  // values the widget itself produces, and deliberately leaves a value it was handed out of range
+  // alone. SliderWithInput ends with exactly this line, and things depend on it — a .lmc written by
+  // hand, or a lens switch that narrows a bound under a value that was legal a frame ago (the
+  // globe's elevation limit), reach the field without going through any control, and the control is
+  // what pulls them back in. Without it the page renders an out-of-domain value as if it were fine.
+  *value = std::clamp(*value, min_val, max_val);
+  // Same return contract as SliderWithInput: "the value is not what it was", clamp included, since
+  // a clamp is a change the caller has to commit like any other.
+  return *value != old_value;
+}
+
 // SliderInt + InputInt + label text, same layout as SliderWithInput.
 // Returns true if value changed.
 bool SliderIntWithInput(const char* label, int* value, int min_val, int max_val, bool trailing_label, bool* committed,

--- a/src/gui/panels.hpp
+++ b/src/gui/panels.hpp
@@ -10,6 +10,29 @@ namespace lumice::gui {
 // Slider scale modes for SliderWithInput
 enum class SliderScale { kLinear, kSqrt, kLog, kLogLinear };
 
+// One control per value: a single DragFloat where a [slider][input] pair would otherwise sit.
+// Ctrl+click (or, with io.ConfigDragClickToInputText on, a plain click-release) types an exact
+// value, so the input half is not lost, it is folded in. The item id is "##<label>", with no
+// _slider / _input suffix, because there is no longer a pair to distinguish. Today's only call
+// sites are the Overlays table's alpha cells (RenderOverlaysTab, app_panels.cpp), where a cell
+// has room for exactly one control; SliderWithInput remains the default elsewhere.
+//
+// `scale` keeps meaning what it means for SliderWithInput, but a Drag has no track position
+// to map, only a speed, so the three non-linear modes collapse onto ImGui's own logarithmic
+// drag: kLog and kLogLinear are what it natively is, and kSqrt takes it as the closer of the
+// two available approximations (a linear drag over a 0-360 domain moves ~1.6 deg per pixel,
+// which cannot express the sub-degree spreads the sqrt mapping existed to make reachable).
+// Dragging to either end still yields exactly min / max — ImGui special-cases the extents.
+//
+// The value is clamped to [min_val, max_val] UNCONDITIONALLY, not just when the widget moved it:
+// ImGuiSliderFlags_AlwaysClamp constrains what the widget produces and leaves an out-of-range value
+// it was handed alone, and fields do arrive here from outside any control (a hand-written .lmc, a
+// lens switch that narrows a bound under a value that was legal a frame ago). Returns true when the
+// value is not what it was — clamp included, since a clamp is a change the caller has to commit
+// like any other. Both match what SliderWithInput does.
+bool DragFloatField(const char* label, float* value, float min_val, float max_val, const char* fmt = "%.1f",
+                    SliderScale scale = SliderScale::kLinear);
+
 // Slider + InputFloat + label text, laid out as: [slider] [input] Label
 // Uses a fixed label column width so vertically stacked sliders align.
 // Returns true if value changed.

--- a/src/gui/theme.cpp
+++ b/src/gui/theme.cpp
@@ -232,6 +232,12 @@ bool Checkbox(const char* label, bool* v) {
 void ApplyVisualLanguage(ImGuiIO& io) {
   ImGui::StyleColorsDark();
 
+  // Lets a click-release (no drag, no ctrl) on a DragFloat enter text-input mode — the only
+  // consumer today is the Overlay table's Alpha cells (RenderOverlaysTab, app_panels.cpp), so
+  // this flag's blast radius is exactly that table. Re-read this note before adding a second bare
+  // DragFloat/DragInt call site anywhere in the GUI.
+  io.ConfigDragClickToInputText = true;
+
   ImGuiStyle& style = ImGui::GetStyle();
   ApplyGridSpacing(style);
   ApplyPalette(style, kIceTruePalette);

--- a/test/gui/functional/test_defaults_panel.cpp
+++ b/test/gui/functional/test_defaults_panel.cpp
@@ -1420,7 +1420,7 @@ void RegisterDefaultsPanelTests(ImGuiTestEngine* engine) {
       // wildcard finds nothing while the window-relative id resolves and scrolls to it. The FOV
       // control is above the fold and either form reaches it — this one has no choice.
       ctx->SetRef("##RightPanel");
-      ctx->ItemInputValue("##Alpha##grid_input", 7.5f);
+      ctx->ItemInputValue("##grid_alpha", 7.5f);
       ctx->SetRef("");
       ctx->Yield(3);
       IM_CHECK_EQ(alpha_from_table, gui::g_state.grid_alpha);

--- a/test/gui/functional/test_defaults_panel.cpp
+++ b/test/gui/functional/test_defaults_panel.cpp
@@ -1419,8 +1419,14 @@ void RegisterDefaultsPanelTests(ImGuiTestEngine* engine) {
       // the Overlay group sits past the right panel's fold at the harness window size, so the
       // wildcard finds nothing while the window-relative id resolves and scrolls to it. The FOV
       // control is above the fold and either form reaches it — this one has no choice.
+      //
+      // "##OverlaysTable/" is part of that window-relative path and not decoration: the alpha cell
+      // is a table cell, and BeginTable pushes the table's own id as an override, so every widget
+      // inside hashes against THAT rather than against the window (imgui_tables.cpp). Drop the
+      // segment and the id resolves to nothing — which is what a missing control and a mis-spelled
+      // path look like alike.
       ctx->SetRef("##RightPanel");
-      ctx->ItemInputValue("##grid_alpha", 7.5f);
+      ctx->ItemInputValue("##OverlaysTable/##grid_alpha", 7.5f);
       ctx->SetRef("");
       ctx->Yield(3);
       IM_CHECK_EQ(alpha_from_table, gui::g_state.grid_alpha);

--- a/test/gui/functional/test_overlay_controls.cpp
+++ b/test/gui/functional/test_overlay_controls.cpp
@@ -1,16 +1,23 @@
 // The right panel's Overlay group: the auxiliary lines drawn over the preview and the angle list
-// behind the sun-circle row.
+// behind the Angular Dist. row's fold.
 //
-// What this suite is for. `RenderRightPanel`'s overlay section (src/gui/app_panels.cpp) draws three
-// rows of the same shape plus a zenith/nadir row, and its one non-obvious property is a LAYOUT one:
-// the Line and Label checkboxes are anchored at fixed x so the two columns line up across rows
-// whose names have very different widths. That is only checkable against a rendered frame, and it
-// is the kind of thing that silently stops being true when a name is added — the widest name today
-// is "Angular Distance" and the anchors are derived from it.
+// What this suite is for. `RenderOverlaysTab` (src/gui/app_panels.cpp) draws four rows of the same
+// record — colour, name, line, text label, opacity — as one ImGui table, and its one non-obvious
+// property is a LAYOUT one: the columns have to line up across rows whose names have very different
+// widths, and the longest name must not be cut off. That is only checkable against a rendered
+// frame, and it is the kind of thing that silently stops being true when a name is added or a
+// column's width budget grows. It matters more here than it would in a wider container: the group
+// lives in a 300 px panel, so the name column is what every other column's declared width leaves
+// over, and there is no slack to absorb a change.
 //
-// The angle editor behind "Edit Angles..." is the other half: it is a popup that only exists while
-// a sun-circle overlay is on, and its preset buttons have to know which angles are already in the
-// list, or the user gets duplicates that draw on top of each other.
+// It used to be checkable in a weaker form: the checkboxes were placed at an x computed from the
+// widest name, and the cases below asserted that the anchors agreed. They now assert against the
+// table's own column rectangles, which is a stronger reading of the same claim — an anchor can be
+// consistent across rows and still overlap a name, whereas a column cannot.
+//
+// The angle editor behind the Angular Dist. row's fold is the other half: it is a popup that only
+// exists while a sun-circle overlay is on, and its preset buttons have to know which angles are
+// already in the list, or the user gets duplicates that draw on top of each other.
 //
 // Deliberately NOT here, with where each lives instead. Where the labels are PLACED around the sky
 // is unit-correctness/gui/test_overlay_labels.cpp; the overlay colours reaching the renderer is
@@ -23,8 +30,8 @@
 // that — what it would take is a committed-pixel comparison with a modal open over a labelled
 // preview, i.e. a fifth reference group.
 //
-// What a user sees when these break: a "Label" checkbox sitting under the word "Angular Distance",
-// or a 22-degree halo circle added twice and drawn at double brightness.
+// What a user sees when these break: the row's name clipped mid-word, a checkbox sitting under a
+// name, or a 22-degree halo circle added twice and drawn at double brightness.
 
 #include <algorithm>
 #include <string>
@@ -52,60 +59,124 @@ struct ScopedRef {
   ImGuiTestContext* ctx_;
 };
 
+// The four rows, by the id suffix their widgets carry.
+const char* const kRows[] = { "horizon", "grid", "sun_circles", "zenith_nadir" };
+
+// The name each row displays. Mirrored rather than read from the panel because the panel's row table
+// is file-local to app_panels.cpp — and because a name that changed there without changing here is
+// precisely the event the width check below exists to catch. "Angular Dist." is abbreviated in the
+// panel too, and deliberately: spelled out it does not fit this panel's name column.
+const char* NameOfRow(const std::string& row) {
+  if (row == "horizon") {
+    return "Horizon";
+  }
+  if (row == "grid") {
+    return "Grid";
+  }
+  if (row == "sun_circles") {
+    return "Angular Dist.";
+  }
+  return "Zenith/Nadir";
+}
+
 }  // namespace
 
 void RegisterOverlayControlTests(ImGuiTestEngine* engine) {
-  // P32's layout half. The three rows carry names of different widths and their checkboxes are
-  // placed with an explicit SameLine offset rather than by flow, so "the columns line up" is a
-  // claim about that offset being wide enough for the longest name — and the longest name is the
-  // one that stops fitting first.
+  // P32's layout half, in its table form. Two claims, and they are different: every row's Line
+  // checkbox starts at the same x (a column is a column), and no row's NAME runs into it (the name
+  // column is wide enough for the longest name there is). The second is the one the table exists
+  // for — the previous layout satisfied the first while clipping "Angular Distance".
   //
-  // Asserted as a relation between the items rather than against a pixel constant, so it stays true
+  // Asserted as a relation between the items rather than against pixel constants, so it stays true
   // on a platform whose glyphs render wider instead of quietly shipping an overlap.
   {
-    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_controls", "the_line_and_label_columns_line_up_across_the_rows");
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_controls", "the_columns_line_up_and_no_name_is_cut_off");
     t->TestFunc = [](ImGuiTestContext* ctx) {
       ResetTestState();
       ctx->Yield(3);
+      // Named ref, not the default: the Overlay group is the last one in a scrollable panel, and a
+      // wildcard lookup resolves an item by its LABEL — the engine records no label for a clipped
+      // item, so a row scrolled out of view reads exactly like a missing one. The engine recovers by
+      // panning the window, but only when the ref names the window to pan.
+      const ScopedRef panel_ref(ctx, "//##RightPanel");
 
-      const char* const kRows[] = { "horizon", "grid", "sun_circles" };
       float line_x = -1.0f;
-      float label_x = -1.0f;
       for (const char* row : kRows) {
-        const ImGuiTestItemInfo line = ctx->ItemInfo(("**/Line##" + std::string(row)).c_str());
-        const ImGuiTestItemInfo label = ctx->ItemInfo(("**/Label##" + std::string(row)).c_str());
-        if (line.ID == 0 || label.ID == 0) {
-          IM_ERRORF("row %s: Line or Label is missing", row);
-          continue;
+        const ImGuiTestItemInfo line = ctx->ItemInfo(("**/##" + std::string(row) + "_line").c_str());
+        // The swatch's id is REPRODUCED rather than searched for, because a "**/" search cannot
+        // reach it however it is spelled: ColorButton never calls IMGUI_TEST_ENGINE_ITEM_INFO, so
+        // it registers no debug label, and a wildcard matches by label (same quirk, and the same
+        // fix, as test_run_lifecycle.cpp's "$$0/##color/##ColorButton" and test_color_window.cpp's
+        // ComboPick). Three seeds, outermost first: the window the row was submitted into — taken
+        // from the checkbox rather than derived; the table's override id, which every cell widget
+        // hashes against instead of the window's (imgui_tables.cpp); and ColorEdit3's PushID of its
+        // own label, under which it submits ImGui's "##ColorButton".
+        ImGuiID color_id = 0;
+        if (line.Window != nullptr) {
+          const ImGuiID table_id = ImGui::GetIDWithSeed("##OverlaysTable", nullptr, line.Window->ID);
+          const ImGuiID swatch_group =
+              ImGui::GetIDWithSeed(("##" + std::string(row) + "_color").c_str(), nullptr, table_id);
+          color_id = ImGui::GetIDWithSeed("##ColorButton", nullptr, swatch_group);
+        }
+        const ImGuiTestItemInfo color = ctx->ItemInfo(color_id, ImGuiTestOpFlags_NoError);
+        if (line.ID == 0 || color.ID == 0) {
+          IM_ERRORF("row %s: the Line checkbox or the colour swatch is missing", row);
+          break;
         }
         if (line_x < 0.0f) {
           line_x = line.RectFull.Min.x;
-          label_x = label.RectFull.Min.x;
-        }
-        if (line.RectFull.Min.x != line_x) {
+        } else if (line.RectFull.Min.x != line_x) {
           IM_ERRORF("row %s: Line starts at x=%.1f, the first row measured %.1f", row,
                     static_cast<double>(line.RectFull.Min.x), static_cast<double>(line_x));
+          break;
         }
-        if (label.RectFull.Min.x != label_x) {
-          IM_ERRORF("row %s: Label starts at x=%.1f, the first row measured %.1f", row,
-                    static_cast<double>(label.RectFull.Min.x), static_cast<double>(label_x));
-        }
-        // The two columns are distinct and in order — an anchor that collapsed would satisfy the
-        // equalities above on its own.
-        if (label.RectFull.Min.x <= line.RectFull.Max.x) {
-          IM_ERRORF("row %s: Label at %.1f overlaps Line ending at %.1f", row,
-                    static_cast<double>(label.RectFull.Min.x), static_cast<double>(line.RectFull.Max.x));
-        }
-
-        if (ctx->IsError()) {
+        // The name sits between the swatch and the Line column, and it is the widest thing in that
+        // gap that has to fit. Reading the text width rather than a rendered rect because
+        // ImGui::TextUnformatted submits no addressable item: a clipped name would not report a
+        // narrower rect, it would report nothing at all.
+        const float name_w = ImGui::CalcTextSize(NameOfRow(row)).x;
+        const float name_room = line.RectFull.Min.x - color.RectFull.Max.x;
+        if (name_room < name_w) {
+          IM_ERRORF("row %s: %.1f px between the swatch and Line, the name needs %.1f", row,
+                    static_cast<double>(name_room), static_cast<double>(name_w));
           break;
         }
       }
-      IM_CHECK_GT(line_x, 0.0f);  // a run of three misses would leave this unset
+      IM_CHECK_GT(line_x, 0.0f);  // a run of four misses would leave this unset
 
-      // The zenith/nadir row has no Label column but shares the Line anchor, which is what keeps it
-      // reading as part of the same table rather than as a stray checkbox.
-      IM_CHECK_EQ(ctx->ItemInfo("**/##zenith_nadir_line").RectFull.Min.x, line_x);
+      // "Empty cell IS the information" (doc/gui-visual-language.md §4.4): the marker row carries no
+      // text label, so its Label cell holds nothing — not a disabled checkbox, not a dash. Asserted
+      // against the three rows that DO have one, so the claim is about this row and not about the
+      // id being spelled some other way.
+      IM_CHECK_EQ(ctx->ItemInfo("**/##zenith_nadir_label", ImGuiTestOpFlags_NoError).ID, (ImGuiID)0);
+      IM_CHECK_NE(ctx->ItemInfo("**/##horizon_label").ID, (ImGuiID)0);
+      IM_CHECK_NE(ctx->ItemInfo("**/##grid_label").ID, (ImGuiID)0);
+      IM_CHECK_NE(ctx->ItemInfo("**/##sun_circles_label").ID, (ImGuiID)0);
+    };
+  }
+
+  // The other half of "empty cell is the information": the fold column. Only two of the four rows
+  // have a field the others lack, and only those two offer the button — a fold button on every row
+  // would say the opposite of what this layout is for.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_controls", "only_the_rows_with_an_extra_field_offer_a_fold");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      // The angle fold is gated on the circles being drawn (see the case below); turn them on so
+      // this case measures the fold column and not that gate.
+      gui::g_state.show_sun_circles_line = true;
+      ctx->Yield(3);
+      // Named ref for the reason the case above gives: without it a fold button scrolled out of
+      // view would satisfy the negative checks as readily as one that is not offered.
+      const ScopedRef panel_ref(ctx, "//##RightPanel");
+
+      IM_CHECK(!ctx->ItemExists("**/###horizon_fold"));
+      IM_CHECK(!ctx->ItemExists("**/###grid_fold"));
+      IM_CHECK(ctx->ItemExists("**/###sun_circles_fold"));
+      IM_CHECK(ctx->ItemExists("**/###zenith_nadir_fold"));
+
+      gui::g_state.show_sun_circles_line = false;
+      ctx->Yield(2);
     };
   }
 
@@ -119,38 +190,38 @@ void RegisterOverlayControlTests(ImGuiTestEngine* engine) {
       const ScopedPopups popup_guard(ctx);
       ctx->Yield(3);
       // Everything this case looks up lives in the right panel, and it is named rather than left to
-      // the default ref for a reason the negative checks below depend on. "Edit Angles..." is the
-      // last row of the Overlay group and sits just under the panel's fold; a wildcard lookup
-      // resolves an item by its LABEL, and the engine records no label for a clipped item, so a
-      // clipped button reads exactly like an absent one. The engine recovers by panning the window
-      // — but only when the ref names the window to pan. Without it, `!ItemExists` would be
-      // satisfied by "scrolled out of view" as readily as by "not offered", and whether the case
-      // passes turns on whether some earlier ItemClick happened to scroll the panel first.
+      // the default ref because the negative checks below depend on it. The Overlay group is the
+      // last one in a scrollable panel; a wildcard lookup resolves an item by its LABEL, and the
+      // engine records no label for a clipped item, so a clipped button reads exactly like an
+      // absent one. The engine recovers by panning the window, but only when the ref names the
+      // window to pan. Without it, `!ItemExists` would be satisfied by "scrolled out of view" as
+      // readily as by "not offered", and whether the case passes would turn on whether some earlier
+      // ItemClick happened to scroll the panel first.
       //
       // Scoped as an object rather than a matching SetRef("") at the tail, for the same reason
       // ScopedPopups above is: several of the IM_CHECKs this ref covers are exactly the ones a real
       // regression would trip, and a fatal one exits the lambda before a tail-of-function SetRef("")
       // would run, leaving the ref pinned for the rest of the test process.
-      const ScopedRef right_panel_ref(ctx, "//##RightPanel");
+      const ScopedRef panel_ref(ctx, "//##RightPanel");
       IM_CHECK(!gui::g_state.show_sun_circles_line);
       IM_CHECK(!gui::g_state.show_sun_circles_label);
-      IM_CHECK(!ctx->ItemExists("**/Edit Angles...##overlay"));
+      IM_CHECK(!ctx->ItemExists("**/###sun_circles_fold"));
 
       // Either switch is enough — the lines and the labels are two ways of showing the same set.
-      ctx->ItemClick("**/Line##sun_circles");
+      ctx->ItemClick("**/##sun_circles_line");
       ctx->Yield(3);
       IM_CHECK(gui::g_state.show_sun_circles_line);
-      IM_CHECK(ctx->ItemExists("**/Edit Angles...##overlay"));
+      IM_CHECK(ctx->ItemExists("**/###sun_circles_fold"));
 
-      ctx->ItemClick("**/Line##sun_circles");
+      ctx->ItemClick("**/##sun_circles_line");
       ctx->Yield(3);
-      IM_CHECK(!ctx->ItemExists("**/Edit Angles...##overlay"));
+      IM_CHECK(!ctx->ItemExists("**/###sun_circles_fold"));
 
-      ctx->ItemClick("**/Label##sun_circles");
+      ctx->ItemClick("**/##sun_circles_label");
       ctx->Yield(3);
-      IM_CHECK(ctx->ItemExists("**/Edit Angles...##overlay"));
+      IM_CHECK(ctx->ItemExists("**/###sun_circles_fold"));
 
-      ctx->ItemClick("**/Label##sun_circles");
+      ctx->ItemClick("**/##sun_circles_label");
       ctx->Yield(3);
     };
   }
@@ -165,23 +236,21 @@ void RegisterOverlayControlTests(ImGuiTestEngine* engine) {
     t->TestFunc = [](ImGuiTestContext* ctx) {
       ResetTestState();
       const ScopedPopups popup_guard(ctx);
-      ctx->Yield(3);
       gui::g_state.show_sun_circles_line = true;
       gui::g_state.sun_circle_angles.clear();
       ctx->Yield(3);
 
-      // Named ref for the button only, for the reason given in the case above — it sits under the
-      // panel's fold and a wildcard lookup needs a window it can pan. Scoped to just this click
-      // (rather than covering the case above's several IM_CHECKs) is deliberate: the presets and
-      // the delete rows below live in the "SunCirclesEdit" popup, a different window, which a
-      // right-panel prefix would exclude, so the ref must not still be set once we get there.
+      // Named ref for the fold button only, for the reason given in the case above. Scoped to just
+      // this click is deliberate: the presets and the delete rows live in the popup, a different
+      // window, which a panel-prefixed ref would exclude — so the ref must not still be set once we
+      // get there.
       {
-        const ScopedRef right_panel_ref(ctx, "//##RightPanel");
-        ctx->ItemClick("**/Edit Angles...##overlay");
+        const ScopedRef panel_ref(ctx, "//##RightPanel");
+        ctx->ItemClick("**/###sun_circles_fold");
       }
       ctx->Yield(3);
 
-      // All four presets the panel offers (9 / 22 / 28 / 46 degrees), deliberately clicked out of
+      // All four presets the editor offers (9 / 22 / 28 / 46 degrees), deliberately clicked out of
       // order so "sorted" is a claim about the insert rather than about the order they arrived in.
       // The list is mirrored rather than iterated because the panel's own array is file-local to
       // app_panels.cpp; a preset added there without a row here shows up as the count check below
@@ -225,66 +294,80 @@ void RegisterOverlayControlTests(ImGuiTestEngine* engine) {
     };
   }
 
-  // The overlay group's sliders, at both ends of each declared domain. Literals throughout, for the
-  // reason spelled out at the head of functional/test_scene_controls.cpp: the call site reads the
-  // registry, so asking the registry what to expect would compare one line of code against itself.
-  //
-  // The zenith/nadir pair is the reason this case scrolls. With every group expanded those two rows
-  // sit below the fold of the right panel, and a clipped item is never submitted — so the engine
-  // cannot find them by id at all. The panel is handed back at the top afterwards: gui_test is one
-  // process and a scroll position outlives the case that set it.
+  // The marker radius, the other field behind a fold. Same proposition as the angle list above —
+  // that folding a minority field away did not put it out of reach — and it needs stating
+  // separately because the two folds hold entirely different editors.
   {
-    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_controls", "the_overlay_sliders_clamp_to_their_declared_domains");
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_controls", "the_marker_radius_is_editable_behind_its_fold");
     t->TestFunc = [](ImGuiTestContext* ctx) {
-      struct Slider {
-        const char* input;
-        float* slot;
-        float lo;
-        float hi;
-        bool below_the_fold;
-      };
       ResetTestState();
+      const ScopedPopups popup_guard(ctx);
       ctx->Yield(3);
 
-      const Slider kSliders[] = {
-        { "**/##Alpha##horizon_input", &gui::g_state.horizon_alpha, 0.0f, 1.0f, false },
-        { "**/##Alpha##grid_input", &gui::g_state.grid_alpha, 0.0f, 1.0f, false },
-        { "**/##Alpha##sun_circles_input", &gui::g_state.sun_circles_alpha, 0.0f, 1.0f, false },
-        { "**/##Alpha##zenith_nadir_input", &gui::g_state.zenith_nadir_alpha, 0.0f, 1.0f, true },
-        // The one overlay slider whose domain is neither [0, 1] nor symmetric.
-        { "**/##Radius##zenith_nadir_input", &gui::g_state.zenith_nadir_radius_px, 2.0f, 20.0f, true },
-      };
+      {
+        // Named ref so the negative check reads "not submitted inline" and not "scrolled past" —
+        // see the case above. Released before the popup, which is a different window.
+        const ScopedRef panel_ref(ctx, "//##RightPanel");
+        IM_CHECK(!ctx->ItemExists("**/##Radius##zenith_nadir_input"));  // folded away, not shown inline
+        ctx->ItemClick("**/###zenith_nadir_fold");
+      }
+      ctx->Yield(3);
 
-      bool scrolled = false;
-      for (const Slider& s : kSliders) {
-        if (s.below_the_fold && !scrolled) {
-          ctx->ScrollToBottom("//##RightPanel");
-          ctx->Yield(2);
-          scrolled = true;
-        }
-        ctx->ItemInputValue(s.input, s.hi + 100.0f);
+      // Both ends of the declared domain (2..20 px), so the popup's control is the registry's
+      // control and not a second opinion about the range.
+      ctx->ItemInputValue("**/##Radius##zenith_nadir_input", 100.0f);
+      ctx->Yield();
+      IM_CHECK_EQ(gui::g_state.zenith_nadir_radius_px, 20.0f);
+      ctx->ItemInputValue("**/##Radius##zenith_nadir_input", -5.0f);
+      ctx->Yield();
+      IM_CHECK_EQ(gui::g_state.zenith_nadir_radius_px, 2.0f);
+
+      ctx->KeyPress(ImGuiKey_Escape);
+      ctx->Yield(2);
+    };
+  }
+
+  // The four alpha cells, at both ends of each declared domain. Literals throughout, for the reason
+  // spelled out at the head of functional/test_scene_controls.cpp: the call site reads the registry,
+  // so asking the registry what to expect would compare one line of code against itself.
+  //
+  // The cell is a single DragFloat now rather than a [slider][input] pair, and ItemInputValue drives
+  // it through its text-entry path — which is exactly the path that only clamps because
+  // DragFloatField passes ImGuiSliderFlags_AlwaysClamp and then clamps again unconditionally, so
+  // this is a check on that helper as much as on the domain.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_controls", "the_overlay_alphas_clamp_to_their_declared_domains");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(3);
+      const ScopedRef panel_ref(ctx, "//##RightPanel");
+
+      float* const kSlots[] = {
+        &gui::g_state.horizon_alpha,
+        &gui::g_state.grid_alpha,
+        &gui::g_state.sun_circles_alpha,
+        &gui::g_state.zenith_nadir_alpha,
+      };
+      for (size_t i = 0; i < IM_ARRAYSIZE(kRows); ++i) {
+        const std::string ref = "**/##" + std::string(kRows[i]) + "_alpha";
+        ctx->ItemInputValue(ref.c_str(), 100.0f);
         ctx->Yield();
-        if (*s.slot != s.hi) {
-          IM_ERRORF("%s: clamped to %f, expected the %f maximum", s.input, static_cast<double>(*s.slot),
-                    static_cast<double>(s.hi));
+        if (*kSlots[i] != 1.0f) {
+          IM_ERRORF("%s: clamped to %f, expected the 1.0 maximum", ref.c_str(), static_cast<double>(*kSlots[i]));
         }
         if (ctx->IsError()) {
           break;
         }
-        ctx->ItemInputValue(s.input, s.lo - 100.0f);
+        ctx->ItemInputValue(ref.c_str(), -100.0f);
         ctx->Yield();
-        if (*s.slot != s.lo) {
-          IM_ERRORF("%s: clamped to %f, expected the %f minimum", s.input, static_cast<double>(*s.slot),
-                    static_cast<double>(s.lo));
+        if (*kSlots[i] != 0.0f) {
+          IM_ERRORF("%s: clamped to %f, expected the 0.0 minimum", ref.c_str(), static_cast<double>(*kSlots[i]));
         }
 
         if (ctx->IsError()) {
           break;
         }
       }
-
-      ctx->ScrollToTop("//##RightPanel");
-      ctx->Yield(2);
     };
   }
 }

--- a/test/gui/functional/test_view_display_controls.cpp
+++ b/test/gui/functional/test_view_display_controls.cpp
@@ -153,7 +153,7 @@ void RegisterViewDisplayControlTests(ImGuiTestEngine* engine) {
         { "**/Scene", "**/##Altitude_input" },
         { "**/View", "**/##FOV##view_input" },
         { "**/Display", "**/##EV##display_input" },
-        { "**/Overlay", "**/Line##horizon" },
+        { "**/Overlay", "**/##horizon_line" },
       };
 
       ResetTestState();

--- a/test/gui/references/_thresholds.json
+++ b/test/gui/references/_thresholds.json
@@ -1,7 +1,7 @@
 {
   "groups": {
     "capture_harness": {
-      "generated_at": "2026-08-26T15:40:44",
+      "generated_at": "2026-08-29T11:25:10",
       "n_ref_runs": 10,
       "n_calib_runs": 10,
       "scenes": {

--- a/test/gui/references/smoke_fullframe.png
+++ b/test/gui/references/smoke_fullframe.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8d53fb9535e3cccd22819a404ef9a2bdb83e4d3c749075e556b09aa5e2fdbcd4
-size 105226
+oid sha256:2c05fd4a57a1af2d0a165785b58ffb27bf7557506e04aa52893d333a81e7837b
+size 109930


### PR DESCRIPTION
## 目标

把 `feat/new-gui-layout` 上已验证的 **Overlay 辅助线表格形态**移植到 `main` 的右侧面板 Overlay 组，
替换现状「三条辅助线各占两行 + Zenith/Nadir 占三行」的竖直堆叠形态。

这是兑现 `doc/gui-visual-language.md` §4.4「重复记录 → 表格」这条**已落档但未落地**的结论——
它当初与被内测否决的形态层（PR #272/#273 的 master–detail 三区 shell）捆在一起，回退时被一并丢掉。
**被内测拒的是面板组织方式，不是这张表。**

## 改动

- `RenderOverlaysTab()` 6 列表格（色块 / 名称 / Line / Label / Alpha / 行末折叠 `⋯`），4 行 + 1 表头；
  `Angular Dist.` 折叠装角度编辑器，`Zenith/Nadir` 折叠装像素半径
- 移植 `DragFloatField()` + `kDragTrackReferenceWidth`：alpha 拖动全程 230px、双击进数字输入、
  hover/active 时鼠标指针变左右箭头
- `io.ConfigDragClickToInputText` 落在 `theme.cpp::ApplyVisualLanguage` 这个**单一 owner**，
  而非 `main.cpp`——后者会让 `gui_test` 与真 app 的双击行为不同
- **面板宽度与 theme 全局 `CellPadding` 均未改动**，靠 `Angular Distance` → `Angular Dist.` 缩写腾出名称列宽

## 两个量（上一轮内测教训的直接兑现）

| 量 | 改动前 | 改动后 |
|---|---|---|
| 一屏可见行数 | 10–11 行（组末尾被截断） | **5 行**，一屏全见 |
| 改 alpha | 1 击 | 1 击（±0） |
| 打开角度编辑器 | 1 击（`Edit Angles...`） | 1 击（`⋯`） |
| 改 Zenith/Nadir 半径 | 1 击（常驻滑条） | **2 击**（折叠后） |

最后一项是唯一的步数回退，owner 已明确接受。

## 验证

- `./scripts/test.sh quick` → `RESULT: PASS`（ctest 7/7、fast-e2e、gui-correctness 299/299）
- `check_policies.py` / `check_new_refs.py` / `check_new_gui_tests.py` / `format.sh --check` 全部 exit=0
- code review 3 轮，最终 **APPROVE**
- AC2「没有任何一行名称被裁」由 `test_overlay_controls.cpp` 对着表格自己的列矩形机械断言，
  并经**红态探针自证有牙**（改回全称 `Angular Distance` 确实转红）
- 参考图只重拍 `capture_harness/smoke_fullframe.png`（10/10 逐像素一致）；
  `_thresholds.json` 只动 `generated_at`，**阈值零改动**；`lens_proj` / `left_panel` 未受影响

## 已知遗留（评审后接受，不阻塞）

- `OverlayRowSpec::alpha_id` 与其余 id 字段的「id 归属契约」不对称，调用处靠 `+ 2` 裸指针偏移纠正
  （round 1 标记 Minor，现场有防御性注释）
- CI 的 Ubuntu leg 只跑 `--filter "modal_layout,defaults_panel_layout"`，`overlay_controls` 与
  `capture_harness` 三平台均只编译不运行 ⇒ 本 PR 的机械仲裁者目前只有本地 `test.sh quick` 守卫。
  是否放宽 CI filter 是独立决策（须先读 `doc/testing-architecture.md` §4.6）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ksvEyRTpnaMRHFEtLhJdy