### PR TITLE
fix(core+gui): 全球面快路径补 roll 旋转对称条件，修滑条端点浮点漂移导致的采样路静默切换

### DIFF
--- a/doc/raypath-symmetry.md
+++ b/doc/raypath-symmetry.md
@@ -210,6 +210,14 @@ button appears to the right of the D checkbox. Hovering over it shows the toolti
 This design follows a "weak hint" principle: the user retains control and is not blocked from
 checking D, but is informed when the toggle has no practical effect.
 
+The indicator asks the engine's own predicate rather than re-deriving the condition: the GUI calls
+`LUMICE_IsDApplicable`, which forwards to the same `detail::IsDApplicableParams` the simulator uses.
+It used to keep a private transcription instead, and the two had drifted to different float
+tolerances (1e-3 against core's 1e-5) — so for an azimuth range 3.05e-5° short of a full turn, which
+is what the sqrt-scaled Range slider once stored at its stop, the hint said D was live while the
+engine had already dropped it. A hint that disagrees with the thing it describes is worse than no
+hint, which is why this one has no copy of the rule to drift.
+
 ---
 
 ## 7. Out of Scope

--- a/src/core/crystal.cpp
+++ b/src/core/crystal.cpp
@@ -707,14 +707,18 @@ float Crystal::GetRefractiveIndex(float wl) const {
 
 namespace detail {
 
+bool IsRollAnchorAtMultipleOf30(float roll_anchor_deg) {
+  float remainder = std::fmod(std::fmod(roll_anchor_deg, 30.0f) + 30.0f, 30.0f);
+  return FloatEqual(remainder, 0.0f) || FloatEqual(remainder, 30.0f);
+}
+
+
 bool IsRollMeanAtMultipleOf30(const AxisDistribution& d) {
   // Deliberately type-erased: the anchor slot is read for every DistributionType, not just the
   // Gaussian family, so the generic `center` member is the correct access (a named accessor would
   // assert on the other types). Do NOT read this as "the statistical mean of the roll angle" —
   // for kZigzag it is a tilt offset, for kUniform an interval midpoint.
-  float mean = d.roll_dist.center;
-  float remainder = std::fmod(std::fmod(mean, 30.0f) + 30.0f, 30.0f);
-  return FloatEqual(remainder, 0.0f) || FloatEqual(remainder, 30.0f);
+  return IsRollAnchorAtMultipleOf30(d.roll_dist.center);
 }
 
 int ComputeSigmaA(float roll_mean_deg) {
@@ -725,8 +729,16 @@ int ComputeSigmaA(float roll_mean_deg) {
   return (6 - n) % 6;
 }
 
+bool IsDApplicableParams(DistributionType azimuth_type, float azimuth_full_range_deg, float roll_anchor_deg) {
+  return IsFullTurnUniform(azimuth_type, azimuth_full_range_deg) && IsRollAnchorAtMultipleOf30(roll_anchor_deg);
+}
+
+
 bool IsDApplicable(const AxisDistribution& d) {
-  return d.IsAzRotationallySymmetric() && IsRollMeanAtMultipleOf30(d);
+  // Both fields are read type-erased (raw `spread` / `center`, not the named accessors) for the
+  // reason IsRollMeanAtMultipleOf30 gives above: the arguments are evaluated before either
+  // conjunct has established a type, and the named accessors assert on it.
+  return IsDApplicableParams(d.azimuth_dist.type, d.azimuth_dist.spread, d.roll_dist.center);
 }
 
 }  // namespace detail

--- a/src/core/crystal.hpp
+++ b/src/core/crystal.hpp
@@ -354,12 +354,29 @@ struct BuiltMesh {
 };
 BuiltMesh BuildMeshFromCfGeom(const CrystalGeom& g);
 
+// Returns true if roll's anchor slot (Distribution::center, whatever the type calls it) is a
+// multiple of 30° within FloatEqual precision.
+bool IsRollAnchorAtMultipleOf30(float roll_anchor_deg);
+
 // Returns true if roll_mean_deg is a multiple of 30° (within FloatEqual precision).
 bool IsRollMeanAtMultipleOf30(const AxisDistribution& d);
 
 // Compute σ-mirror parameter a (0..5) from roll_mean_deg.
 // Formula: n = ((int)round(roll_mean / 30.0f) % 6 + 6) % 6; a = (6 - n) % 6.
 int ComputeSigmaA(float roll_mean_deg);
+
+// D applicability over the three raw quantities the rule actually reads, and nothing else:
+// azimuth's distribution type, azimuth's full range in degrees, and roll's anchor slot in degrees.
+// This is the owner; IsDApplicable(const AxisDistribution&) below is a projection onto it.
+//
+// Stated this way so a caller holding the fields but not an AxisDistribution can ask directly.
+// That caller is the C API's LUMICE_IsDApplicable, added so the GUI stops carrying its own
+// transcription of this rule — the copy in symmetry_ui.cpp had drifted to a 1e-3 tolerance against
+// core's 1e-5, which on a 3.05e-5 azimuth-range residue made the checkbox say D was live while the
+// engine had already dropped it. The alternative shape (a wrapper that fills a stand-in
+// AxisDistribution and calls the struct form) would put "which fields are read" in a comment
+// rather than in a signature, and nothing would catch it going stale.
+bool IsDApplicableParams(DistributionType azimuth_type, float azimuth_full_range_deg, float roll_anchor_deg);
 
 // Returns true if D symmetry is applicable for the given axis distribution.
 // Requires azimuth full-360° uniform AND roll mean at a multiple of 30°.

--- a/src/core/math.cpp
+++ b/src/core/math.cpp
@@ -560,13 +560,18 @@ bool AxisDistribution::IsFullSphereUniform() const {
 }
 
 
+bool IsFullTurnUniform(DistributionType type, float full_range_deg) {
+  return type == DistributionType::kUniform && FloatEqual(full_range_deg, 360.0f);
+}
+
+
 bool AxisDistribution::IsAzRotationallySymmetric() const {
-  return azimuth_dist.type == DistributionType::kUniform && FloatEqual(azimuth_dist.UniformFullRange(), 360.0f);
+  return IsFullTurnUniform(azimuth_dist.type, azimuth_dist.spread);
 }
 
 
 bool AxisDistribution::IsRollRotationallySymmetric() const {
-  return roll_dist.type == DistributionType::kUniform && FloatEqual(roll_dist.UniformFullRange(), 360.0f);
+  return IsFullTurnUniform(roll_dist.type, roll_dist.spread);
 }
 
 

--- a/src/core/math.cpp
+++ b/src/core/math.cpp
@@ -553,6 +553,12 @@ std::pair<float, bool> detail::NormalizeLatitude(float latitude_rad) {
 
 
 bool AxisDistribution::IsFullSphereUniform() const {
+  // The az / lat halves read through UniformCenter() / UniformFullRange() while the roll half
+  // (IsRollRotationallySymmetric -> IsFullTurnUniform) reads the raw `spread`. The two are the
+  // same value: for kUniform, UniformFullRange() returns `spread` outright. The accessors are
+  // kept here because they assert the kUniform precondition, which the preceding `type ==` in
+  // each conjunct establishes; IsFullTurnUniform cannot use them because it is also the entry
+  // point for callers that have not yet checked the type.
   return azimuth_dist.type == DistributionType::kUniform && FloatEqual(azimuth_dist.UniformCenter(), 0.0f) &&
          FloatEqual(azimuth_dist.UniformFullRange(), 360.0f) && latitude_dist.type == DistributionType::kUniform &&
          FloatEqual(latitude_dist.UniformCenter(), 90.0f) && FloatEqual(latitude_dist.UniformFullRange(), 360.0f) &&

--- a/src/core/math.cpp
+++ b/src/core/math.cpp
@@ -555,12 +555,18 @@ std::pair<float, bool> detail::NormalizeLatitude(float latitude_rad) {
 bool AxisDistribution::IsFullSphereUniform() const {
   return azimuth_dist.type == DistributionType::kUniform && FloatEqual(azimuth_dist.UniformCenter(), 0.0f) &&
          FloatEqual(azimuth_dist.UniformFullRange(), 360.0f) && latitude_dist.type == DistributionType::kUniform &&
-         FloatEqual(latitude_dist.UniformCenter(), 90.0f) && FloatEqual(latitude_dist.UniformFullRange(), 360.0f);
+         FloatEqual(latitude_dist.UniformCenter(), 90.0f) && FloatEqual(latitude_dist.UniformFullRange(), 360.0f) &&
+         IsRollRotationallySymmetric();
 }
 
 
 bool AxisDistribution::IsAzRotationallySymmetric() const {
   return azimuth_dist.type == DistributionType::kUniform && FloatEqual(azimuth_dist.UniformFullRange(), 360.0f);
+}
+
+
+bool AxisDistribution::IsRollRotationallySymmetric() const {
+  return roll_dist.type == DistributionType::kUniform && FloatEqual(roll_dist.UniformFullRange(), 360.0f);
 }
 
 

--- a/src/core/math.cpp
+++ b/src/core/math.cpp
@@ -554,10 +554,10 @@ std::pair<float, bool> detail::NormalizeLatitude(float latitude_rad) {
 
 bool AxisDistribution::IsFullSphereUniform() const {
   // The az / lat halves read through UniformCenter() / UniformFullRange() while the roll half
-  // (IsRollRotationallySymmetric -> IsFullTurnUniform) reads the raw `spread`. The two are the
+  // (IsRollRotationallySymmetric -> detail::IsFullTurnUniform) reads the raw `spread`. The two are
   // same value: for kUniform, UniformFullRange() returns `spread` outright. The accessors are
   // kept here because they assert the kUniform precondition, which the preceding `type ==` in
-  // each conjunct establishes; IsFullTurnUniform cannot use them because it is also the entry
+  // each conjunct establishes; detail::IsFullTurnUniform cannot use them because it is also the entry
   // point for callers that have not yet checked the type.
   return azimuth_dist.type == DistributionType::kUniform && FloatEqual(azimuth_dist.UniformCenter(), 0.0f) &&
          FloatEqual(azimuth_dist.UniformFullRange(), 360.0f) && latitude_dist.type == DistributionType::kUniform &&
@@ -566,18 +566,20 @@ bool AxisDistribution::IsFullSphereUniform() const {
 }
 
 
-bool IsFullTurnUniform(DistributionType type, float full_range_deg) {
+// Qualified definition rather than a `namespace detail { ... }` block, matching
+// detail::NormalizeLatitude above — this file spells detail members that way.
+bool detail::IsFullTurnUniform(DistributionType type, float full_range_deg) {
   return type == DistributionType::kUniform && FloatEqual(full_range_deg, 360.0f);
 }
 
 
 bool AxisDistribution::IsAzRotationallySymmetric() const {
-  return IsFullTurnUniform(azimuth_dist.type, azimuth_dist.spread);
+  return detail::IsFullTurnUniform(azimuth_dist.type, azimuth_dist.spread);
 }
 
 
 bool AxisDistribution::IsRollRotationallySymmetric() const {
-  return IsFullTurnUniform(roll_dist.type, roll_dist.spread);
+  return detail::IsFullTurnUniform(roll_dist.type, roll_dist.spread);
 }
 
 

--- a/src/core/math.hpp
+++ b/src/core/math.hpp
@@ -268,19 +268,29 @@ void Normalized3(const float* vec, float* vec_out);
 void Vec3FromTo(const float* vec1, const float* vec2, float* vec);
 void TriangleNormal(const float* p1, const float* p2, const float* p3, float* normal);
 
+namespace detail {
+
 //! @brief Whether a distribution over an angle is unchanged by an arbitrary constant rotation —
 //!   i.e. kUniform spanning a full turn.
 //! @details The shared primitive under AxisDistribution::IsAzRotationallySymmetric and
 //!   ::IsRollRotationallySymmetric, and the one place the 360° tolerance is spelled. Stated over
 //!   the two raw fields it reads rather than over a Distribution, so a caller holding the fields
-//!   but not the struct — the C API's LUMICE_IsDApplicable, which the GUI consults instead of
-//!   keeping its own copy of this rule — can ask without assembling a stand-in object whose unread
-//!   members are a contract no compiler checks. `full_range_deg` is read type-erased (the raw
-//!   `Distribution::spread`, not UniformFullRange()) because it is passed unconditionally, before
-//!   the type has been established.
+//!   but not the struct can ask without assembling a stand-in object whose unread members are a
+//!   contract no compiler checks. Its direct callers are the two AxisDistribution members below
+//!   and detail::IsDApplicableParams (crystal.cpp); the reason the raw-field form exists at all
+//!   is two hops further out — LUMICE_IsDApplicable (c_api.cpp) reaches it through
+//!   IsDApplicableParams, and the GUI consults that instead of keeping its own copy of this rule.
+//!   `full_range_deg` is read type-erased (the raw `Distribution::spread`, not
+//!   UniformFullRange()) because it is passed unconditionally, before the type has been
+//!   established.
 //! @note Deliberately says nothing about the center: a full-period uniform is rotation invariant
 //!   wherever it is centered.
+//! @note Lives in `detail` for the same reason detail::NormalizeLatitude and
+//!   detail::IsDApplicableParams do: a core-internal primitive that is consumed across files but
+//!   is not part of the stable surface a caller outside core should bind to.
 bool IsFullTurnUniform(DistributionType type, float full_range_deg);
+
+}  // namespace detail
 
 struct AxisDistribution {
   AxisDistribution();

--- a/src/core/math.hpp
+++ b/src/core/math.hpp
@@ -272,7 +272,10 @@ struct AxisDistribution {
   AxisDistribution();
 
   //! @brief Check if this distribution represents full-sphere uniform sampling.
-  //! @details Only checks azimuth and latitude — roll does not participate in sphere sampling dispatch.
+  //! @details Checks all three of azimuth, latitude AND roll. Roll is not decorative here: the
+  //!   fast path this predicate dispatches to never applies the pole-crossing `roll += π`
+  //!   correction that the general LatLut path applies on a flip, so the two paths only agree
+  //!   when roll is invariant under that +180° shift. See IsRollRotationallySymmetric.
   //! @warning The parameterized SampleSphericalPointsSph does NOT include the asin(u) Jacobian correction.
   //!   For full-sphere uniform, the caller must use the parameter-less overload instead.
   bool IsFullSphereUniform() const;
@@ -280,6 +283,24 @@ struct AxisDistribution {
   //! @brief Check if azimuth is uniformly distributed over the full 360°.
   //! @details Only checks the azimuth type and its full range; latitude and roll are ignored.
   bool IsAzRotationallySymmetric() const;
+
+  //! @brief Check whether roll is invariant under the pole-crossing +180° correction — i.e.
+  //!   sampling roll and sampling roll+π yield the same distribution.
+  //! @details This is what makes the kFullSphere fast path a provable optimization rather than a
+  //!   semantic fork: detail::NormalizeLatitude reflects a latitude past the pole and reports a
+  //!   `flip`, on which the general path adds π to BOTH azimuth and roll (Rz(roll) has period 2π),
+  //!   while the fast path adds nothing at all. Equal distributions therefore require roll's own
+  //!   distribution to be unchanged by a +π shift.
+  //! @warning The condition implemented below — kUniform spanning a full 360° — is STRICTER than
+  //!   the mathematical requirement. The requirement is only "invariant under a +180° shift"; a
+  //!   full-period uniform is merely the one non-degenerate form among the six DistributionTypes
+  //!   this repo has today that satisfies it (which is also why, like
+  //!   IsAzRotationallySymmetric, it need not check the center: a full-period uniform is shift
+  //!   invariant regardless of where it is centered). If a new DistributionType is added, do not
+  //!   copy this implementation mechanically — ask whether the new type can be +180°-invariant
+  //!   without being a full-range uniform (e.g. a symmetric two-lobe form), and widen the
+  //!   predicate rather than assuming uniform is the only answer.
+  bool IsRollRotationallySymmetric() const;
 
   //! @brief Check whether every one of azimuth/latitude/roll is kNoRandom — i.e. this axis
   //!   never consumes the RNG and yields one fixed orientation for every ray.
@@ -297,11 +318,18 @@ struct AxisDistribution {
   //!   bit-identical rotation for every ray, and a stochastic one really does vary. That is what
   //!   the sample count depends on, and it is invisible to a truth-table test — a change making
   //!   kNoRandom consume the RNG turns the pin red while every truth-table case stays green
-  //!   (verified by mutation). It does NOT pin which branch InitRay_rot takes: since the unified
-  //!   area-measure LatLut, the full_sphere fast path and the parameterized path are
-  //!   statistically equivalent (measured: fraction of |world z| < 0.5 is 0.5000 vs 0.4977 over
-  //!   20k samples), so that branch is an optimization rather than a correctness fork and
-  //!   decoupling it is not behaviorally detectable. Do not add a test claiming otherwise.
+  //!   (verified by mutation). It does NOT pin which branch InitRay_rot takes.
+  //! @note This comment used to claim the two sampler paths were "statistically equivalent", on
+  //!   the strength of a measurement of the fraction of |world z| < 0.5 (0.5000 vs 0.4977 over 20k
+  //!   samples), and told the reader not to add a test claiming otherwise. That claim was wrong and
+  //!   the measurement could not have caught it: |world z| reads the sampled AXIS DIRECTION only,
+  //!   and the difference between the two paths lives entirely in roll — the fast path drops the
+  //!   pole-crossing `roll += π` that the general path applies on a flip. A yardstick that cannot
+  //!   see the quantity under test reports agreement no matter what (a16). The two paths are now
+  //!   made equivalent by construction instead: IsFullSphereUniform requires
+  //!   IsRollRotationallySymmetric, so the fast path is only ever taken where the correction is a
+  //!   no-op in distribution. RollFlipDivergence.* (test_simulator.cpp) measures roll directly and
+  //!   pins that.
   bool IsAxisDeterministic() const;
 
   Distribution azimuth_dist;

--- a/src/core/math.hpp
+++ b/src/core/math.hpp
@@ -268,6 +268,20 @@ void Normalized3(const float* vec, float* vec_out);
 void Vec3FromTo(const float* vec1, const float* vec2, float* vec);
 void TriangleNormal(const float* p1, const float* p2, const float* p3, float* normal);
 
+//! @brief Whether a distribution over an angle is unchanged by an arbitrary constant rotation —
+//!   i.e. kUniform spanning a full turn.
+//! @details The shared primitive under AxisDistribution::IsAzRotationallySymmetric and
+//!   ::IsRollRotationallySymmetric, and the one place the 360° tolerance is spelled. Stated over
+//!   the two raw fields it reads rather than over a Distribution, so a caller holding the fields
+//!   but not the struct — the C API's LUMICE_IsDApplicable, which the GUI consults instead of
+//!   keeping its own copy of this rule — can ask without assembling a stand-in object whose unread
+//!   members are a contract no compiler checks. `full_range_deg` is read type-erased (the raw
+//!   `Distribution::spread`, not UniformFullRange()) because it is passed unconditionally, before
+//!   the type has been established.
+//! @note Deliberately says nothing about the center: a full-period uniform is rotation invariant
+//!   wherever it is centered.
+bool IsFullTurnUniform(DistributionType type, float full_range_deg);
+
 struct AxisDistribution {
   AxisDistribution();
 

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -1199,27 +1199,7 @@ static bool FillColorPredicate(LUMICE_ColorPredicate* dst, const ColorClassRefCo
 // ========== Build a LUMICE_Scene handle (for LUMICE_CommitScene / LUMICE_SceneToJson) ==========
 
 static void FillAxisDist(const AxisDist& src, LUMICE_Distribution* dst) {
-  static_assert(static_cast<int>(AxisDistType::kCount) == 5, "Update FillAxisDist when adding new AxisDistType");
-  switch (src.type) {
-    case AxisDistType::kGauss:
-      dst->type = LUMICE_DIST_GAUSS;
-      break;
-    case AxisDistType::kUniform:
-      dst->type = LUMICE_DIST_UNIFORM;
-      break;
-    case AxisDistType::kZigzag:
-      dst->type = LUMICE_DIST_ZIGZAG;
-      break;
-    case AxisDistType::kLaplacian:
-      dst->type = LUMICE_DIST_LAPLACIAN;
-      break;
-    case AxisDistType::kGaussLegacy:
-      dst->type = LUMICE_DIST_GAUSS_LEGACY;
-      break;
-    default:
-      dst->type = LUMICE_DIST_GAUSS;
-      break;
-  }
+  dst->type = AxisDistTypeToWire(src.type);
   dst->center = src.mean;
   dst->spread = src.std;
 }

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -45,6 +45,30 @@ enum class RunIntent { kNone, kLoaded, kRunning, kStopping, kStopped, kRunComple
 // Values must stay contiguous 0..N-1 — ImGui RadioButton relies on static_cast<int>.
 enum class AxisDistType { kGauss, kUniform, kZigzag, kLaplacian, kGaussLegacy, kCount };
 
+// The GUI enum above is a UI presentation order (it is what a RadioButton row indexes); the
+// LUMICE_DIST_* constants are the wire encoding. They are different orders, so every place that
+// hands a GUI distribution to the C API needs this translation — file_io.cpp when it builds a
+// LUMICE_Scene, symmetry_ui.cpp when it asks LUMICE_IsDApplicable. One owner, so a sixth type
+// cannot be added to one and forgotten in the other.
+inline int AxisDistTypeToWire(AxisDistType type) {
+  static_assert(static_cast<int>(AxisDistType::kCount) == 5, "Update AxisDistTypeToWire when adding new AxisDistType");
+  switch (type) {
+    case AxisDistType::kGauss:
+      return LUMICE_DIST_GAUSS;
+    case AxisDistType::kUniform:
+      return LUMICE_DIST_UNIFORM;
+    case AxisDistType::kZigzag:
+      return LUMICE_DIST_ZIGZAG;
+    case AxisDistType::kLaplacian:
+      return LUMICE_DIST_LAPLACIAN;
+    case AxisDistType::kGaussLegacy:
+      return LUMICE_DIST_GAUSS_LEGACY;
+    case AxisDistType::kCount:
+      break;
+  }
+  return LUMICE_DIST_GAUSS;
+}
+
 // Aspect ratio presets for preview window
 enum class AspectPreset { kFree, k16x9, k3x2, k4x3, k1x1, k2x1, kMatchBg };
 inline const char* const kAspectPresetNames[] = { "Free", "16:9", "3:2", "4:3", "1:1", "2:1", "Match Background" };

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -60,6 +60,16 @@ static bool RenderNonlinearSlider(const char* slider_id, float* value, float min
       changed = true;
     }
   } else {
+    // Linear: no *Snapped counterpart, and none is needed. The three branches above snap because
+    // they round-trip the value through a transform and its inverse, which lands a few ULP short
+    // of the bound at a stop. This branch hands `value` to ImGui untransformed, and ImGui itself
+    // special-cases the extents -- ScaleValueFromRatioT (imgui_widgets.cpp) opens with
+    // `if (t <= 0.0f ...) return v_min; if (t >= 1.0f) return v_max;`, so a stop yields the bound
+    // bit-for-bit. Verified against the vendored copy rather than inferred from the other
+    // branches, because it matters here: the Mean slider runs through this branch, and its value
+    // feeds the same family of absolute-epsilon predicates (IsRollMeanAtMultipleOf30, and the
+    // 90-degree latitude center inside IsFullSphereUniform) that a few ULP would flip exactly as
+    // the Range slider's drift once flipped IsFullSphereUniform.
     changed |= ImGui::SliderFloat(slider_id, value, min_val, max_val, fmt, ImGuiSliderFlags_NoInput);
   }
   return changed;

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -41,19 +41,22 @@ static bool RenderNonlinearSlider(const char* slider_id, float* value, float min
     float sqrt_val = std::sqrt(std::max(*value, 0.0f));
     float sqrt_max = std::sqrt(max_val);
     if (ImGui::SliderFloat(slider_id, &sqrt_val, 0.0f, sqrt_max, "", ImGuiSliderFlags_NoInput)) {
-      *value = sqrt_val * sqrt_val;
+      // The *Snapped inverses here are load-bearing, not tidiness: at a slider stop the plain
+      // round trip lands a few ULP short of the bound, which core's absolute-epsilon predicates
+      // read as a different value entirely. See slider_mapping.hpp for the full account.
+      *value = slider_mapping::SqrtNormToValueSnapped(sqrt_val, sqrt_max, max_val);
       changed = true;
     }
   } else if (scale == SliderScale::kLog && min_val > 0.0f) {
     float norm = slider_mapping::LogValueToNorm(*value, min_val, max_val);
     if (ImGui::SliderFloat(slider_id, &norm, 0.0f, 1.0f, "", ImGuiSliderFlags_NoInput)) {
-      *value = slider_mapping::LogNormToValue(norm, min_val, max_val);
+      *value = slider_mapping::LogNormToValueSnapped(norm, min_val, max_val);
       changed = true;
     }
   } else if (scale == SliderScale::kLogLinear && min_val == 0.0f) {
     float norm = slider_mapping::LogLinearValueToNorm(*value, max_val);
     if (ImGui::SliderFloat(slider_id, &norm, 0.0f, 1.0f, "", ImGuiSliderFlags_NoInput)) {
-      *value = slider_mapping::LogLinearNormToValue(norm, max_val);
+      *value = slider_mapping::LogLinearNormToValueSnapped(norm, max_val);
       changed = true;
     }
   } else {

--- a/src/gui/slider_mapping.hpp
+++ b/src/gui/slider_mapping.hpp
@@ -65,6 +65,55 @@ inline float LogLinearNormToValue(float norm, float max_val) {
   return kLogLinearX0 * std::exp(t_log * log_ratio);
 }
 
+// --- Endpoint-snapped inverse mappings ---
+//
+// Every inverse above round-trips through sqrt or exp/log, and neither is bit-exact at the ends:
+// sqrtf(360.0f) squared back is 359.999969f, 3.05e-5 short. That residue is invisible in the UI
+// (the paired InputFloat prints "%.1f") but not to core, which uses absolute-epsilon predicates on
+// exactly these quantities to pick a sampling path — FloatEqual's threshold is 1e-5, so a Range
+// slider dragged to its stop silently stopped meaning "360". Round-tripping is the right behavior
+// everywhere except at the two ends, where the intended value is known exactly rather than
+// approximated: ImGui::SliderFloat clamps its output to the v_min / v_max it was handed, so
+// "the handle is at the stop" is an exact comparison, not a tolerance.
+//
+// Use these wherever a slider position is converted back into a stored value. The bare functions
+// above stay as they are — their interior approximation is fine, and their own tests pin it.
+
+// Sqrt-scale inverse with both ends snapped. `sqrt_val` and `sqrt_max` live in sqrt space;
+// `max_val` is the target-space bound (i.e. sqrt_max * sqrt_max as the caller means it).
+inline float SqrtNormToValueSnapped(float sqrt_val, float sqrt_max, float max_val) {
+  if (sqrt_val <= 0.0f) {
+    return 0.0f;
+  }
+  if (sqrt_val >= sqrt_max) {
+    return max_val;
+  }
+  return sqrt_val * sqrt_val;
+}
+
+// Log-scale inverse with both ends snapped.
+inline float LogNormToValueSnapped(float norm, float min_val, float max_val) {
+  if (norm <= 0.0f) {
+    return min_val;
+  }
+  if (norm >= 1.0f) {
+    return max_val;
+  }
+  return LogNormToValue(norm, min_val, max_val);
+}
+
+// LogLinear hybrid inverse with both ends snapped. The lower end is 0 by construction (this pair
+// is purpose-built for min_val == 0; see LogLinearValueToNorm's note).
+inline float LogLinearNormToValueSnapped(float norm, float max_val) {
+  if (norm <= 0.0f) {
+    return 0.0f;
+  }
+  if (norm >= 1.0f) {
+    return max_val;
+  }
+  return LogLinearNormToValue(norm, max_val);
+}
+
 }  // namespace lumice::gui::slider_mapping
 
 #endif  // LUMICE_GUI_SLIDER_MAPPING_HPP

--- a/src/gui/symmetry_ui.cpp
+++ b/src/gui/symmetry_ui.cpp
@@ -5,6 +5,7 @@
 #include "IconsFontAwesome6.h"
 #include "gui/theme.hpp"
 #include "imgui.h"
+#include "lumice.h"
 
 namespace lumice::gui {
 
@@ -17,10 +18,7 @@ constexpr const char* kDTooltipText =
 }  // namespace
 
 bool IsDApplicableGuiAxis(const AxisDist& az, const AxisDist& roll) {
-  const bool az_sym = az.type == AxisDistType::kUniform && std::fabs(az.std - 360.0f) < 1e-3f;
-  const float rem = std::fmod(std::fmod(roll.mean, 30.0f) + 30.0f, 30.0f);
-  const bool roll_ok = rem < 1e-3f || std::fabs(rem - 30.0f) < 1e-3f;
-  return az_sym && roll_ok;
+  return LUMICE_IsDApplicable(AxisDistTypeToWire(az.type), az.std, roll.mean) != 0;
 }
 
 void RenderSymmetryCheckboxes(bool& sym_p, bool& sym_b, bool& sym_d, bool d_applicable, const char* id_suffix) {

--- a/src/gui/symmetry_ui.hpp
+++ b/src/gui/symmetry_ui.hpp
@@ -16,7 +16,12 @@ namespace lumice::gui {
 
 // Returns true when the given (azimuth, roll) axis config satisfies D-symmetry
 // conditions: azimuth uniform 360° AND roll mean a multiple of 30°.
-// Mirrors core detail::IsDApplicable (src/core/crystal.cpp). Keep in sync.
+//
+// Delegates to core's own predicate through LUMICE_IsDApplicable — it does not mirror it. This
+// used to be a transcription with a "keep in sync" note, and it had drifted: a 1e-3 tolerance
+// against core's 1e-5, which on a 3.05e-5 azimuth-range residue (what a Range slider dragged to
+// its stop used to store) made the checkbox report D as live while the engine had already
+// dropped it. A comment asking two copies to agree is not a mechanism; one owner is.
 bool IsDApplicableGuiAxis(const AxisDist& az, const AxisDist& roll);
 
 // Renders the "P B D [i]" checkbox row (ImGui). `id_suffix` disambiguates ImGui

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -1238,6 +1238,24 @@ const char* LUMICE_ShapeIndicesKeyName(int upper);
 // internal latitude (zenith = 90 - latitude): the key names the file format, not the field.
 const char* LUMICE_AxisScalarKeyName(int slot);
 
+// Returns non-zero when D (the sigma-d mirror) is applicable to a crystal whose axis has this
+// azimuth distribution and this roll anchor. D needs the azimuth to be uniform over a full turn
+// and the roll anchor to sit on a multiple of 30 degrees; an axis failing either condition has its
+// D flag silently ignored by the engine.
+//
+// Arguments are the three raw quantities the rule reads and no others:
+//   azimuth_dist_type      one of LUMICE_DIST_*, from the azimuth LUMICE_Distribution's .type
+//   azimuth_full_range_deg that distribution's .spread (for LUMICE_DIST_UNIFORM, the full width)
+//   roll_anchor_deg        the roll LUMICE_Distribution's .center, read type-erased -- it is a
+//                          tilt offset for ZIGZAG and an interval midpoint for UNIFORM, so do not
+//                          read the name as "the statistical mean of the roll angle"
+//
+// This is core's own predicate, not a second copy of it. Ask it rather than transcribing the rule:
+// a GUI-side transcription is exactly what once let a checkbox report D as live while the engine
+// had already dropped it, the two having drifted to different float tolerances (1e-3 against
+// 1e-5) on a difference of 3.05e-5.
+int LUMICE_IsDApplicable(int azimuth_dist_type, float azimuth_full_range_deg, float roll_anchor_deg);
+
 // =============== Raypath Validation ===============
 // Validation state for raypath text input (GUI border color + OK gate).
 typedef enum LUMICE_RaypathValidationState_ {

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -3187,6 +3187,37 @@ const char* LUMICE_AxisScalarKeyName(int slot) {
   return ns::AxisScalarKeyName(slot);
 }
 
+int LUMICE_IsDApplicable(int azimuth_dist_type, float azimuth_full_range_deg, float roll_anchor_deg) {
+  // Spelled as a switch rather than a cast: the header promises only that LUMICE_DIST_* stays
+  // self-consistent, not that it stays numerically equal to core's DistributionType (every other
+  // translation in this file goes through a string switch for the same reason). An unrecognised
+  // value answers the negative, matching LUMICE_IsLegalFace / LUMICE_IsShapeScalarApplicable.
+  ns::DistributionType az_type{};
+  switch (azimuth_dist_type) {
+    case LUMICE_DIST_NO_RANDOM:
+      az_type = ns::DistributionType::kNoRandom;
+      break;
+    case LUMICE_DIST_UNIFORM:
+      az_type = ns::DistributionType::kUniform;
+      break;
+    case LUMICE_DIST_GAUSS:
+      az_type = ns::DistributionType::kGaussian;
+      break;
+    case LUMICE_DIST_ZIGZAG:
+      az_type = ns::DistributionType::kZigzag;
+      break;
+    case LUMICE_DIST_LAPLACIAN:
+      az_type = ns::DistributionType::kLaplacian;
+      break;
+    case LUMICE_DIST_GAUSS_LEGACY:
+      az_type = ns::DistributionType::kGaussianLegacy;
+      break;
+    default:
+      return 0;
+  }
+  return ns::detail::IsDApplicableParams(az_type, azimuth_full_range_deg, roll_anchor_deg) ? 1 : 0;
+}
+
 
 // =============== Raypath Validation ===============
 LUMICE_ErrorCode LUMICE_ValidateRaypathText(const char* text, LUMICE_CrystalKind kind,

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -3189,9 +3189,10 @@ const char* LUMICE_AxisScalarKeyName(int slot) {
 
 int LUMICE_IsDApplicable(int azimuth_dist_type, float azimuth_full_range_deg, float roll_anchor_deg) {
   // Spelled as a switch rather than a cast: the header promises only that LUMICE_DIST_* stays
-  // self-consistent, not that it stays numerically equal to core's DistributionType (every other
-  // translation in this file goes through a string switch for the same reason). An unrecognised
-  // value answers the negative, matching LUMICE_IsLegalFace / LUMICE_IsShapeScalarApplicable.
+  // self-consistent, not that it stays numerically equal to core's DistributionType. Every other
+  // wire-enum translation in this file (LUMICE_DIST_* above, LUMICE_LENS_TYPE_*) goes through an
+  // explicit switch for the same reason. An unrecognised value answers the negative, matching
+  // LUMICE_IsLegalFace / LUMICE_IsShapeScalarApplicable.
   ns::DistributionType az_type{};
   switch (azimuth_dist_type) {
     case LUMICE_DIST_NO_RANDOM:

--- a/test/e2e/configs/full_sphere_roll_flip_drifted.json
+++ b/test/e2e/configs/full_sphere_roll_flip_drifted.json
@@ -1,0 +1,135 @@
+{
+  "crystal": [
+    {
+      "axis": {
+        "azimuth": {
+          "mean": 0.0,
+          "std": 360.0,
+          "type": "uniform"
+        },
+        "roll": {
+          "mean": 0.0,
+          "std": 0.0,
+          "type": "gauss"
+        },
+        "zenith": {
+          "mean": 0.0,
+          "std": 359.9999694824219,
+          "type": "uniform"
+        }
+      },
+      "id": 0,
+      "shape": {
+        "face_distance": [
+          {
+            "mean": 1.0,
+            "std": 0.0,
+            "type": "uniform"
+          },
+          {
+            "mean": 1.0,
+            "std": 0.0,
+            "type": "uniform"
+          },
+          {
+            "mean": 1.0,
+            "std": 0.0,
+            "type": "uniform"
+          },
+          {
+            "mean": 1.0,
+            "std": 0.0,
+            "type": "uniform"
+          },
+          {
+            "mean": 1.0,
+            "std": 0.0,
+            "type": "uniform"
+          },
+          {
+            "mean": 1.0,
+            "std": 0.0,
+            "type": "uniform"
+          }
+        ],
+        "height": {
+          "mean": 1.0,
+          "std": 0.0,
+          "type": "uniform"
+        }
+      },
+      "type": "prism"
+    }
+  ],
+  "filter": [
+    {
+      "action": "filter_in",
+      "id": 0,
+      "raypath": [
+        3,
+        5
+      ],
+      "symmetry": "D",
+      "type": "raypath"
+    }
+  ],
+  "render": [
+    {
+      "background": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "id": 0,
+      "intensity_factor": 1.0,
+      "lens": {
+        "fov": 180.0,
+        "type": "dual_fisheye_equal_area"
+      },
+      "lens_shift": [
+        0,
+        0
+      ],
+      "opacity": 1.0,
+      "overlap": 0.08720000088214874,
+      "ray_color": [
+        -1.0,
+        -1.0,
+        -1.0
+      ],
+      "resolution": [
+        512,
+        256
+      ],
+      "view": {
+        "azimuth": 0.0,
+        "elevation": 0.0,
+        "roll": 0.0
+      },
+      "visible": "full"
+    }
+  ],
+  "scene": {
+    "light_source": {
+      "altitude": 20.0,
+      "azimuth": 0.0,
+      "diameter": 0.5,
+      "spectrum": "D65",
+      "type": "sun"
+    },
+    "max_hits": 2,
+    "ray_num": 400000,
+    "scattering": [
+      {
+        "entries": [
+          {
+            "crystal": 0,
+            "filter": 0,
+            "proportion": 100.0
+          }
+        ],
+        "prob": 0.0
+      }
+    ]
+  }
+}

--- a/test/e2e/configs/full_sphere_roll_flip_exact.json
+++ b/test/e2e/configs/full_sphere_roll_flip_exact.json
@@ -1,0 +1,135 @@
+{
+  "crystal": [
+    {
+      "axis": {
+        "azimuth": {
+          "mean": 0.0,
+          "std": 360.0,
+          "type": "uniform"
+        },
+        "roll": {
+          "mean": 0.0,
+          "std": 0.0,
+          "type": "gauss"
+        },
+        "zenith": {
+          "mean": 0.0,
+          "std": 360.0,
+          "type": "uniform"
+        }
+      },
+      "id": 0,
+      "shape": {
+        "face_distance": [
+          {
+            "mean": 1.0,
+            "std": 0.0,
+            "type": "uniform"
+          },
+          {
+            "mean": 1.0,
+            "std": 0.0,
+            "type": "uniform"
+          },
+          {
+            "mean": 1.0,
+            "std": 0.0,
+            "type": "uniform"
+          },
+          {
+            "mean": 1.0,
+            "std": 0.0,
+            "type": "uniform"
+          },
+          {
+            "mean": 1.0,
+            "std": 0.0,
+            "type": "uniform"
+          },
+          {
+            "mean": 1.0,
+            "std": 0.0,
+            "type": "uniform"
+          }
+        ],
+        "height": {
+          "mean": 1.0,
+          "std": 0.0,
+          "type": "uniform"
+        }
+      },
+      "type": "prism"
+    }
+  ],
+  "filter": [
+    {
+      "action": "filter_in",
+      "id": 0,
+      "raypath": [
+        3,
+        5
+      ],
+      "symmetry": "D",
+      "type": "raypath"
+    }
+  ],
+  "render": [
+    {
+      "background": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "id": 0,
+      "intensity_factor": 1.0,
+      "lens": {
+        "fov": 180.0,
+        "type": "dual_fisheye_equal_area"
+      },
+      "lens_shift": [
+        0,
+        0
+      ],
+      "opacity": 1.0,
+      "overlap": 0.08720000088214874,
+      "ray_color": [
+        -1.0,
+        -1.0,
+        -1.0
+      ],
+      "resolution": [
+        512,
+        256
+      ],
+      "view": {
+        "azimuth": 0.0,
+        "elevation": 0.0,
+        "roll": 0.0
+      },
+      "visible": "full"
+    }
+  ],
+  "scene": {
+    "light_source": {
+      "altitude": 20.0,
+      "azimuth": 0.0,
+      "diameter": 0.5,
+      "spectrum": "D65",
+      "type": "sun"
+    },
+    "max_hits": 2,
+    "ray_num": 400000,
+    "scattering": [
+      {
+        "entries": [
+          {
+            "crystal": 0,
+            "filter": 0,
+            "proportion": 100.0
+          }
+        ],
+        "prob": 0.0
+      }
+    ]
+  }
+}

--- a/test/e2e/configs/full_sphere_roll_flip_mean_shifted.json
+++ b/test/e2e/configs/full_sphere_roll_flip_mean_shifted.json
@@ -1,0 +1,135 @@
+{
+  "crystal": [
+    {
+      "axis": {
+        "azimuth": {
+          "mean": 0.0,
+          "std": 360.0,
+          "type": "uniform"
+        },
+        "roll": {
+          "mean": 0.0,
+          "std": 0.0,
+          "type": "gauss"
+        },
+        "zenith": {
+          "mean": 0.001,
+          "std": 360,
+          "type": "uniform"
+        }
+      },
+      "id": 0,
+      "shape": {
+        "face_distance": [
+          {
+            "mean": 1.0,
+            "std": 0.0,
+            "type": "uniform"
+          },
+          {
+            "mean": 1.0,
+            "std": 0.0,
+            "type": "uniform"
+          },
+          {
+            "mean": 1.0,
+            "std": 0.0,
+            "type": "uniform"
+          },
+          {
+            "mean": 1.0,
+            "std": 0.0,
+            "type": "uniform"
+          },
+          {
+            "mean": 1.0,
+            "std": 0.0,
+            "type": "uniform"
+          },
+          {
+            "mean": 1.0,
+            "std": 0.0,
+            "type": "uniform"
+          }
+        ],
+        "height": {
+          "mean": 1.0,
+          "std": 0.0,
+          "type": "uniform"
+        }
+      },
+      "type": "prism"
+    }
+  ],
+  "filter": [
+    {
+      "action": "filter_in",
+      "id": 0,
+      "raypath": [
+        3,
+        5
+      ],
+      "symmetry": "D",
+      "type": "raypath"
+    }
+  ],
+  "render": [
+    {
+      "background": [
+        0.0,
+        0.0,
+        0.0
+      ],
+      "id": 0,
+      "intensity_factor": 1.0,
+      "lens": {
+        "fov": 180.0,
+        "type": "dual_fisheye_equal_area"
+      },
+      "lens_shift": [
+        0,
+        0
+      ],
+      "opacity": 1.0,
+      "overlap": 0.08720000088214874,
+      "ray_color": [
+        -1.0,
+        -1.0,
+        -1.0
+      ],
+      "resolution": [
+        512,
+        256
+      ],
+      "view": {
+        "azimuth": 0.0,
+        "elevation": 0.0,
+        "roll": 0.0
+      },
+      "visible": "full"
+    }
+  ],
+  "scene": {
+    "light_source": {
+      "altitude": 20.0,
+      "azimuth": 0.0,
+      "diameter": 0.5,
+      "spectrum": "D65",
+      "type": "sun"
+    },
+    "max_hits": 2,
+    "ray_num": 400000,
+    "scattering": [
+      {
+        "entries": [
+          {
+            "crystal": 0,
+            "filter": 0,
+            "proportion": 100.0
+          }
+        ],
+        "prob": 0.0
+      }
+    ]
+  }
+}

--- a/test/gui/functional/test_edit_modal.cpp
+++ b/test/gui/functional/test_edit_modal.cpp
@@ -1298,6 +1298,38 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // Dragging a sqrt-scaled slider to its stop must store the bound itself, not the bound recovered
+  // through the sqrt round trip. sqrtf(360)^2 is 359.999969 — 3.05e-5 short, invisible behind the
+  // "%.1f" readout, and enough for core's FloatEqual (1e-5) to stop calling the axis a full turn,
+  // which silently reroutes the whole orientation sampler. The mapping itself is unit-tested
+  // (SliderMapping.EndpointSnappingWritesBackTheBoundExactly); what needs a live frame, and is the
+  // only reason this case is here, is that the real widget path reaches it — that ImGui hands the
+  // stop position back as exactly the v_max it was given, so the snap actually fires.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "edit_modal", "dragging_a_range_slider_to_its_stop_stores_the_exact_bound");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      const ScopedPopups popup_guard(ctx);
+      auto& cr = EntryCrystal();
+      cr.zenith = gui::AxisDist{ gui::AxisDistType::kUniform, 0.0f, 90.0f };
+      ctx->Yield(2);
+
+      ctx->ItemClick("**/Edit##ax");
+      ctx->Yield(4);
+      ctx->ItemClick("**/###axis_tab");
+      ctx->Yield(2);
+      IM_CHECK(ctx->ItemExists("**/Zenith/##Range_slider"));
+
+      // Far enough right that ImGui clamps at v_max whatever the slider's on-screen width.
+      ctx->ItemDragWithDelta("**/Zenith/##Range_slider", ImVec2(2000.0f, 0.0f));
+      ctx->Yield(3);
+      ctx->ItemClick(kOk);
+      ctx->Yield(2);
+
+      IM_CHECK_EQ(EntryCrystal().zenith.std, 360.0f);
+    };
+  }
+
   // ===================================================================================
   // The shape table: rows, domains, randomization, and the width budget.
   // ===================================================================================

--- a/test/regression-sentinel/test_full_sphere_roll_flip.py
+++ b/test/regression-sentinel/test_full_sphere_roll_flip.py
@@ -1,0 +1,123 @@
+"""End-to-end guard: an axis whose roll is fixed must not take the full-sphere fast path.
+
+The reported symptom was that one config rendered two different halos depending on
+whether the user had touched the Range slider. The mechanism, in three steps:
+
+1. The GUI's sqrt-scaled Range slider stored ``sqrtf(360)**2 == 359.999969`` when dragged
+   to its stop -- 3.05e-5 short of 360, and invisible behind a "%.1f" readout.
+2. ``AxisDistribution::IsFullSphereUniform`` compares that range with an absolute
+   epsilon of 1e-5, so it flipped, and ``lat_path::SelectLatPath`` rerouted the whole
+   orientation sampler from ``kFullSphere`` to ``kLutInverseCdf``.
+3. Those two paths were not equivalent. The general path applies the pole-crossing
+   ``roll += pi`` that ``detail::NormalizeLatitude`` reports; the fast path never did.
+   With a fixed roll, half the crystals came out rotated a further 180 degrees about
+   their own c axis, which shifts the prism face numbering by three -- and this config
+   filters on raypath [3,5], so it selected an entirely different set of physical paths.
+
+The fix makes ``IsFullSphereUniform`` require roll to be rotationally symmetric, so the
+fast path is only ever taken where dropping the correction is invisible in distribution.
+The three configs below are the user's own, differing only in how they do (or do not)
+approach the full-sphere condition.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from test.e2e.capi_runner import run_scene_capi_buffered
+from test.e2e.runner import get_project_root
+
+CONFIGS_DIR = get_project_root() / "test" / "e2e" / "configs"
+
+# One seed, shared by every arm. The first two arms are meant to be the same simulation
+# down to the random stream, so they must be handed the same one to be compared at the
+# precision below.
+_SEED = 20260829
+
+# The exact/drifted pair differs only by float rounding inside the accumulator: measured
+# relative L1 over the XYZ image ran 4.6e-8 to 2.8e-5 across six seeds, against 0.63-0.65
+# in the defect state. This sits ~40x above the largest agreeing value and ~650x below the
+# smallest disagreeing one.
+_MAX_REL_L1 = 1e-3
+
+# The third arm resamples rather than reproduces (see the docstring on the second test), so
+# it is compared on aggregates, not pixels. Measured spread of the total-energy difference
+# across six seeds: 0 to 1.3%. In the defect state the fast-path arm carried 1.8x the energy.
+_MAX_REL_TOTAL = 0.08
+
+# Rear-hemisphere energy share on the general path, measured across six seeds: 0.0092 to
+# 0.0116 on either arm. On the fast path it was exactly 0.00000000 -- the sharpest single
+# fingerprint of the defect, and the reason the lower bound here is what matters.
+_REAR_FRACTION_RANGE = (0.004, 0.025)
+
+
+def _arm(config_name: str) -> np.ndarray:
+    """Luminance channel of one arm's accumulated XYZ image."""
+    result = run_scene_capi_buffered(str(CONFIGS_DIR / config_name), sim_seed=_SEED, timeout_sec=600)
+    assert result.has_valid_data, f"{config_name}: server returned no valid data"
+    luminance = result.flt_buf[..., 1].astype(np.float64)
+    assert luminance.sum() > 0.0, f"{config_name}: rendered nothing at all"
+    return luminance
+
+
+def _rel_l1(a: np.ndarray, b: np.ndarray) -> float:
+    return float(np.abs(a - b).sum() / a.sum())
+
+
+def _rear_fraction(luminance: np.ndarray) -> float:
+    """Share of the energy in the right half of the dual-fisheye image, i.e. the rear hemisphere."""
+    return float(luminance[:, luminance.shape[1] // 2 :].sum() / luminance.sum())
+
+
+@pytest.mark.slow
+def test_a_slider_sized_range_drift_does_not_change_the_halo():
+    """The user's reproduction: zenith range 360 against 359.9999694824219.
+
+    A difference of 3.05e-5 degrees in a range must not be able to select a different
+    physical answer. It could, and did.
+    """
+    exact = _arm("full_sphere_roll_flip_exact.json")
+    drifted = _arm("full_sphere_roll_flip_drifted.json")
+    difference = _rel_l1(exact, drifted)
+    assert difference < _MAX_REL_L1, f"a 3.05e-5 deg range difference moved the image: relative L1 {difference:.3g}"
+
+
+@pytest.mark.slow
+def test_both_arms_land_on_the_pole_crossing_answer_not_the_fast_path_one():
+    """Agreement alone is not the property under test; agreeing on the RIGHT answer is.
+
+    Two arms would also agree if a later change sent both down the fast path again -- and
+    that is the defect, not the fix. So this pins the answer itself, from two directions.
+
+    The first is a third arm that reaches the general path through a condition this task
+    did not touch: a zenith centered at 0.001 deg rather than 0, which fails
+    IsFullSphereUniform's center check. It is on the general path both before and after the
+    fix, so it says independently what the correct image is. It is compared on aggregates
+    rather than pixel by pixel, deliberately: shifting the center by 0.001 deg re-maps the
+    random stream onto slightly different angles, and against a filter as sparse as
+    raypath [3,5] that changes WHICH rays survive, not just where they land. Measured
+    per-pixel L1 against the main arm was bimodal across seeds (0 on three of six, 0.14 to
+    0.52 on the rest) while total energy stayed within 1.3% -- ordinary Monte-Carlo
+    resampling on a sparse image, not instability in the physics.
+
+    The second is the rear hemisphere, which must carry energy. Under the fast path it
+    carried exactly none (0.00000000 against ~0.010, with 1.8x the total energy), and no
+    run that applies the pole-crossing correction can reproduce that zero.
+    """
+    exact = _arm("full_sphere_roll_flip_exact.json")
+    mean_shifted = _arm("full_sphere_roll_flip_mean_shifted.json")
+
+    total_difference = abs(float(exact.sum() - mean_shifted.sum())) / float(exact.sum())
+    assert total_difference < _MAX_REL_TOTAL, (
+        "the full-360 arm carries a different amount of energy from an arm that reaches the general "
+        f"path by another route: relative difference {total_difference:.3g}"
+    )
+
+    low, high = _REAR_FRACTION_RANGE
+    for name, luminance in (("exact", exact), ("mean_shifted", mean_shifted)):
+        rear = _rear_fraction(luminance)
+        assert low < rear < high, (
+            f"{name}: rear-hemisphere energy share {rear:.8f} is outside [{low}, {high}] — "
+            "exactly 0 is the fast-path signature this test exists to catch"
+        )

--- a/test/regression-sentinel/test_full_sphere_roll_flip.py
+++ b/test/regression-sentinel/test_full_sphere_roll_flip.py
@@ -17,7 +17,14 @@ whether the user had touched the Range slider. The mechanism, in three steps:
 The fix makes ``IsFullSphereUniform`` require roll to be rotationally symmetric, so the
 fast path is only ever taken where dropping the correction is invisible in distribution.
 The three configs below are the user's own, differing only in how they do (or do not)
-approach the full-sphere condition.
+approach the full-sphere condition. They are kept as three full literal copies rather than
+derived from one another at load time, matching the existing convention of this directory
+(see the nine ``degenerate_pipeline_*.json`` siblings, which differ only in one ``std``).
+
+Both cases carry ``@pytest.mark.slow``, which in this repo means "needs the shared-library
+build" (``./scripts/build.sh -sj release``), not "takes a long time" -- these two together run
+in about 2.5 s. The marker is what keeps them out of CI's fast leg, where no shared library
+exists to load; see AGENTS.md under "E2E test split".
 """
 
 from __future__ import annotations

--- a/test/unit-correctness/core/test_math.cpp
+++ b/test/unit-correctness/core/test_math.cpp
@@ -401,6 +401,7 @@ TEST(IsAxisDeterministic, FullSphereUniform_ReturnsFalse) {
   AxisDistribution d{};
   d.azimuth_dist = { DistributionType::kUniform, 0.0f, 360.0f };
   d.latitude_dist = { DistributionType::kUniform, 90.0f, 360.0f };
+  d.roll_dist = { DistributionType::kUniform, 0.0f, 360.0f };
   ASSERT_TRUE(d.IsFullSphereUniform());
   EXPECT_FALSE(d.IsAxisDeterministic());
 }

--- a/test/unit-correctness/core/test_rng.cpp
+++ b/test/unit-correctness/core/test_rng.cpp
@@ -84,29 +84,61 @@ TEST_F(RngTest, IsFullSphereUniform) {
   using lumice::AxisDistribution;
   using lumice::DistributionType;
 
-  // Default full-sphere: azimuth={kUniform,0,360}, latitude={kUniform,90,360}
+  // Full-sphere: azimuth={kUniform,0,360}, latitude={kUniform,90,360}, roll={kUniform,*,360}.
+  // Roll is a required conjunct, not decoration: the fast path this predicate dispatches to skips
+  // the pole-crossing `roll += pi` the general path applies, so it is only equivalent when roll's
+  // distribution is unchanged by that shift.
   AxisDistribution full_sphere;
   full_sphere.azimuth_dist = { DistributionType::kUniform, 0.0f, 360.0f };
   full_sphere.latitude_dist = { DistributionType::kUniform, 90.0f, 360.0f };
+  full_sphere.roll_dist = { DistributionType::kUniform, 0.0f, 360.0f };
   EXPECT_TRUE(full_sphere.IsFullSphereUniform());
 
   // Custom azimuth range -> false
   AxisDistribution custom_az;
   custom_az.azimuth_dist = { DistributionType::kUniform, 45.0f, 90.0f };
   custom_az.latitude_dist = { DistributionType::kUniform, 90.0f, 360.0f };
+  custom_az.roll_dist = { DistributionType::kUniform, 0.0f, 360.0f };
   EXPECT_FALSE(custom_az.IsFullSphereUniform());
 
   // Custom latitude range -> false
   AxisDistribution custom_lat;
   custom_lat.azimuth_dist = { DistributionType::kUniform, 0.0f, 360.0f };
   custom_lat.latitude_dist = { DistributionType::kUniform, 60.0f, 60.0f };
+  custom_lat.roll_dist = { DistributionType::kUniform, 0.0f, 360.0f };
   EXPECT_FALSE(custom_lat.IsFullSphereUniform());
 
   // Gaussian type -> false
   AxisDistribution gauss;
   gauss.azimuth_dist = { DistributionType::kGaussian, 0.0f, 10.0f };
   gauss.latitude_dist = { DistributionType::kUniform, 90.0f, 360.0f };
+  gauss.roll_dist = { DistributionType::kUniform, 0.0f, 360.0f };
   EXPECT_FALSE(gauss.IsFullSphereUniform());
+
+  // Azimuth and latitude full-sphere, but roll fixed -> false. This is the user-reported defect
+  // configuration: the fast path would drop the +180 deg roll correction on half the rays, which is
+  // a different physical distribution, not the same one sampled faster.
+  AxisDistribution fixed_roll;
+  fixed_roll.azimuth_dist = { DistributionType::kUniform, 0.0f, 360.0f };
+  fixed_roll.latitude_dist = { DistributionType::kUniform, 90.0f, 360.0f };
+  EXPECT_FALSE(fixed_roll.IsFullSphereUniform());  // roll_dist stays the kNoRandom default
+
+  // Roll uniform but only over a half turn -> false: a 180 deg-wide uniform maps onto its
+  // complement under a +180 deg shift, so it is not shift invariant.
+  AxisDistribution half_roll;
+  half_roll.azimuth_dist = { DistributionType::kUniform, 0.0f, 360.0f };
+  half_roll.latitude_dist = { DistributionType::kUniform, 90.0f, 360.0f };
+  half_roll.roll_dist = { DistributionType::kUniform, 0.0f, 180.0f };
+  EXPECT_FALSE(half_roll.IsFullSphereUniform());
+
+  // Roll centered anywhere is fine as long as it spans a full turn -- shift invariance of a
+  // full-period uniform does not depend on where it is centered (same reason
+  // IsAzRotationallySymmetric ignores the azimuth center).
+  AxisDistribution offset_roll;
+  offset_roll.azimuth_dist = { DistributionType::kUniform, 0.0f, 360.0f };
+  offset_roll.latitude_dist = { DistributionType::kUniform, 90.0f, 360.0f };
+  offset_roll.roll_dist = { DistributionType::kUniform, 137.0f, 360.0f };
+  EXPECT_TRUE(offset_roll.IsFullSphereUniform());
 
   // Default constructor (kNoRandom) -> false
   AxisDistribution default_ctor;

--- a/test/unit-correctness/core/test_simulator.cpp
+++ b/test/unit-correctness/core/test_simulator.cpp
@@ -19,6 +19,7 @@
 #include "core/geo3d.hpp"
 #include "core/math.hpp"
 #include "core/raypath.hpp"
+#include "core/shared/lat_path_selection.hpp"
 #include "core/simulator.hpp"
 #include "core/trace_ops.hpp"
 #include "util/queue.hpp"
@@ -550,10 +551,19 @@ std::vector<std::array<float, 9>> SampleOrientations(const AxisDistribution& axi
 // latitude branch turns the first case red while all five truth-table cases in
 // test_math.cpp stay green, which is the gap this test exists to fill. It does
 // NOT catch InitRay_rot's full_sphere branch being decoupled from
-// IsFullSphereUniform: the two sampler paths are statistically equivalent since
-// the unified area-measure LatLut, so nothing observable changes. Do not "fix"
-// that by weakening these assertions into a distributional check — there is no
-// difference to detect.
+// IsFullSphereUniform.
+//
+// This comment used to justify that last sentence by asserting the two sampler
+// paths were "statistically equivalent since the unified area-measure LatLut, so
+// nothing observable changes", and told the reader not to weaken these
+// assertions into a distributional check because "there is no difference to
+// detect". That was wrong. The difference is real and lives in roll: the
+// full_sphere fast path never applies the pole-crossing `roll += pi` that the
+// LatLut path applies on a flip. The measurement the old claim rested on — the
+// fraction of samples with |world z| < 0.5 — reads the sampled axis direction
+// only, so it is structurally blind to roll and would have reported agreement no
+// matter how far apart the two paths were (a16: the yardstick has to reach the
+// quantity under test). RollFlipDivergence.* below measures roll itself.
 TEST(AxisDeterminismMatchesRuntimeOrientation, DeterministicAxisYieldsOneFixedRotation) {
   AxisDistribution axis;  // default ctor: all three kNoRandom
   ASSERT_TRUE(axis.IsAxisDeterministic());
@@ -568,11 +578,17 @@ TEST(AxisDeterminismMatchesRuntimeOrientation, DeterministicAxisYieldsOneFixedRo
 
 TEST(AxisDeterminismMatchesRuntimeOrientation, FullSphereAxisIsStochasticAndVaries) {
   // roll stays kNoRandom on purpose: this is the combination most likely to be
-  // misjudged by a predicate that stops short of all three fields.
+  // misjudged by a predicate that stops short of all three fields. It used to be
+  // misjudged — this assertion was ASSERT_TRUE, which is exactly how the defect
+  // this test now guards was pinned as expected behavior. An axis whose roll is
+  // fixed cannot take the fast path: that path drops the pole-crossing
+  // `roll += pi`, so on the ~50% of rays that cross a pole it produces a crystal
+  // rotated a further 180 deg about its own c axis relative to what the config
+  // asks for. See RollFlipDivergence.* below for the measurement.
   AxisDistribution axis;
   axis.azimuth_dist = { DistributionType::kUniform, 0.0f, 360.0f };
   axis.latitude_dist = { DistributionType::kUniform, 90.0f, 360.0f };
-  ASSERT_TRUE(axis.IsFullSphereUniform());
+  ASSERT_FALSE(axis.IsFullSphereUniform());
   EXPECT_FALSE(axis.IsAxisDeterministic());
 
   constexpr size_t kN = 16;
@@ -585,6 +601,134 @@ TEST(AxisDeterminismMatchesRuntimeOrientation, FullSphereAxisIsStochasticAndVari
     }
   }
   EXPECT_EQ(distinct_from_first, kN - 1) << "predicate says stochastic but InitRay_rot repeated a rotation";
+}
+
+// --- RollFlipDivergence: the yardstick that can see roll ---
+//
+// Why this suite exists. IsFullSphereUniform dispatches InitRay_rot to a fast
+// path that samples the axis direction directly and never applies the
+// pole-crossing correction detail::NormalizeLatitude reports; the general
+// kLutInverseCdf path adds pi to BOTH azimuth and roll whenever it flips. The
+// two therefore agree on the axis DIRECTION under any roll, and disagree on the
+// crystal's rotation about that axis unless roll's own distribution is
+// unchanged by a +180 deg shift. A criterion built on the sampled direction
+// (the fraction of |world z| < 0.5 that the comments here used to cite) cannot
+// separate them at all. These cases read roll itself.
+//
+// Recovering roll. BuildCrystalRotation composes
+//   M = Rz(azimuth - pi) * Ry(latitude - pi/2) * Rz(roll),
+// a ZYZ Euler triple whose third row is
+//   (-sin(b)*cos(roll), sin(b)*sin(roll), cos(b)),  b = latitude - pi/2.
+// So atan2(M[2][1], -M[2][0]) recovers roll up to a constant pi offset --
+// b ranges over [-pi, 0], where sin(b) <= 0, so the sign never varies mid-run.
+// Every assertion below is about how the recovered values CLUSTER, never about
+// an absolute angle, so that constant offset is immaterial.
+//
+// Near the poles sin(b) -> 0 and the recovery is ill-conditioned (roll and
+// azimuth become the same rotation there). Samples inside that band are
+// dropped; the retained fraction is asserted so a change that pushed most
+// samples to the poles could not quietly empty the measurement.
+constexpr float kPoleGuardSinB = 0.05f;
+
+// Recovered roll angles for `n` production-sampled orientations, one entry per
+// ray outside the pole guard band.
+std::vector<float> SampleRecoveredRolls(const AxisDistribution& axis, size_t n, uint32_t seed) {
+  auto mats = SampleOrientations(axis, n, seed);
+  std::vector<float> out;
+  out.reserve(mats.size());
+  for (const auto& m : mats) {
+    const float m20 = m[6];
+    const float m21 = m[7];
+    if (std::hypot(m20, m21) <= kPoleGuardSinB) {
+      continue;
+    }
+    out.push_back(std::atan2(m21, -m20));
+  }
+  return out;
+}
+
+// The defect the user reported, at the smallest scale that still shows it: an
+// axis whose azimuth and latitude span the full sphere but whose roll is fixed.
+// Before IsFullSphereUniform grew its roll conjunct this axis took the fast
+// path, and both assertions below failed -- the path was kFullSphere, and every
+// ray came back with the same roll instead of the half-and-half split the config
+// actually describes. Latitude is uniform over 360 deg, i.e. it spans the far
+// side of the sphere too, so detail::NormalizeLatitude reflects roughly half the
+// draws back and the general path adds pi to their roll.
+TEST(RollFlipDivergence, FixedRollAxisTakesLutPathAndSplitsRollAcrossHalfTurn) {
+  AxisDistribution axis;
+  axis.azimuth_dist = { DistributionType::kUniform, 0.0f, 360.0f };
+  axis.latitude_dist = { DistributionType::kUniform, 90.0f, 360.0f };
+  // roll_dist stays the kNoRandom default: one fixed roll for every ray.
+
+  ASSERT_EQ(lat_path::SelectLatPath(axis).kind, lat_path::LatPathKind::kLutInverseCdf)
+      << "an axis with a fixed roll must not take the fast path: that path drops the pole-crossing roll += pi";
+
+  constexpr size_t kN = 2000;
+  auto rolls = SampleRecoveredRolls(axis, kN, /*seed=*/20260829);
+  ASSERT_GT(rolls.size(), kN * 95 / 100) << "pole guard dropped an implausible share of the samples";
+
+  // rng.Get on a kNoRandom roll returns the same constant every time, so the
+  // only thing that can move roll is the flip: the recovered angles must sit on
+  // exactly two points half a turn apart, not spread between them.
+  size_t upper = 0;
+  size_t lower = 0;
+  size_t off_cluster = 0;
+  float worst_c = 1.0f;
+  for (float roll : rolls) {
+    const float c = std::cos(roll);
+    if (std::abs(c) <= 0.99f) {
+      off_cluster++;
+      worst_c = std::min(worst_c, std::abs(c));
+    }
+    (c > 0.0f ? upper : lower)++;
+  }
+  EXPECT_EQ(off_cluster, 0u) << off_cluster << " recovered rolls sit between the two discrete values (worst |cos| "
+                             << worst_c << ")";
+  const double upper_frac = static_cast<double>(upper) / static_cast<double>(rolls.size());
+  // A latitude uniform over the full 360 deg crosses a pole on half its draws,
+  // so the split is 50/50. The window is ~4.5 sigma wide at this sample count.
+  EXPECT_GT(upper_frac, 0.45) << "roll flip fires too rarely (" << upper << " of " << rolls.size() << ")";
+  EXPECT_LT(upper_frac, 0.55) << "roll flip fires too often (" << upper << " of " << rolls.size() << ")";
+  EXPECT_EQ(upper + lower, rolls.size());
+}
+
+// The positive half of the same proposition, and the reason the fast path is
+// kept rather than deleted: when roll is uniform over a full turn, adding pi to
+// half the rays is invisible in distribution, so dropping the correction costs
+// nothing and IsFullSphereUniform still routes here.
+TEST(RollFlipDivergence, UniformRollAxisKeepsFastPathAndRollStaysUniform) {
+  AxisDistribution axis;
+  axis.azimuth_dist = { DistributionType::kUniform, 0.0f, 360.0f };
+  axis.latitude_dist = { DistributionType::kUniform, 90.0f, 360.0f };
+  axis.roll_dist = { DistributionType::kUniform, 0.0f, 360.0f };
+
+  ASSERT_TRUE(axis.IsFullSphereUniform());
+  ASSERT_EQ(lat_path::SelectLatPath(axis).kind, lat_path::LatPathKind::kFullSphere);
+
+  constexpr size_t kN = 4000;
+  auto rolls = SampleRecoveredRolls(axis, kN, /*seed=*/20260829);
+  ASSERT_GT(rolls.size(), kN * 95 / 100) << "pole guard dropped an implausible share of the samples";
+
+  constexpr size_t kBins = 8;
+  std::array<size_t, kBins> hist{};
+  for (float roll : rolls) {
+    float t = roll;
+    while (t < 0.0f) {
+      t += 2.0f * math::kPi;
+    }
+    auto bin = static_cast<size_t>(t / (2.0f * math::kPi) * kBins);
+    hist[std::min(bin, kBins - 1)]++;
+  }
+  // Uniform over 8 bins is 0.125 each; sigma is ~0.005 at this sample count, so
+  // the window below is wide enough to be stable and narrow enough that a roll
+  // pinned to one or two values (the failure mode this guards) blows straight
+  // through it.
+  for (size_t i = 0; i < kBins; i++) {
+    const double frac = static_cast<double>(hist[i]) / static_cast<double>(rolls.size());
+    EXPECT_GT(frac, 0.10) << "roll bin " << i << " underfilled: " << hist[i];
+    EXPECT_LT(frac, 0.15) << "roll bin " << i << " overfilled: " << hist[i];
+  }
 }
 
 TEST(DeterministicOrientationCountTest, CountsAxisDeterministicSlotsAcrossLayers) {

--- a/test/unit-correctness/gui/test_gui_widget_rules.cpp
+++ b/test/unit-correctness/gui/test_gui_widget_rules.cpp
@@ -477,6 +477,43 @@ TEST(SliderMapping, EachLawIsInvertibleAndNeverGoesBackwards) {
 // assert, and five cases asserting std::clamp were exactly that -- so the coverage that matters
 // lives where the call site is driven, in gui_test's pyramid_h_* modal cases.
 
+using lumice::gui::slider_mapping::LogLinearNormToValueSnapped;
+using lumice::gui::slider_mapping::LogNormToValueSnapped;
+using lumice::gui::slider_mapping::SqrtNormToValueSnapped;
+
+// At a slider stop the value written back must be the bound itself, bit for bit -- not the bound
+// recovered through sqrt or exp/log. EXPECT_EQ, not EXPECT_NEAR, is the point of this case: the
+// residue these snaps remove is 3.05e-5 on a 360 deg range, which every tolerance above would
+// happily accept, and which core's FloatEqual (threshold 1e-5) reads as a different value. That is
+// how an azimuth range dragged to its stop stopped counting as a full turn, and with it a crystal
+// axis stopped counting as full-sphere uniform. The interior of each law is unchanged and is pinned
+// by the EXPECT_NEAR cases above; these three only bind the ends.
+TEST(SliderMapping, EndpointSnappingWritesBackTheBoundExactly) {
+  // The uniform-distribution Range slider: sqrt scale over [0, 360].
+  const float sqrt_max_360 = std::sqrt(360.0f);
+  EXPECT_NE(sqrt_max_360 * sqrt_max_360, 360.0f) << "premise of this case: the plain round trip is not exact here";
+  EXPECT_EQ(SqrtNormToValueSnapped(sqrt_max_360, sqrt_max_360, 360.0f), 360.0f);
+  EXPECT_EQ(SqrtNormToValueSnapped(0.0f, sqrt_max_360, 360.0f), 0.0f);
+  // Past the stop (ImGui clamps, but the guard must not depend on that) and inside it.
+  EXPECT_EQ(SqrtNormToValueSnapped(sqrt_max_360 * 1.5f, sqrt_max_360, 360.0f), 360.0f);
+  EXPECT_EQ(SqrtNormToValueSnapped(-1.0f, sqrt_max_360, 360.0f), 0.0f);
+  EXPECT_FLOAT_EQ(SqrtNormToValueSnapped(3.0f, sqrt_max_360, 360.0f), 9.0f);
+
+  // Prism height: log scale over [0.01, 100].
+  EXPECT_EQ(LogNormToValueSnapped(1.0f, 0.01f, 100.0f), 100.0f);
+  EXPECT_EQ(LogNormToValueSnapped(0.0f, 0.01f, 100.0f), 0.01f);
+  EXPECT_EQ(LogNormToValueSnapped(2.0f, 0.01f, 100.0f), 100.0f);
+  EXPECT_EQ(LogNormToValueSnapped(-0.5f, 0.01f, 100.0f), 0.01f);
+  EXPECT_FLOAT_EQ(LogNormToValueSnapped(0.5f, 0.01f, 100.0f), LogNormToValue(0.5f, 0.01f, 100.0f));
+
+  // Pyramid prism height: log-linear hybrid over [0, 100].
+  EXPECT_EQ(LogLinearNormToValueSnapped(1.0f, 100.0f), 100.0f);
+  EXPECT_EQ(LogLinearNormToValueSnapped(0.0f, 100.0f), 0.0f);
+  EXPECT_EQ(LogLinearNormToValueSnapped(1.25f, 100.0f), 100.0f);
+  EXPECT_EQ(LogLinearNormToValueSnapped(-0.25f, 100.0f), 0.0f);
+  EXPECT_FLOAT_EQ(LogLinearNormToValueSnapped(0.5f, 100.0f), LogLinearNormToValue(0.5f, 100.0f));
+}
+
 using lumice::gui::AspectFitResult;
 using lumice::gui::ClampWindowSizeToWorkarea;
 using lumice::gui::kAspectClampTolerance;

--- a/test/unit-correctness/server/test_c_api.cpp
+++ b/test/unit-correctness/server/test_c_api.cpp
@@ -1709,6 +1709,41 @@ TEST(ShapeScalarApplicableApi, PyramidOwnsThreeHeightsAndTheSixFaces) {
   EXPECT_EQ(LUMICE_IsShapeScalarApplicable(LUMICE_CRYSTAL_PYRAMID, LUMICE_SHAPE_SCALAR_HEIGHT), 0);
 }
 
+// ============================================================
+// LUMICE_IsDApplicable
+// ============================================================
+
+// The rule: azimuth uniform over a full turn AND the roll anchor on a multiple of 30 deg.
+TEST(IsDApplicableApi, AnswersTheTwoConditionsAndNothingElse) {
+  EXPECT_NE(LUMICE_IsDApplicable(LUMICE_DIST_UNIFORM, 360.0f, 0.0f), 0);
+  EXPECT_NE(LUMICE_IsDApplicable(LUMICE_DIST_UNIFORM, 360.0f, 30.0f), 0);
+  EXPECT_NE(LUMICE_IsDApplicable(LUMICE_DIST_UNIFORM, 360.0f, -60.0f), 0);
+  EXPECT_NE(LUMICE_IsDApplicable(LUMICE_DIST_UNIFORM, 360.0f, 180.0f), 0);
+
+  EXPECT_EQ(LUMICE_IsDApplicable(LUMICE_DIST_UNIFORM, 360.0f, 15.0f), 0);   // roll off the grid
+  EXPECT_EQ(LUMICE_IsDApplicable(LUMICE_DIST_UNIFORM, 180.0f, 0.0f), 0);    // not a full turn
+  EXPECT_EQ(LUMICE_IsDApplicable(LUMICE_DIST_GAUSS, 360.0f, 0.0f), 0);      // wrong type
+  EXPECT_EQ(LUMICE_IsDApplicable(LUMICE_DIST_NO_RANDOM, 360.0f, 0.0f), 0);  // wrong type
+}
+
+// The tolerance is core's, not a second one chosen here. 3.05e-5 is the residue a sqrt-mapped
+// Range slider used to leave behind at its stop, and it is the value on which the GUI's former
+// private copy (1e-3) and core (1e-5) gave opposite answers -- the checkbox saying D was live
+// while the engine had already dropped it. This case is the pin that they now cannot disagree:
+// whatever core answers here is what the GUI shows, because the GUI asks this function.
+TEST(IsDApplicableApi, TheToleranceIsCoresOwn) {
+  EXPECT_EQ(LUMICE_IsDApplicable(LUMICE_DIST_UNIFORM, 360.0f - 3.05e-5f, 0.0f), 0);
+  EXPECT_EQ(LUMICE_IsDApplicable(LUMICE_DIST_UNIFORM, 360.0f, 3.05e-5f), 0)
+      << "a roll anchor off the 30 deg grid by more than core's epsilon must not pass either";
+  // Just inside it, so the case above is testing the threshold and not merely "any nonzero delta".
+  EXPECT_NE(LUMICE_IsDApplicable(LUMICE_DIST_UNIFORM, 360.0f - 1e-6f, 0.0f), 0);
+}
+
+TEST(IsDApplicableApi, AnUnrecognisedDistributionTypeAnswersFalse) {
+  EXPECT_EQ(LUMICE_IsDApplicable(-1, 360.0f, 0.0f), 0);
+  EXPECT_EQ(LUMICE_IsDApplicable(999, 360.0f, 0.0f), 0);
+}
+
 TEST(ShapeScalarApplicableApi, OutOfRangeSlotsAnswerFalseRatherThanTrapping) {
   for (auto kind : { LUMICE_CRYSTAL_PRISM, LUMICE_CRYSTAL_PYRAMID }) {
     EXPECT_EQ(LUMICE_IsShapeScalarApplicable(kind, -1), 0);


### PR DESCRIPTION
## 背景

内测用户报告：同一份 config（`~/…/cli-uniform.json` 形态：`zenith = uniform(mean 0, range 360)`、`roll = gauss(0, 0)` 即固定、filter `raypath [3,5]` symmetry `D`）在 GUI 里**直接加载后跑仿真**，与**先拖一下 zenith 的 Range 滑条再拖回「360」后跑仿真**，渲染出的晕不一样。

## 根因（三段因果链）

1. **GUI 滑条把 360 存成了 359.999969**。uniform 的 Range 滑条走 `SliderScale::kSqrt`，在 √ 空间操作、回写时平方：`sqrtf(360.0f)² = 359.999969`，差 3.05e-5；配套 `InputFloat` 用 `%.1f` 显示成 `360.0`，用户看不见。放大因素：显示为「360.0」的区间是 [359.95, 360.0]，而走快路径要求误差 < 1e-5 ⇒ 滑条上几乎任何「看起来是 360」的位置都会脱离快路径，所以能稳定复现。

2. **谓词翻转**。`IsFullSphereUniform()` 用 `FloatEqual(..., 360.0f)`（`kFloatEps = 1e-5`）⇒ `lat_path::SelectLatPath` 从 `kFullSphere` 改判 `kLutInverseCdf`。

3. **这两条路径本就不等价**。`kFullSphere` 永不置 `flip`，丢掉了 pole-crossing 的 `roll += π`；LUT 路按 `flip_prob` 抽（zenith U(−180,180) 时约 50%）。roll 非旋转对称时（本例固定 0）一半晶体绕自身 c 轴多转 180° ⇒ 正六棱柱面号整体位移 3（3↔6 / 4↔7 / 5↔8）⇒ 选 raypath `[3,5]` 的 filter 选中了完全不同的物理子集。

**是快路径错了**：config 写的是 zenith ∈ U(−180°,180°)，按本仓自己的语义（`detail::NormalizeLatitude` + flip），负 zenith 就是「同一根轴、azimuth+180、roll+180」。LUT 路忠实实现了这一点；快路径静默把请求重新解释成「zenith ∈ [0,180]、roll 照写」，那是另一个分布。

## 改动

- **core（根本）**：`IsFullSphereUniform()` 增加「roll 旋转对称」这一必要条件（新增 `AxisDistribution::IsRollRotationallySymmetric()`），使快路径退化为**可证等价**的优化而非语义分叉。三后端经 `SelectLatPath` 单源自动覆盖，另有 Metal 后端实测补证。
- **GUI（防漂移 + 体验）**：`slider_mapping.hpp` 新增 `*Snapped` 三个包装，sqrt / log / loglinear 三条非线性分支在端点回写 bit-exact 的 `min_val` / `max_val`。线性分支经查 ImGui `ScaleValueFromRatioT` 已自行特判两端，无需吸附（结论写在代码旁）。
- **容差单一 owner**：新增 `LUMICE_IsDApplicable` C API + `detail::IsDApplicableParams`，GUI 委托 core 判定 D 对称适用性。此前 GUI 用 1e-3、core 用 1e-5，在 3.05e-5 这个漂移值上结论**相反**——界面显示 D 生效而引擎已丢弃。
- **订正三处错误断言**：`math.hpp` 两处 doc comment 与 `test_simulator.cpp` 的注释，此前明文写着两条路径「statistically equivalent … Do not add a test claiming otherwise」。其依据的代理量（`|world z| < 0.5` 的占比）只读采样到的轴方向，对 roll 结构性盲。订正文案说明了错在哪。

## 验证

- **红态自证**：`RollFlipDivergence.*`（ZYZ 分解反解 roll 作判据）与 `test_full_sphere_roll_flip.py` 均为修复前红、修复后绿的实跑。
- **参数连续性实测**（5M rays，32×32 块均值结构距离，噪声地板 0.031）：修复后 std = 359.999969 / 359.5 / 358 / 355 / 350 相对 360.0 的距离全部落在噪声地板内，340 才刚探出噪声，320 明显偏离——单调平缓。修复前 `360.0 → 359.999969` 是 **0.3584**（噪声地板的 11 倍，输入只差 3e-5 度），而 `360.0 → 358` 是 0.3583，两者几乎相同 ⇒ 旧行为是**阶跃**而非梯度。
- **参考图影响面**：机械清点 148 个带 `axis` 的 crystal 条目，命中「全球面 zenith + 非旋转对称 roll」的只有本 PR 新增的那份复现 config；GUI 侧 `kAxisPresets` 唯一带全球面 zenith 的 `Random` 预设配的是 uniform-360 roll。**零张既有参考图需要重拍。**
- `./scripts/test.sh pr` 在 rebase 到 main 顶端后重跑：**RESULT: PASS**（ctest / fast-e2e / gui-correctness / gui-real-timing / slow-e2e 全绿）。

## 行为变化（发版说明用）

渲染结果发生变化的是**恰好精确等于 360 的那一个点**：它从此与周围所有邻居一致。此前用滑条拖出来的「另一种」结果才是物理忠实的那个，直接加载 JSON 拿到的精确 360 反而是错的。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7D5vsDzUZAJj81wqBqw79