### PR TITLE
refactor(gui): 颜色收口——色槽补齐 58/58 + 调用点裸字面量逐处 disposition

### DIFF
--- a/doc/gui-visual-language.md
+++ b/doc/gui-visual-language.md
@@ -88,7 +88,9 @@ ScrollbarRounding 3  WindowRounding 4  PopupRounding 4
 
 实测收益：同一面板在字号更大的前提下，可见内容反而**多于**现状（现状 Overlay 组被截断，量化后连末尾的半径行都可见）。
 
-**4.3 调色板** —— 见 §3 定案列。核心两条规则：强调色只在**交互进行中**出现；分组标题是**染色**不是实心条。
+**4.3 调色板** —— 见 §3 定案列。核心两条规则：**强调色不做大面积常驻填充，且滑条静止态不上色**；分组标题是**染色**不是实心条。
+
+⚠️ 这条规则曾被写成"强调色只在**交互进行中**出现"，那个措辞是错的，且会主动否掉正确答案。`src/gui/theme.cpp` 的 `ApplyPalette` 自己就把 accent 给了**静止的**勾选态（`c[ImGuiCol_CheckMark] = p.accent`），而紧随其后那段注释解释的其实是**滑条**——"Grab neutral at rest, accent only while dragging"，理由是滑条是面板里重复次数最多的控件，它的静止色调定全局基调。所以规则真正管的是**面积**与**滑条**，不是"任何交互态都不许常驻上色"：勾选态本身就是内容（"这一项被选中"），涂色是内容的一部分，不是装饰性强调。同理，卡片的关联边框（`src/gui/panels.cpp` 的 active / co-shared 两态）、状态栏的 `Simulating...`、LINK 徽标都用 accent 而不违反这条——它们都是细线或短文本，且都在陈述"此刻是这个"。
 
 **4.4 重复记录 → 表格** —— 形态错配的判据是：**若干条目共享同一记录结构**（同样的字段集），却用竖直堆叠 + 每条重复标签来表达。Overlay 的四个辅助线正是如此（颜色 / 线 / 文字标签 / 透明度，外加仅标记点具备的像素半径）。
 
@@ -132,8 +134,32 @@ ScrollbarRounding 3  WindowRounding 4  PopupRounding 4
 - ~~**正文字体未定案**~~ —— **已定案并落地**：Roboto Medium 15px。分发按当时判断比照 FontAwesome，走构建期嵌入（`scripts/embed_binary.py` 生成 `roboto_medium_embed.cpp`，声明头 `src/gui/roboto_medium_embed.h`），运行期不读文件；字体与 style 的初始化收敛到单一 owner `src/gui/theme.{hpp,cpp}`（此前 `src/gui/main.cpp` 与 `test/gui/test_gui_main.cpp` 各写一遍，截图与真 app 只是碰巧一致——见 §1）。
 - ~~**颜色存在第二个 owner**~~ —— **已收口**：good / warning / destructive 三档语义色现由 `src/gui/semantic_colors.hpp` 单一定义，21 处调用点（绿色 Run 按钮、锈色 Resolution 输入框、Stop 按钮、日志级别色、filter 编辑器的三态校验底色等）改为引用具名函数。每档提供两种消费形态——`*TextColor()` 亮色用于文本/图标/边框，`*FillColor(alpha)` 哑光用于 FrameBg/CellBg 背景染色，alpha 由调用点给（各调用点的强调程度本就有意不同）。按钮三态只在存在消费者的档位提供：good 在同一头文件，destructive 仍是 `src/gui/destructive_style.hpp` 的 `PushDestructiveStyle`/`PopDestructiveStyle`（12 处配对调用的既有实现，一档一形态只留一个 owner），warning 无按钮消费者故不预先实现。
   - 每个 canonical 取值都锚定收编前**已存在**的字面量（复用次数最多的那个），不是新拍的折中色——于是 5 处近重复琥珀、3 处近重复红折叠后只有几个百分点的通道位移，而参考图覆盖到的场景**逐像素不变**。
-  - 三类颜色**不**在此收编，判据是"颜色是否表达产品对内容的判断"：**强调色**（hover/active/选中高亮）表达交互状态，与语义色取值必须分开，否则"正在被操作"会读成"有风险"；**数据色**（用户在 Overlay 面板配的线色、由组号派生的 sync-group 色板）由用户或索引决定；**结构色**（透明 hover 触发区、占位边框、标签底衬、按填充色 luma 派生的对比文字）不携带判断。
-  - 状态栏的 `Simulating...` / `Stopping...` / `Done` 也不并入：它们是进度/信息指示。把"任何非稳态"塞进 warning 会把该档从"内容需要你处理"稀释掉，反而淹没 Resolution 这种真正会触发重跑的提示。
+  - 三类颜色**不**在此收编，判据是"颜色是否表达产品对内容的判断"：**强调色**（hover/active/选中高亮）表达交互状态，与语义色取值必须分开，否则"正在被操作"会读成"有风险"；**数据色**（用户在 Overlay 面板配的线色、由组号派生的 sync-group 色板）由用户或索引决定；**画布内容色**（画在预览图 / 3D 渲染之上的标注、以及渲染自身的底色）不携带判断。
+  - 状态栏的 `Simulating...` / `Stopping...` / `Done` 也不并入：它们是进度/信息指示。把"任何非稳态"塞进 warning 会把该档从"内容需要你处理"稀释掉，反而淹没 Resolution 这种真正会触发重跑的提示。它们的归宿是下面那条"中性刻度"。
+- **调用点颜色是否跟着色盘走：判据与豁免清单** —— 上一条解决的是"同一语义的颜色有几个 owner"；这一条解决的是另一个正交问题：一个调用点自己挑的颜色，**换一套色盘时跟不跟着变**。跟不着变的即为泄漏，必须改为读色槽（`ImGui::GetStyleColorVec4` / `ImGui::GetColorU32`）或读 `lumice::gui::AccentColor()`。
+
+  判据本身可机械检验，不必靠人工点检：`src/gui/theme_test_hooks.hpp` 暴露一个 test-only 的对照色盘（`ApplyContrastPaletteForTest`，取值与生产色盘每个字段的欧氏距离 ≥ 0.54），`gui_test --theme-palette contrast` 用它重跑 `theme_scan` 类别的场景，`scripts/scan_theme_leaks.py` 逐像素比较两套色盘下的同一批截图并高亮**两次色值相同**的像素。它产出的是**候选**不是判决——豁免类颜色本来就应当不变——但"哪些像素没跟着色盘动"这个问题从此有机械答案。
+
+  **豁免只有三类，其余一律视为泄漏**（面板铬件——缩略图边框、日志正文档位、按钮/复选框染色——一律不豁免）：
+
+  | 可豁免 | 判据 | 实例 |
+  |---|---|---|
+  | **数据色** | 取值由**用户或索引**决定，不由主题决定 | `panels.cpp` 的 `kSyncGroupPalette` 六色板；Overlay 面板里用户配的辅助线色 |
+  | **画布内容色** | 画在**预览图 / 3D 渲染**之上或之下，对比对象是**图像**而不是面板 | `overlay_labels.cpp` 的标签黑底、`face_number_overlay.cpp` 的面号描边；以及 `crystal_renderer.cpp` 渲染晶体缩略图/预览时自己的 `glClearColor` 底色 |
+  | **内容语义色** | 携带"这个值健康 / 需要注意 / 危险"的产品判断，与皮肤无关（正如 OS 深浅色切换通常不会改变错误红的色相） | `semantic_colors.hpp` 的 good / warning / destructive 三档，含绿色 Run 按钮与 `destructive_style.hpp` 的按钮三态 |
+
+  ⚠️ **"结构色"这个旧类别已废止**。它曾被用来豁免占位边框、标签底衬一类颜色，在本判据下站不住：缩略图的占位块与边框正是靠它免检，而它们换肤时会原样留在原地。今天它们读 `ImGuiCol_FrameBg` / `ImGuiCol_Border`。仍然合法的只是它当年混进去的另外两样：**全透明**的 hover 触发区（`ImVec4(0,0,0,0)`，alpha=0 画不出像素，谈不上跟不跟色盘）与**由填充色派生**的对比文字（`panels.cpp` 里按 sync-group 填充色的 luma 在黑/白之间取值——它的输入是数据色，派生规则本身不是颜色选择）。
+
+  **不带判断的进度/状态文字取"中性刻度"**：主题给的三档是 `ImGuiCol_Text`（静息）/ `ImGuiCol_TextDisabled`（暗淡）/ accent（此刻正在发生）。状态栏据此为 `Simulating...` = accent、`Stopping...` = `TextDisabled`（同一帧里 Stop 按钮本就是灰掉且禁用的）、`Done` = `Text`；日志面板的 trace/debug = `TextDisabled`、默认档 = `Text`。带判断的两态仍走语义色（`Ready` = good，`Modified` = warning）。
+
+  **顶栏那两处自造蓝一并归 accent**，但它们的语义**并不同类**，这一点必须记下来，否则这次合并会变成一个没人记得的隐性决定：
+
+  - Composite 勾选框的勾选态（`app_panels.cpp`，条件是 `composite_now`）是**同一个控件的不同状态**。主题本来就把 accent 花在静止的勾选态上（`theme.cpp` 的 `c[ImGuiCol_CheckMark] = p.accent`），所以这处属既有做法。
+  - 顶栏 Colors 按钮的三态（条件是 `ShouldTintColorsButton`，即文档里配了色类）是**内容状态投影到控件上的徽章**——按钮在两种情况下行为完全相同，染色只是在窗口打开**之前**就告诉你染色配没配。
+
+  两者仍都进 accent，理由是**举证责任**而不是语义相同：为徽章单开一档 `Palette` 角色，今天只有**一个**调用点撑着。⭐ **触发条件登记：出现第二个"内容非空 → 给控件染色"的徽章式用法时**，才是把它从 accent 里拆出来、单立一档 `Palette` 角色的时机。
+
+  ⭐ **另一条边界，同样先登记不动手**：`crystal_renderer.cpp` 的画布底色被豁免为画布内容色，但它是**整块可见面积**。若将来真的出第二套皮肤（尤其是浅色），这块底色与画在它上面的线框色**必须作为同一个画布问题一起重新决定**，不能只改其中一个——单独改任何一侧都会破坏它们之间的对比关系。
 - **一值两控件仍是主流行式** —— 表格单元格内已验证单控件（`DragFloat`）可行，但推广属控件形态层，见 §6。
 - **左面板空区** —— 见 §2 第 6 条。
 

--- a/scripts/scan_theme_leaks.py
+++ b/scripts/scan_theme_leaks.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Locate GUI colours that do not follow the palette.
+
+The question this answers is the one the theme cannot answer about itself: given a second,
+deliberately distant palette, WHICH PIXELS COME OUT THE SAME? A pixel that is identical under both
+palettes was drawn with a colour some call site chose on its own — either a leak to fix, or an
+exemption that needs a name and a reason (doc/gui-visual-language.md, section 7).
+
+It only ever produces CANDIDATES. A pixel can legitimately be palette-independent (a user-chosen
+data colour, a mark drawn on top of the rendered image), so nothing here is a verdict; the
+disposition is done by a person, per candidate, with a written reason.
+
+Two layers, kept separate on purpose because they have different callers:
+
+  Layer A -- compare_export_dirs(): a general per-pixel comparison of two directories of PNGs,
+             paired by filename. It knows nothing about gui_test, palettes or this task. Both
+             modes below call it, and it is the only place a pixel is ever compared.
+
+  Layer B -- the default CLI mode: drive gui_test twice over the `theme_scan` cases (once with the
+             production palette, once with --theme-palette contrast) and hand the two export
+             directories to layer A.
+
+  Layer A is also reachable directly: `--compare-dirs A B --tolerance T` skips layer B's
+  orchestration entirely and compares two directories the caller already prepared. That is how a
+  before/after check of an unrelated reference group is done (same palette on both sides, so
+  --tolerance 0 asks for exact equality).
+
+Usage:
+    # Layer B: find candidates.
+    python scripts/scan_theme_leaks.py --binary build/Release/static/bin/gui_test
+
+    # Layer A: did this code change move any pixel of an already-exported group?
+    python scripts/scan_theme_leaks.py --compare-dirs before/ after/ --tolerance 0
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+
+try:
+    import numpy as np
+    from PIL import Image
+except ImportError:
+    print("ERROR: numpy and Pillow are required. Install with: pip install numpy Pillow", file=sys.stderr)
+    sys.exit(1)
+
+# The gui_test category these scenes register under. Also the filename prefix they export with,
+# so the two runs' PNGs pair up by name.
+SCAN_FILTER = "theme_scan"
+
+# Default tolerance for layer B, in 0..255 RGB Euclidean distance.
+#
+# Calibrated against the two populations it has to separate, both sampled from real exports of
+# these scenes: a themed pixel moves by hundreds (the contrast palette is >=0.54 away per field in
+# 0..1 units, i.e. >=138 here), while a pixel that is genuinely the same colour in both runs moves
+# by 0 -- except along an anti-aliased glyph or rounded-rect edge, where the SAME literal colour
+# composites against a DIFFERENT background and can shift by a few counts. 8 sits far above that
+# edge noise and two orders below a real palette response, so the choice is not delicate.
+DEFAULT_TOLERANCE = 8.0
+
+# A pixel that survives the tolerance test is painted this, so the highlight PNG reads as "here are
+# the candidates" at a glance; everything else is dimmed rather than blanked, to keep the context
+# needed to tell WHICH widget a candidate belongs to.
+HIGHLIGHT_RGB = (255, 0, 0)
+CONTEXT_DIM = 0.28
+
+
+def _load_rgb(path: str) -> np.ndarray:
+    """PNG -> float32 HxWx3 in 0..255. Alpha, if present, is dropped rather than composited:
+    these captures come from glReadPixels on the default framebuffer, where alpha carries no
+    information the comparison wants."""
+    with Image.open(path) as im:
+        return np.asarray(im.convert("RGB"), dtype=np.float32)
+
+
+def compare_export_dirs(dir_a: str, dir_b: str, tolerance: float, out_dir: str | None = None) -> list[dict]:
+    """Layer A. Pair PNGs by filename across two directories and report, per pair, how much of the
+    image did NOT change by more than `tolerance`.
+
+    Returns one dict per pair: name, total pixels, unchanged pixels, unchanged fraction, and the
+    path of the highlight image if one was written. A file present in only one directory is
+    reported with an `error` field instead of being skipped silently -- a missing scene is a hole
+    in the scan, not a pair that happens to match.
+    """
+    names_a = {f for f in os.listdir(dir_a) if f.endswith(".png")}
+    names_b = {f for f in os.listdir(dir_b) if f.endswith(".png")}
+    results: list[dict] = []
+
+    for name in sorted(names_a | names_b):
+        if name not in names_a or name not in names_b:
+            missing = dir_b if name not in names_b else dir_a
+            results.append({"name": name, "error": f"missing in {missing}"})
+            continue
+
+        a = _load_rgb(os.path.join(dir_a, name))
+        b = _load_rgb(os.path.join(dir_b, name))
+        if a.shape != b.shape:
+            results.append({"name": name, "error": f"shape {a.shape} vs {b.shape}"})
+            continue
+
+        dist = np.sqrt(np.sum((a - b) ** 2, axis=2))
+        unchanged = dist <= tolerance
+        total = int(unchanged.size)
+        n_unchanged = int(np.count_nonzero(unchanged))
+
+        entry = {
+            "name": name,
+            "total": total,
+            "unchanged": n_unchanged,
+            "fraction": n_unchanged / total if total else 0.0,
+            "highlight": None,
+        }
+
+        if out_dir is not None:
+            os.makedirs(out_dir, exist_ok=True)
+            vis = (a * CONTEXT_DIM).astype(np.uint8)
+            vis[unchanged] = HIGHLIGHT_RGB
+            highlight = os.path.join(out_dir, f"highlight_{name}")
+            Image.fromarray(vis).save(highlight)
+            entry["highlight"] = highlight
+
+        results.append(entry)
+
+    return results
+
+
+def _run_scan(binary: str, export_dir: str, contrast: bool) -> None:
+    """One layer-B gui_test run. --keep-export-png so the PNGs survive for the comparison."""
+    cmd = [binary, "--filter", SCAN_FILTER, "--export-dir", export_dir, "--keep-export-png", "--fixed-dt",
+           "--no-user-config"]
+    if contrast:
+        cmd += ["--theme-palette", "contrast"]
+    print("  $ " + " ".join(cmd))
+    result = subprocess.run(cmd)
+    # Not fatal: a scene may fail its own assertions while still having exported a usable PNG, and
+    # a partial scan is more useful than none. It is printed loudly because a non-zero exit here is
+    # a reason to distrust whichever scene is missing below.
+    if result.returncode != 0:
+        print(f"  WARNING: gui_test exited {result.returncode}", file=sys.stderr)
+
+
+def _report(results: list[dict], tolerance: float) -> int:
+    print(f"\n{'scene':44s} {'unchanged':>12s} {'of total':>12s} {'pct':>7s}")
+    print("-" * 80)
+    errors = 0
+    for r in results:
+        if "error" in r:
+            print(f"{r['name']:44s}   ERROR: {r['error']}")
+            errors += 1
+            continue
+        print(f"{r['name']:44s} {r['unchanged']:12d} {r['total']:12d} {100 * r['fraction']:6.2f}%")
+        if r["highlight"]:
+            print(f"{'':44s}   -> {r['highlight']}")
+    print(f"\ntolerance = {tolerance} (RGB Euclidean, 0..255)")
+    print("Non-zero 'unchanged' is a CANDIDATE LIST, not a verdict: dispose of each one by hand.")
+    return errors
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--binary", default="build/Release/static/bin/gui_test",
+                    help="gui_test binary (layer B only)")
+    ap.add_argument("--compare-dirs", nargs=2, metavar=("DIR_A", "DIR_B"),
+                    help="layer A direct call: compare two prepared export directories, no gui_test run")
+    ap.add_argument("--tolerance", type=float, default=None,
+                    help=f"RGB Euclidean distance below which a pixel counts as unchanged "
+                         f"(default {DEFAULT_TOLERANCE} for layer B; required to be given explicitly "
+                         f"is not enforced, but --compare-dirs callers should state it)")
+    ap.add_argument("--out-dir", default=None,
+                    help="where to write highlight PNGs (default: a directory next to the exports)")
+    args = ap.parse_args()
+
+    tolerance = args.tolerance if args.tolerance is not None else DEFAULT_TOLERANCE
+
+    if args.compare_dirs:
+        dir_a, dir_b = args.compare_dirs
+        results = compare_export_dirs(dir_a, dir_b, tolerance, args.out_dir)
+        return 1 if _report(results, tolerance) else 0
+
+    if not os.path.exists(args.binary):
+        print(f"ERROR: gui_test not found at {args.binary}. Build with: ./scripts/build.sh -gtj release",
+              file=sys.stderr)
+        return 1
+
+    work = tempfile.mkdtemp(prefix="theme_scan_")
+    dir_default = os.path.join(work, "palette_default")
+    dir_contrast = os.path.join(work, "palette_contrast")
+    os.makedirs(dir_default)
+    os.makedirs(dir_contrast)
+
+    print(f"Scratch: {work}")
+    print("Run 1/2 - production palette")
+    _run_scan(args.binary, dir_default, contrast=False)
+    print("Run 2/2 - contrast palette")
+    _run_scan(args.binary, dir_contrast, contrast=True)
+
+    out_dir = args.out_dir or os.path.join(work, "highlights")
+    results = compare_export_dirs(dir_default, dir_contrast, tolerance, out_dir)
+    return 1 if _report(results, tolerance) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -288,9 +288,12 @@ void RenderTopBar(float window_width) {
   // with Run (green) / Stop (red).
   const bool tint_colors_button = ShouldTintColorsButton(g_state.raypath_color.empty());
   if (tint_colors_button) {
-    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.30f, 0.35f, 0.65f, 1.0f));
-    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.40f, 0.45f, 0.75f, 1.0f));
-    ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.25f, 0.28f, 0.55f, 1.0f));
+    // Accent, at the alphas the theme uses for a tint rather than a fill (theme.cpp's header_tint
+    // rule: a surface the size of a button says "look here" by being tinted, not by being flooded).
+    // It was three literal blues, which is why swapping the palette left this badge behind.
+    ImGui::PushStyleColor(ImGuiCol_Button, AccentColor(0.35f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, AccentColor(0.50f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, AccentColor(0.25f));
   }
   if (ImGui::Button(ICON_FA_PALETTE " Colors")) {
     // task-348.3 AC3 (⑦): apply the "default enable on open with no classes" rule
@@ -356,9 +359,12 @@ void RenderTopBar(float window_width) {
     const std::string checkbox_id = std::string(mode_label) + "##CompositePreviewToggle";
     bool checked = composite_now;
     if (composite_now) {
-      ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.35f, 0.55f, 0.85f, 1.0f));
-      ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, ImVec4(0.45f, 0.65f, 0.95f, 1.0f));
-      ImGui::PushStyleColor(ImGuiCol_CheckMark, ImVec4(1.0f, 1.0f, 1.0f, 1.0f));
+      ImGui::PushStyleColor(ImGuiCol_FrameBg, AccentColor(0.55f));
+      ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, AccentColor(0.75f));
+      // The mark has to come off the accent-filled box it sits in, and the theme's own
+      // ImGuiCol_CheckMark IS the accent — so it would vanish. Text is the palette's answer to
+      // "legible on this app's surfaces"; a literal white is only the answer for a dark one.
+      ImGui::PushStyleColor(ImGuiCol_CheckMark, ImGui::GetStyleColorVec4(ImGuiCol_Text));
     }
     ImGui::BeginDisabled(composite_empty);
     if (Checkbox(checkbox_id.c_str(), &checked)) {
@@ -1407,13 +1413,23 @@ void RenderStatusBar(float window_width, float window_height) {
       ImGui::TextColored(GoodTextColor(), "Ready");
       break;
     case SimState::kSimulating:
-      ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.0f, 1.0f), "Simulating...");
+      // Accent, because that is what the accent is for: the one thing on screen that is live right
+      // now. Not a semantic grade — a run in progress is a fact, not a judgement about the
+      // document, and doc/gui-visual-language.md section 7 is explicit that folding progress into
+      // the warning grade would dilute the grade that means "you need to look at this".
+      ImGui::TextColored(AccentColor(), "Simulating...");
       break;
     case SimState::kStopping:
-      ImGui::TextColored(ImVec4(1.0f, 0.6f, 0.0f, 1.0f), "Stopping...");
+      // Winding down: the same frame greys and disables the Stop button, so the word takes the
+      // dimmed text colour and says the same thing the button already says.
+      ImGui::TextColored(ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled), "Stopping...");
       break;
     case SimState::kDone:
-      ImGui::TextColored(ImVec4(0.3f, 0.7f, 1.0f, 1.0f), "Done");
+      // A finished, unmodified run is the resting state, so it takes the resting text colour. The
+      // two states that DO carry a judgement keep their grades (Ready good, Modified warning) and
+      // the accent above marks the one that is in flight; between them there is nothing left for
+      // "Done" to claim that would not weaken one of the other three.
+      ImGui::TextUnformatted("Done");
       break;
     case SimState::kModified:
       ImGui::TextColored(WarningTextColor(), "Modified");
@@ -1902,7 +1918,7 @@ void RenderLogPanel(float window_width, float window_height) {
       switch (entry.level) {
         case spdlog::level::trace:
         case spdlog::level::debug:
-          color = ImVec4(0.6f, 0.6f, 0.6f, 1.0f);
+          color = ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled);
           break;
         case spdlog::level::warn:
           color = WarningTextColor();
@@ -1912,7 +1928,7 @@ void RenderLogPanel(float window_width, float window_height) {
           color = DestructiveTextColor();
           break;
         default:
-          color = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);
+          color = ImGui::GetStyleColorVec4(ImGuiCol_Text);
           break;
       }
       ImGui::PushStyleColor(ImGuiCol_Text, color);

--- a/src/gui/gui_constants.hpp
+++ b/src/gui/gui_constants.hpp
@@ -96,6 +96,15 @@ constexpr float kHoverBtnGap = 4.0f;
 // PushStyleVar(ImGuiStyleVar_ChildBorderSize).
 constexpr float kActiveCardBorder = 2.0f;
 
+// Border strength of a card that shares its (crystal, filter) pair with the one whose edit modal
+// is open. The accent at this alpha is theme.cpp's established "about to be acted on" marker.
+constexpr float kCoSharedBorderAlpha = 0.55f;
+
+// Opacity of an excluded entry card's thumbnail area — the rendered image, the placeholder that
+// stands in for it, and the frame around both. One constant rather than a per-branch literal so
+// "excluded" is one visual statement instead of two that can drift apart.
+constexpr float kExcludedThumbAlpha = 70.0f / 255.0f;
+
 // Default camera zoom for the crystal renderer. Lower value → crystal fills
 // more of the canvas (screen coverage ≈ 1/zoom). Must stay in sync between
 // the thumbnail cache and the edit-modal preview so the crystal does not

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -1056,7 +1056,19 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
     }
   }
   if (co_shared) {
-    ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(1.0f, 0.65f, 0.2f, 1.0f));
+    // The same accent the ACTIVE card's border uses, weakened: this card is in the same
+    // relationship to the open modal, just not the one being edited. Distinguishing it by
+    // INTENSITY rather than by a second hue is what keeps it inside the theme — the amber literal
+    // it replaced was a third colour the palette had never heard of, and it stayed amber whatever
+    // palette was installed. The alpha is theme.cpp's existing "accent at 0.55 marks a region
+    // about to be acted on" value (ImGuiCol_SeparatorHovered, ImGuiCol_ResizeGripHovered), which
+    // is the same statement this border makes.
+    //
+    // Telling the two apart never requires judging one border in isolation: a co-shared card only
+    // exists while a modal is open on ANOTHER card, so the full-strength one is always on screen
+    // beside it. Measured against the panel background (12,12,15) the active border peaks at
+    // (50,89,132) and this one at (33,54,79).
+    ImGui::PushStyleColor(ImGuiCol_Border, AccentColor(kCoSharedBorderAlpha));
     ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, kActiveCardBorder);
   }
 
@@ -1086,16 +1098,27 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
   ImVec2 thumb_br(thumb_pos.x + thumb_display_size, thumb_pos.y + thumb_display_size);
   // An excluded entry draws its thumbnail dimmed so the card reads as "out" at a
   // glance, from across the panel, without having to find the toggle glyph.
-  const ImU32 thumb_tint = entry.enabled ? IM_COL32(255, 255, 255, 255) : IM_COL32(255, 255, 255, 70);
+  //
+  // One rule covers both branches of the thumbnail — the rendered image and the placeholder that
+  // stands in until the cache produces one: an excluded card draws its thumbnail area at
+  // kExcludedThumbAlpha. Written twice as two unrelated pairs of literals (a white tint dropped to
+  // alpha 70, and a second, darker grey), they were free to disagree, and the placeholder pair did
+  // not follow the palette at all.
+  //
+  // The tint stays white because for an image a white tint is the IDENTITY, not a colour choice —
+  // what varies here is opacity. The placeholder takes ImGuiCol_FrameBg, the theme's token for an
+  // inset well with nothing in it yet, and the border ImGuiCol_Border like every other framed thing
+  // in the app.
+  const float thumb_alpha = entry.enabled ? 1.0f : kExcludedThumbAlpha;
+  const ImU32 thumb_tint = ImGui::GetColorU32(IM_COL32(255, 255, 255, 255), thumb_alpha);
   if (thumb_tex != 0) {
     // OpenGL texture Y-axis is flipped relative to ImGui: uv0=(0,1) uv1=(1,0)
     draw_list->AddImage(static_cast<ImTextureID>(thumb_tex), thumb_pos, thumb_br, ImVec2(0, 1), ImVec2(1, 0),
                         thumb_tint);
   } else {
-    draw_list->AddRectFilled(thumb_pos, thumb_br,
-                             entry.enabled ? IM_COL32(60, 60, 60, 255) : IM_COL32(45, 45, 45, 255));
+    draw_list->AddRectFilled(thumb_pos, thumb_br, ImGui::GetColorU32(ImGuiCol_FrameBg, thumb_alpha));
   }
-  draw_list->AddRect(thumb_pos, thumb_br, IM_COL32(100, 100, 100, 255));
+  draw_list->AddRect(thumb_pos, thumb_br, ImGui::GetColorU32(ImGuiCol_Border, thumb_alpha));
 
   // ---- Participation toggle (always visible) ----
   // Semantics: "exclude this crystal, then re-run". Turning it off does NOT subtract this
@@ -1327,7 +1350,10 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
       const float badge_x = btn_x + (btn_w - glyph_w) * 0.5f;
       const float badge_y = dup_y + btn_h + kHoverBtnGap;
       ImGui::SetCursorScreenPos(ImVec2(badge_x, badge_y));
-      ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.4f, 0.8f, 1.0f, 1.0f));
+      // Accent: the badge points at a relationship between cards, which is exactly the "look
+      // here, these belong together" job the accent does elsewhere. It was its own lighter blue,
+      // close enough to the accent to look intentional and independent enough to stop following it.
+      ImGui::PushStyleColor(ImGuiCol_Text, AccentColor());
       ImGui::TextUnformatted(ICON_FA_LINK);
       ImGui::PopStyleColor();
       if (ImGui::IsItemHovered()) {

--- a/src/gui/theme.cpp
+++ b/src/gui/theme.cpp
@@ -148,6 +148,50 @@ ImVec4 WithAlpha(const ImVec4& c, float a) {
   return ImVec4(c.x, c.y, c.z, a);
 }
 
+// Test-only second palette. Its job is to answer one question mechanically — "does this pixel
+// follow the palette?" — by being applied in place of kIceTruePalette for a second capture of the
+// same frame: a pixel that comes out unchanged is a call site that did not ask the theme.
+//
+// It is NOT a candidate skin and is not meant to be usable or pretty. The one property it must
+// have is distance, and the binding constraint is per-FIELD distance from kIceTruePalette: a
+// contrast field that landed close to its Ice counterpart would leave a genuinely themed pixel
+// looking unchanged, i.e. a false negative in the direction that matters. Measured over all 17
+// fields, the smallest RGB Euclidean distance to the Ice counterpart is 0.54 (grab), well clear
+// of the 0.3 floor this was calibrated against.
+//
+// Secondary, and weaker: every field is also kept ≥0.38 away from each bare colour literal known
+// to exist at a GUI call site (the amber/orange/blue status text, the grey and white log grades,
+// the three thumbnail greys, the LINK blue, the co-shared amber, the two hand-rolled blues). That
+// one does not prevent false negatives — an unchanged literal reads as a candidate whatever its
+// hue — it only keeps the diff's highlight image readable. Hence every field here is bright and
+// saturated: the literals in this tree cluster in the dark greys and the blues, and the cheapest
+// way to stay away from a cluster is to leave the neighbourhood entirely.
+constexpr Palette kContrastPaletteForTest{
+  /*text*/ { 1.000f, 0.300f, 0.850f, 1.00f },
+  /*text_dim*/ { 0.550f, 0.900f, 0.200f, 1.00f },
+  /*window_bg*/ { 0.150f, 0.950f, 0.700f, 1.00f },
+  /*child_bg*/ { 0.300f, 0.990f, 0.550f, 1.00f },
+  /*popup_bg*/ { 0.980f, 0.550f, 0.880f, 1.00f },
+  /*frame_bg*/ { 0.800f, 0.150f, 0.620f, 1.00f },
+  /*frame_hover*/ { 0.900f, 0.320f, 0.740f, 1.00f },
+  /*frame_active*/ { 0.990f, 0.480f, 0.850f, 1.00f },
+  /*button*/ { 0.200f, 0.800f, 0.500f, 1.00f },
+  /*button_hover*/ { 0.350f, 0.920f, 0.640f, 1.00f },
+  /*button_active*/ { 0.100f, 0.660f, 0.380f, 1.00f },
+  // A saturated border rather than another near-black: the production border is (0,0,0,0.55), and
+  // swapping one dark edge for another dark edge is exactly the weak contrast that would let a
+  // hand-drawn grey border (panels.cpp's thumbnail rect) pass for a themed one.
+  /*border*/ { 0.850f, 0.100f, 0.750f, 0.55f },
+  /*title_bg*/ { 0.550f, 0.100f, 0.900f, 1.00f },
+  /*title_active*/ { 0.700f, 0.280f, 0.990f, 1.00f },
+  /*accent*/ { 0.950f, 0.150f, 0.750f, 1.00f },
+  /*grab*/ { 0.550f, 0.850f, 0.150f, 1.00f },
+  // Alpha deliberately equals the Ice tint's 0.16: ApplyPalette derives HeaderHovered/HeaderActive
+  // by scaling it, so holding it fixed keeps the two captures identical in blend weight and
+  // different only in hue — a difference the diff can attribute.
+  /*header_tint*/ { 0.950f, 0.150f, 0.750f, 0.160f },
+};
+
 void ApplyPalette(ImGuiStyle& style, const Palette& p) {
   ImVec4* c = style.Colors;
   c[ImGuiCol_Text] = p.text;
@@ -193,6 +237,34 @@ void ApplyPalette(ImGuiStyle& style, const Palette& p) {
   c[ImGuiCol_TabSelected] = p.frame_active;
   c[ImGuiCol_TabDimmed] = p.title_bg;
   c[ImGuiCol_TabDimmedSelected] = p.frame_bg;
+  // The rule under a selected tab head. Nothing draws it today — ImGui gates it on
+  // ImGuiTabBarFlags_DrawSelectedOverline, which only DockNodeUpdateTabBar sets, and the tab bar in
+  // edit_modals.cpp is a plain BeginTabBar. It is assigned anyway because the value ImGui would
+  // otherwise use is not a value anyone chose: StyleColorsDark COPIES it from HeaderActive, so the
+  // moment a dock node appears the overline would arrive in the pre-theme header colour with no
+  // review and no red test. Accent while focused; the Separator white when the bar is dimmed, so an
+  // unfocused bar is demoted rather than recoloured.
+  c[ImGuiCol_TabSelectedOverline] = p.accent;
+  c[ImGuiCol_TabDimmedSelectedOverline] = ImVec4(1.0f, 1.0f, 1.0f, 0.10f);
+  // Docking. No DockSpace exists on this branch, so neither slot is reachable; same reasoning as
+  // the overline above — claimed so that introducing docking is a visible decision here rather than
+  // a silent inheritance of ImGui's factory blue. The drag preview follows the file's existing
+  // "accent at low alpha marks the region about to be acted on" convention (SeparatorHovered,
+  // ResizeGripHovered); an empty node takes the window background so it reads as a gap rather than
+  // as a panel with nothing in it.
+  c[ImGuiCol_DockingPreview] = WithAlpha(p.accent, 0.35f);
+  c[ImGuiCol_DockingEmptyBg] = p.window_bg;
+  // Plot slots. Also unreachable — there is no PlotLines/PlotHistogram/ProgressBar call in src/gui/
+  // (app_panels.cpp says so in as many words where the run status is drawn). ImGui's defaults here
+  // are the ones that would hurt most if they ever surfaced: PlotHistogram defaults to
+  // (0.90, 0.70, 0.00), i.e. this app's warning grade, which would announce "needs your attention"
+  // about a plain progress readout.
+  c[ImGuiCol_PlotLines] = p.accent;
+  c[ImGuiCol_PlotLinesHovered] = WithAlpha(p.accent, 0.85f);
+  c[ImGuiCol_PlotHistogram] = p.accent;
+  c[ImGuiCol_PlotHistogramHovered] = WithAlpha(p.accent, 0.85f);
+  // ImGui::TextLink* has no call site here either; accent is the same emphasis a link would want.
+  c[ImGuiCol_TextLink] = p.accent;
   c[ImGuiCol_TableHeaderBg] = p.title_active;
   c[ImGuiCol_TableBorderStrong] = p.border;
   c[ImGuiCol_TableBorderLight] = ImVec4(1.0f, 1.0f, 1.0f, 0.06f);
@@ -201,6 +273,13 @@ void ApplyPalette(ImGuiStyle& style, const Palette& p) {
   c[ImGuiCol_TextSelectedBg] = WithAlpha(p.accent, 0.35f);
   c[ImGuiCol_NavCursor] = p.accent;
   c[ImGuiCol_DragDropTarget] = p.accent;
+  // The Ctrl+Tab window switcher. Unlike the slots above this one IS reachable —
+  // ImGuiConfigFlags_NavEnableKeyboard is set in both main.cpp and the test harness — and it drew
+  // in ImGui's 70% white over a 20% grey dim until this line existed.
+  c[ImGuiCol_NavWindowingHighlight] = p.accent;
+  // One dim value shared by the two things that dim the whole screen behind a foreground window
+  // (the switcher and a modal). A second, slightly different darkness would be a value nobody chose.
+  c[ImGuiCol_NavWindowingDimBg] = ImVec4(0.0f, 0.0f, 0.0f, 0.55f);
   c[ImGuiCol_ModalWindowDimBg] = ImVec4(0.0f, 0.0f, 0.0f, 0.55f);
 }
 
@@ -229,6 +308,18 @@ bool Checkbox(const char* label, bool* v) {
   return changed;
 }
 
+void ApplyStyle(ImGuiStyle& style) {
+  ApplyGridSpacing(style);
+  ApplyPalette(style, kIceTruePalette);
+}
+
+void ApplyContrastPaletteForTest(ImGuiStyle& style) {
+  // Palette only, no ApplyGridSpacing: the diff this feeds compares two captures of the same
+  // frame, so they must differ in colour and in nothing else. Re-running the spacing would be
+  // a no-op today, but the point is that geometry is not this function's business.
+  ApplyPalette(style, kContrastPaletteForTest);
+}
+
 void ApplyVisualLanguage(ImGuiIO& io) {
   ImGui::StyleColorsDark();
 
@@ -238,9 +329,7 @@ void ApplyVisualLanguage(ImGuiIO& io) {
   // DragFloat/DragInt call site anywhere in the GUI.
   io.ConfigDragClickToInputText = true;
 
-  ImGuiStyle& style = ImGui::GetStyle();
-  ApplyGridSpacing(style);
-  ApplyPalette(style, kIceTruePalette);
+  ApplyStyle(ImGui::GetStyle());
 
   if (!AddBodyFont(io, kBodyFontSizePx)) {
     GUI_LOG_WARNING("Roboto Medium failed to load; falling back to the built-in bitmap font.");

--- a/src/gui/theme.cpp
+++ b/src/gui/theme.cpp
@@ -290,6 +290,11 @@ constexpr float kUncheckedBoxBorderAlpha = 0.13f;
 
 }  // namespace
 
+ImVec4 AccentColor(float alpha) {
+  const ImVec4 accent = ImGui::GetStyleColorVec4(ImGuiCol_CheckMark);
+  return ImVec4(accent.x, accent.y, accent.z, accent.w * alpha);
+}
+
 bool Checkbox(const char* label, bool* v) {
   const bool changed = ImGui::Checkbox(label, v);
   if (!*v) {

--- a/src/gui/theme.hpp
+++ b/src/gui/theme.hpp
@@ -15,6 +15,17 @@ namespace lumice::gui {
 // Must be called after ImGui::CreateContext(), before the render loop.
 void ApplyVisualLanguage(ImGuiIO& io);
 
+// The colour+geometry half of ApplyVisualLanguage: grid spacing plus the palette, applied to a
+// caller-supplied style rather than to ImGui::GetStyle(). Split out so a test can hand it a
+// scratch ImGuiStyle and ask what it wrote — the "was this slot claimed" question needs a style
+// it owns, and it must reach the very code path the app uses, not a copy of it
+// (test/gui/functional/test_theme_coverage.cpp).
+//
+// It deliberately does NOT call ImGui::StyleColorsDark() first: the coverage test fills its
+// scratch style with a sentinel and requires none of it to survive, which is only a question
+// about this function if the baseline preset is not run inside it.
+void ApplyStyle(ImGuiStyle& style);
+
 // Draws ImGui::Checkbox, then — because the theme's FrameBorderSize is 0 — adds a
 // low-contrast inset border around an UNCHECKED box so it stays legible against the panel
 // background. A checked box is already filled with the accent colour and needs no such aid.

--- a/src/gui/theme.hpp
+++ b/src/gui/theme.hpp
@@ -26,6 +26,17 @@ void ApplyVisualLanguage(ImGuiIO& io);
 // about this function if the baseline preset is not run inside it.
 void ApplyStyle(ImGuiStyle& style);
 
+// The accent colour as it is CURRENTLY INSTALLED in the live style, optionally at a different
+// alpha. This is the one place that knows how to read it back: ApplyPalette writes Palette::accent
+// into several slots and ImGuiCol_CheckMark is one of them, so asking the style is both cheaper
+// than exporting the Palette and — the part that matters — it follows whatever palette is actually
+// in force rather than a compile-time constant.
+//
+// It exists because "borrow the accent here" was being spelled out at call sites as a literal blue
+// that no longer moved when the palette did. A call site that wants the accent says so; the
+// coupling to a particular ImGuiCol_ slot lives here and nowhere else.
+ImVec4 AccentColor(float alpha = 1.0f);
+
 // Draws ImGui::Checkbox, then — because the theme's FrameBorderSize is 0 — adds a
 // low-contrast inset border around an UNCHECKED box so it stays legible against the panel
 // background. A checked box is already filled with the accent colour and needs no such aid.

--- a/src/gui/theme_test_hooks.hpp
+++ b/src/gui/theme_test_hooks.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "imgui.h"
+
+namespace lumice::gui {
+
+// Test-only entry point into theme.cpp, kept in its own header on purpose.
+//
+// It could have been declared in theme.hpp behind a comment saying "do not call this from the
+// app". A separate header makes that a structural fact instead of a promise: no production
+// translation unit has any reason to include a file named theme_test_hooks.hpp, so an accidental
+// production call site shows up as an odd include line rather than as one more function in the
+// theme's public list. The only includer today is test/gui/test_gui_main.cpp.
+//
+// What it does: re-applies ONLY the palette (not spacing, not rounding, not the font atlas), using
+// a deliberately distant test palette. A frame captured after this call and a frame captured under
+// the production ApplyStyle() therefore differ in colour and in nothing else, which is what makes
+// the pair a valid input to a pixel diff: a pixel that is the same in both was drawn with a colour
+// the theme does not own.
+//
+// Call after ApplyVisualLanguage(), before the render loop.
+void ApplyContrastPaletteForTest(ImGuiStyle& style);
+
+}  // namespace lumice::gui

--- a/test/gui/CMakeLists.txt
+++ b/test/gui/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(gui_test
     functional/test_shell_chrome.cpp
     functional/test_log_panel.cpp
     functional/test_theme_coverage.cpp
+    functional/test_theme_scan.cpp
     functional/test_overlay_controls.cpp
     functional/test_preview_viewport.cpp
     functional/test_preview_texture.cpp

--- a/test/gui/CMakeLists.txt
+++ b/test/gui/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(gui_test
     functional/test_scene_controls.cpp
     functional/test_shell_chrome.cpp
     functional/test_log_panel.cpp
+    functional/test_theme_coverage.cpp
     functional/test_overlay_controls.cpp
     functional/test_preview_viewport.cpp
     functional/test_preview_texture.cpp

--- a/test/gui/functional/test_theme_coverage.cpp
+++ b/test/gui/functional/test_theme_coverage.cpp
@@ -1,0 +1,75 @@
+// The theme claims every ImGuiCol_ slot there is.
+//
+// The proposition is about omission, which is why it needs a case of its own: a slot the palette
+// never mentions does not look wrong at review time, it looks like nothing at all, and then ships
+// ImGui's default colour under this app's name. Eleven slots were in that state when this case was
+// written — among them ImGuiCol_PlotHistogram, whose ImGui default is (0.90, 0.70, 0.00), i.e. the
+// amber this app reserves for "this needs your attention". Nothing drew it, so nothing was wrong
+// yet; the first ProgressBar anyone adds would have arrived pre-coloured as a warning.
+//
+// How it is checked, and why not the obvious way. Comparing the live style against a pristine
+// StyleColorsDark() would be the shorter test and it would be wrong in both directions: two slots
+// (BorderShadow, TableRowBg) are deliberately assigned the very value dark already had, so they
+// would read as unclaimed, and any future slot whose chosen value happens to coincide would join
+// them. Filling a scratch style with a value no palette entry can produce and requiring that none
+// of it survives ApplyStyle() asks the actual question — "was this slot written to" — with no
+// dependency on WHAT was written.
+//
+// It also covers slots that do not exist yet: an ImGui upgrade that adds one gets a red here
+// rather than a quiet default in the next screenshot.
+
+#include "gui/theme.hpp"
+#include "test_gui_shared.hpp"
+
+namespace {
+
+// Outside the range any colour can take (channels are 0..1), so no palette entry can produce it
+// and no slot can be "claimed" by coincidence.
+constexpr ImVec4 kUnclaimed(-1.0f, -2.0f, -3.0f, -4.0f);
+
+bool IsUnclaimed(const ImVec4& c) {
+  return c.x == kUnclaimed.x && c.y == kUnclaimed.y && c.z == kUnclaimed.z && c.w == kUnclaimed.w;
+}
+
+}  // namespace
+
+void RegisterThemeCoverageTests(ImGuiTestEngine* engine) {
+  ImGuiTest* t = IM_REGISTER_TEST(engine, "theme_coverage", "the_palette_claims_every_color_slot");
+  t->TestFunc = [](ImGuiTestContext* ctx) {
+    // One frame before reading the live style below, so the assertions run against a style the
+    // renderer has actually drawn with rather than one that merely exists in memory.
+    ctx->Yield(1);
+
+    ImGuiStyle probe;
+    for (int i = 0; i < ImGuiCol_COUNT; ++i) {
+      probe.Colors[i] = kUnclaimed;
+    }
+
+    lumice::gui::ApplyStyle(probe);
+
+    // Names are reported rather than indices: an index moves with every ImGui upgrade, and the
+    // whole point of a red here is that someone can go add the missing line.
+    std::string unclaimed;
+    for (int i = 0; i < ImGuiCol_COUNT; ++i) {
+      if (IsUnclaimed(probe.Colors[i])) {
+        unclaimed += std::string(" ") + ImGui::GetStyleColorName(i);
+      }
+    }
+    ctx->LogInfo("slots=%d unclaimed:[%s]", ImGuiCol_COUNT, unclaimed.c_str());
+    IM_CHECK_STR_EQ(unclaimed.c_str(), "");
+
+    // The live style is the thing the app actually draws with, and it is reached by a different
+    // path (ApplyVisualLanguage at startup). Anchoring the one slot whose default is this app's
+    // warning grade keeps the case honest about the defect it came from: whatever the accent is,
+    // it is not that amber.
+    const ImVec4& hist = ImGui::GetStyle().Colors[ImGuiCol_PlotHistogram];
+    IM_CHECK(!(hist.x == 0.90f && hist.y == 0.70f && hist.z == 0.00f));
+    // Same accent as the check marks, which is what makes it the theme's accent rather than a
+    // second blue that merely looks like it.
+    const ImVec4& check = ImGui::GetStyle().Colors[ImGuiCol_CheckMark];
+    IM_CHECK_EQ(hist.x, check.x);
+    IM_CHECK_EQ(hist.y, check.y);
+    IM_CHECK_EQ(hist.z, check.z);
+    IM_CHECK_EQ(hist.w, check.w);
+  };
+}

--- a/test/gui/functional/test_theme_scan.cpp
+++ b/test/gui/functional/test_theme_scan.cpp
@@ -1,0 +1,410 @@
+// The oracle for "does this colour follow the palette?" — the class-B half of theme closure.
+//
+// The question. theme.cpp owns a Palette, but a colour only follows it if the call site READS it.
+// A literal ImVec4/IM_COL32 written at a call site produces exactly the same pixel whatever palette
+// is installed, and nothing in the build says so: it compiles, it renders, it looks deliberate. The
+// mechanical statement of the defect is therefore a differential one — swap the palette for a
+// deliberately distant one, and any pixel that DID NOT MOVE was painted by something that ignored
+// the palette.
+//
+// What these cases are, and are not. They are the scene battery that differential needs: each one
+// drives the app into a state where one known family of literals is on screen, then exports the
+// rectangle that contains it. They compare nothing. The comparison is done outside, by
+// scripts/scan_theme_leaks.py, which runs this same category twice — once with the production
+// palette, once with --theme-palette contrast — and reports the pixels that came out equal.
+//
+// And the output of THAT is a candidate list, never a verdict: a colour can legitimately be
+// palette-independent (a user-chosen data colour, a mark drawn on the rendered image). Every
+// candidate is dispositioned by hand against the criteria in doc/gui-visual-language.md section 7.
+//
+// Why they are still assertions rather than a bare export. Each case checks that the state it meant
+// to reach was actually reached (the tinted branch is live, the modal really opened) and that the
+// capture came back non-empty. Without that, a scene that silently stopped reaching its literal
+// would export a clean-looking PNG and the scan would report "no candidates here" — a false green
+// produced by the scene, not by the code under test.
+//
+// These are B1 (a rendered frame is the observable) and they live in gui_test for that reason.
+
+#include <algorithm>
+#include <cmath>
+#include <string>
+#include <vector>
+
+#include "IconsFontAwesome6.h"
+#include "gui/app.hpp"
+#include "gui/color_window.hpp"
+#include "gui/edit_modals.hpp"
+#include "gui/gui_logger.hpp"
+#include "gui/gui_state.hpp"
+#include "gui/log_sink.hpp"
+#include "test_gui_shared.hpp"
+
+namespace {
+
+using lumice::gui::g_state;
+
+// Filename the two runs pair by. scripts/scan_theme_leaks.py matches PNGs across its two export
+// directories by name alone, so the name has to be a function of the scene and nothing else.
+std::string ScenePath(const char* scene) {
+  return GuiTestTempPath(std::string("theme_scan_") + scene + ".png").string();
+}
+
+// Read a window's live rectangle out of the default framebuffer and write it as a PNG.
+//
+// The rect comes from the window rather than from constants so the scene keeps framing its subject
+// after a layout change. ImGui is origin-top-left in window coordinates and glReadPixels is
+// origin-bottom-left in framebuffer pixels, hence the flip; the Retina scale is applied here for
+// the same reason functional/test_status_bar.cpp applies it — the hook takes framebuffer pixels.
+//
+// window_ref == nullptr captures the whole framebuffer (rect_w left at 0).
+bool ExportRegion(ImGuiTestContext* ctx, const char* window_ref, const char* scene) {
+  g_fullframe_capture.Reset();
+  if (window_ref != nullptr) {
+    ImGuiWindow* win = ctx->GetWindowByRef(window_ref);
+    if (win == nullptr) {
+      IM_ERRORF("scene %s: window %s is not up", scene, window_ref);
+      return false;
+    }
+    const ImGuiIO& io = ImGui::GetIO();
+    const float sx = io.DisplayFramebufferScale.x;
+    const float sy = io.DisplayFramebufferScale.y;
+    const float fb_w = io.DisplaySize.x * sx;
+    const float fb_h = io.DisplaySize.y * sy;
+    const ImVec2 vp_pos = ImGui::GetMainViewport()->Pos;
+    // Clipped to the framebuffer, and that is load-bearing rather than defensive. ImGui clamps
+    // every window to style.WindowMinSize (32 px), so the 28 px status bar is 32 px tall and its
+    // last four rows sit BELOW the bottom of the window. Reading them back yields four rows that
+    // are black under either palette — 12.5% of that capture, reported as unchanged, i.e. a
+    // candidate the scan invented out of its own framing. Any rectangle read here is intersected
+    // with the framebuffer first, so what the scan sees is only pixels the app actually drew.
+    const float x0 = std::max(0.0f, (win->Pos.x - vp_pos.x) * sx);
+    const float y0 = std::max(0.0f, (win->Pos.y - vp_pos.y) * sy);
+    const float x1 = std::min(fb_w, (win->Pos.x - vp_pos.x + win->Size.x) * sx);
+    const float y1 = std::min(fb_h, (win->Pos.y - vp_pos.y + win->Size.y) * sy);
+    g_fullframe_capture.rect_x = static_cast<int>(std::lround(x0));
+    g_fullframe_capture.rect_y = static_cast<int>(std::lround(fb_h - y1));
+    g_fullframe_capture.rect_w = static_cast<int>(std::lround(x1 - x0));
+    g_fullframe_capture.rect_h = static_cast<int>(std::lround(y1 - y0));
+  }
+  g_fullframe_capture.requested.store(true);
+  for (int i = 0; i < 10 && !g_fullframe_capture.done.load(); ++i) {
+    ctx->Yield(1);
+  }
+  if (!g_fullframe_capture.done.load()) {
+    IM_ERRORF("scene %s: the framebuffer readback did not complete", scene);
+    return false;
+  }
+  if (g_fullframe_capture.width <= 0 || g_fullframe_capture.height <= 0) {
+    IM_ERRORF("scene %s: captured %dx%d", scene, g_fullframe_capture.width, g_fullframe_capture.height);
+    return false;
+  }
+  // A readback that quietly returned zeros compares equal to itself under both palettes, i.e. it
+  // reports the whole rectangle as a candidate. Catching it here keeps that out of the scan.
+  bool has_nonzero = false;
+  for (size_t i = 0; i < g_fullframe_capture.pixels.size() && !has_nonzero; ++i) {
+    has_nonzero = g_fullframe_capture.pixels[i] != 0;
+  }
+  if (!has_nonzero) {
+    IM_ERRORF("scene %s: the capture is entirely black", scene);
+    return false;
+  }
+  const std::vector<unsigned char> rgb = lumice::test::StripAlpha(
+      g_fullframe_capture.pixels.data(), g_fullframe_capture.width, g_fullframe_capture.height);
+  const std::string path = ScenePath(scene);
+  if (!lumice::test::SavePng(path.c_str(), rgb.data(), g_fullframe_capture.width, g_fullframe_capture.height, 3)) {
+    IM_ERRORF("scene %s: could not write %s", scene, path.c_str());
+    return false;
+  }
+  ctx->LogInfo("[theme_scan] %s -> %s (%dx%d)", scene, path.c_str(), g_fullframe_capture.width,
+               g_fullframe_capture.height);
+  return true;
+}
+
+// Park the cursor off-window and let the frame settle before capturing. A hovered widget paints a
+// different colour token than the one the scene is aiming at, and a tooltip would cover it.
+void Settle(ImGuiTestContext* ctx) {
+  ctx->MouseMoveToPos(ImVec2(-100.0f, -100.0f));
+  ctx->Yield(3);
+}
+
+// One color class over the default document's only placement — enough to put the top bar into its
+// "colors are configured" branch. Mirrors functional/test_color_window.cpp's MakeMatchAllClass;
+// copied rather than shared because that one is file-local there and this needs only the shape.
+gui::ColorClassConfig MakeMatchAllClass() {
+  gui::ColorClassConfig cls;
+  cls.color[0] = 1.0f;
+  cls.color[1] = 0.0f;
+  cls.color[2] = 0.0f;
+  cls.visible = true;
+  cls.z_order = 0;
+  gui::ColorClassRefConfig ref;
+  ref.layer_idx = 0;
+  ref.crystal_pool_id = g_state.layers[0].entries[0].crystal_id;
+  ref.match_all = true;
+  cls.match.push_back(ref);
+  return cls;
+}
+
+// A second entry bound to the SAME pool slot and filter as the first: that is what CountEntriesSharing
+// counts, so it is what puts the LINK badge on both cards.
+void AddEntrySharingSlotZero(ImGuiTestContext* ctx) {
+  gui::EntryCard shared;
+  shared.crystal_id = g_state.layers[0].entries[0].crystal_id;
+  shared.filter_id = g_state.layers[0].entries[0].filter_id;
+  g_state.layers[0].entries.push_back(shared);
+  gui::g_thumbnail_cache.OnLayerStructureChanged();
+  ctx->Yield(3);
+}
+
+// The GUI logger's sinks and level are process-wide and gui_test is one process. Same shape as
+// functional/test_log_panel.cpp's guard, and for the same reason: a case that leaves a sink
+// attached changes what every later case sees.
+struct ScopedLogPanel {
+  bool prev_enable;
+  std::shared_ptr<gui::ImGuiLogSink> prev_sink;
+  std::vector<spdlog::sink_ptr> prev_sinks;
+  spdlog::level::level_enum prev_level;
+  int prev_gui_log_level;
+
+  ScopedLogPanel()
+      : prev_enable(g_enable_log_panel), prev_sink(gui::g_imgui_log_sink), prev_sinks(gui::GetGuiLogger().sinks()),
+        prev_level(gui::GetGuiLogger().level()), prev_gui_log_level(g_state.gui_log_level) {
+    g_enable_log_panel = true;
+    gui::g_imgui_log_sink = std::make_shared<gui::ImGuiLogSink>();
+    gui::GetGuiLogger().sinks().push_back(gui::g_imgui_log_sink);
+    gui::GetGuiLogger().set_level(spdlog::level::trace);
+  }
+  ~ScopedLogPanel() {
+    gui::GetGuiLogger().sinks() = prev_sinks;
+    gui::GetGuiLogger().set_level(prev_level);
+    g_state.gui_log_level = prev_gui_log_level;
+    gui::g_imgui_log_sink = prev_sink;
+    g_enable_log_panel = prev_enable;
+    g_state.log_panel_open = false;
+  }
+};
+
+}  // namespace
+
+void RegisterThemeScanTests(ImGuiTestEngine* engine) {
+  // The two top-bar controls that paint themselves: the Colors button, tinted while the document
+  // has color classes, and the Colored checkbox, tinted while the preview is showing a composite.
+  // Both are "content state projected onto a control", and both currently choose their own blue.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "theme_scan", "topbar_badges");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(3);
+      g_state.raypath_color.push_back(MakeMatchAllClass());
+      // Ground truth for the checkbox's label AND its tint branch. SyncFromPoller is the only
+      // production writer, and it does nothing without a server, so this survives to the frame
+      // that draws it.
+      g_state.last_uploaded_as_composite = true;
+      ctx->Yield(4);
+
+      // The scene really is in the branch it exists to photograph. Without this the case would
+      // still export a plausible top bar, and the scan would read "no candidates" from a top bar
+      // that never entered either branch.
+      IM_CHECK(gui::ShouldTintColorsButton(g_state.raypath_color.empty()));
+      IM_CHECK(ctx->ItemExists("##TopBar/Colored##CompositePreviewToggle"));
+
+      Settle(ctx);
+      ExportRegion(ctx, "##TopBar", "topbar_badges");
+
+      g_state.last_uploaded_as_composite = false;
+      g_state.raypath_color.clear();
+      ctx->Yield(2);
+    };
+  }
+
+  // The status bar's run-state word. Each state is its own export because they are three separate
+  // literals in one switch, and a single capture would only ever contain one of them.
+  //
+  // sim_state is not written directly: SyncFromPoller derives it from run_intent every tick, so a
+  // direct write does not survive to the drawing frame (the mechanism functional/test_status_bar.cpp
+  // documents). "Stopping..." is unreachable that way — with no live server a kStopping intent is
+  // promoted immediately — so it has no scene here and is dispositioned by reading the switch it
+  // shares with the two that do.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "theme_scan", "status_bar_states");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(3);
+
+      struct State {
+        const char* scene;
+        gui::RunIntent intent;
+        bool dirty;
+      };
+      static const State kStates[] = {
+        { "status_ready", gui::RunIntent::kNone, false },  // GoodTextColor()
+        { "status_simulating", gui::RunIntent::kRunning, false },
+        { "status_done", gui::RunIntent::kLoaded, false },
+        { "status_modified", gui::RunIntent::kLoaded, true },  // WarningTextColor()
+      };
+      for (const State& s : kStates) {
+        g_state.run_intent = s.intent;
+        g_state.dirty = s.dirty;
+        Settle(ctx);
+        ExportRegion(ctx, "##StatusBar", s.scene);
+        // One row per loop level: every ImGuiTestContext action opens with `if (IsError()) return`,
+        // so a reported failure here turns every later row into a shadow of the first.
+        if (ctx->IsError()) {
+          break;
+        }
+      }
+      g_state.run_intent = gui::RunIntent::kNone;
+      g_state.dirty = false;
+      ctx->Yield(2);
+    };
+  }
+
+  // The log panel paints one line per severity. Two of the five branches are literals (trace/debug
+  // grey, the default white) and two go through semantic_colors.hpp — so this one rectangle holds
+  // both a suspected leak and a suspected exemption, which is the comparison the disposition needs.
+  //
+  // Logged through the logger's runtime log() rather than the GUI_LOG_* macros: those compile out
+  // below SPDLOG_ACTIVE_LEVEL, and this target does not set it.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "theme_scan", "log_panel_levels");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ScopedLogPanel scoped;
+      g_state.log_panel_open = true;
+      g_state.gui_log_level = 0;
+      ctx->Yield(3);
+
+      gui::GetGuiLogger().log(spdlog::level::trace, "theme_scan trace line");
+      gui::GetGuiLogger().log(spdlog::level::debug, "theme_scan debug line");
+      gui::GetGuiLogger().log(spdlog::level::info, "theme_scan default line");
+      gui::GetGuiLogger().log(spdlog::level::warn, "theme_scan warning line");
+      gui::GetGuiLogger().log(spdlog::level::err, "theme_scan error line");
+      ctx->Yield(4);
+
+      // All five reached the ring buffer the panel reads. A level filtered out at the logger would
+      // leave its colour branch undrawn and silently out of the scan.
+      IM_CHECK(gui::g_imgui_log_sink->Size() >= (size_t)5);
+
+      Settle(ctx);
+      ExportRegion(ctx, "##LogPanel", "log_panel_levels");
+    };
+  }
+
+  // The entry card's chrome: the thumbnail's placeholder fill and its border, the dimming an
+  // excluded card gets, and the LINK badge two cards sharing a pool slot both carry.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "theme_scan", "entry_card_chrome");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(3);
+      AddEntrySharingSlotZero(ctx);
+      g_state.layers[0].entries[1].enabled = false;
+      ctx->Yield(4);
+
+      IM_CHECK_EQ((int)g_state.layers[0].entries.size(), 2);
+      IM_CHECK_EQ(gui::CountEntriesSharing(g_state, g_state.layers[0].entries[0].crystal_id,
+                                           g_state.layers[0].entries[0].filter_id),
+                  2);
+
+      Settle(ctx);
+      ExportRegion(ctx, "##LeftPanel", "entry_card_chrome");
+    };
+  }
+
+  // The co-shared border: with the edit modal open on one card, every OTHER card bound to the same
+  // (crystal, filter) pair is outlined to say the in-flight edit will reach it too. That outline is
+  // the one card-chrome colour not reachable from the scene above, because it needs a modal open.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "theme_scan", "card_co_shared");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      const ScopedPopups popup_guard(ctx);
+      ctx->Yield(3);
+      AddEntrySharingSlotZero(ctx);
+
+      gui::EditRequest req{ gui::EditTarget::kCrystal, /*layer_idx=*/0, /*entry_idx=*/0 };
+      gui::OpenEditModal(req, g_state);
+      ctx->Yield(4);
+      IM_CHECK(gui::IsEditModalOpen());
+      IM_CHECK_EQ(gui::GetEditModalTarget().entry_idx, 0);
+
+      Settle(ctx);
+      ExportRegion(ctx, "##LeftPanel", "card_co_shared");
+    };
+  }
+
+  // The sync-group swatch, which is where the palette-independent colours the criterion is supposed
+  // to EXEMPT actually live: the six-colour group table is indexed by group number, and the digit
+  // drawn on a swatch picks black or white from that fill's luminance. Both are in this rectangle,
+  // next to ordinary themed chrome, so the scan reports them together and the disposition has to
+  // separate them by reason rather than by which scene they came from.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "theme_scan", "sync_swatch_probe");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      const ScopedPopups popup_guard(ctx);
+      ctx->Yield(2);
+
+      // Two groups, chosen for their luminance: group 2's amber crosses the 0.55 luma threshold that
+      // selects a black digit, group 1's blue does not and gets a white one. One capture therefore
+      // contains both branches of the derived-contrast rule.
+      g_state.crystals[g_state.layers[0].entries[0].crystal_id].height.sync_group = 2;
+      g_state.crystals[g_state.layers[0].entries[0].crystal_id].face_distance[2].sync_group = 1;
+      ctx->Yield(2);
+
+      gui::EditRequest req{ gui::EditTarget::kCrystal, /*layer_idx=*/0, /*entry_idx=*/0 };
+      gui::OpenEditModal(req, g_state);
+      ctx->Yield(4);
+      IM_CHECK(gui::IsEditModalOpen());
+      ctx->ItemOpen("**/Face Distance##modal");
+      ctx->Yield(4);
+      IM_CHECK_NE(ctx->ItemInfo("**/##sync_Face 3##modal_fd", ImGuiTestOpFlags_NoError).ID, (ImGuiID)0);
+
+      Settle(ctx);
+      ExportRegion(ctx, "Edit Entry", "sync_swatch_probe");
+    };
+  }
+
+  // The Overlay group's table and its drag fields, in all three states a drag field has. They are
+  // expected to be clean — they were written against the theme's tokens — and that is exactly why
+  // they are here: an oracle that only visits the places already known to be dirty cannot report
+  // that anywhere is clean.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "theme_scan", "overlay_table_controls");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(3);
+      g_state.show_grid_line = true;
+      ctx->Yield(3);
+
+      const ImGuiTestItemInfo drag = ctx->ItemInfo("//##RightPanel/**/##grid_alpha");
+      IM_CHECK_NE(drag.ID, (ImGuiID)0);
+
+      Settle(ctx);
+      ExportRegion(ctx, "##RightPanel", "overlay_table_default");
+      if (ctx->IsError()) {
+        return;
+      }
+
+      // Hover, then drag. The two states push different frame-background tokens, and the point of
+      // photographing them separately is that a literal in either one is invisible in the other.
+      ctx->MouseMove("//##RightPanel/**/##grid_alpha");
+      ctx->Yield(3);
+      ExportRegion(ctx, "##RightPanel", "overlay_table_hover");
+      if (ctx->IsError()) {
+        return;
+      }
+
+      ctx->MouseDown(ImGuiMouseButton_Left);
+      ctx->Yield(3);
+      const bool active = ImGui::GetActiveID() == drag.ID;
+      ExportRegion(ctx, "##RightPanel", "overlay_table_active");
+      ctx->MouseUp(ImGuiMouseButton_Left);
+      ctx->Yield(2);
+      IM_CHECK(active);
+
+      g_state.show_grid_line = false;
+      ctx->Yield(2);
+    };
+  }
+}

--- a/test/gui/functional/test_theme_scan.cpp
+++ b/test/gui/functional/test_theme_scan.cpp
@@ -311,6 +311,63 @@ void RegisterThemeScanTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // The thumbnail PLACEHOLDER, which the scene above cannot photograph however long it waits: the
+  // cache renders a texture within a frame or two of the cards appearing, and from then on the card
+  // composites an image. The placeholder is what stands in until then, and it had its own pair of
+  // greys.
+  //
+  // Reaching it deterministically is a matter of arithmetic rather than timing luck. The cache
+  // rebuilds at most kMaxThumbnailUpdatesPerFrame (2) slots per frame, so seven cards on seven
+  // distinct pool slots, invalidated all at once, cannot all be back before the readback lands —
+  // and the case asserts afterwards that at least one really was still waiting, so a future change
+  // to that budget turns this into a red rather than into a scene that quietly photographs nothing.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "theme_scan", "thumb_placeholder");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(3);
+      std::vector<int> ids;
+      ids.push_back(g_state.layers[0].entries[0].crystal_id);
+      for (int i = 0; i < 6; ++i) {
+        gui::CrystalConfig extra;
+        gui::EntryCard card;
+        card.crystal_id = static_cast<int>(g_state.crystals.size());
+        g_state.crystals.push_back(extra);
+        g_state.layers[0].entries.push_back(card);
+        ids.push_back(card.crystal_id);
+      }
+      gui::g_thumbnail_cache.OnLayerStructureChanged();
+      // Long enough for every card to have got its texture, so what follows is a transition from
+      // "all present" to "most missing" rather than a state that was never established. The cursor
+      // is parked BEFORE the invalidation, not after: Settle()'s three frames are three frames of
+      // rebuilding, which is most of the budget this scene is spending.
+      Settle(ctx);
+      ctx->Yield(40);
+      gui::g_thumbnail_cache.InvalidateAll();
+      // One frame, and exactly one. The test engine's coroutine runs at the END of an ImGui frame,
+      // so a cache invalidated here first reaches the cards on the NEXT frame — while the capture
+      // hook fires at the end of the CURRENT one. Requesting the readback without this yield
+      // photographs the frame that was drawn before the invalidation, i.e. the textures. Each
+      // further frame rebuilds two more slots, so anything beyond one gives the queue time to
+      // finish and the scene stops reaching the branch at all.
+      ctx->Yield(1);
+      ExportRegion(ctx, "##LeftPanel", "thumb_placeholder");
+      if (ctx->IsError()) {
+        return;
+      }
+
+      int still_pending = 0;
+      for (int id : ids) {
+        if (gui::g_thumbnail_cache.GetTexture(id) == 0) {
+          ++still_pending;
+        }
+      }
+      ctx->LogInfo("[theme_scan] thumb_placeholder: %d/%d slots still rendering at capture time", still_pending,
+                   static_cast<int>(ids.size()));
+      IM_CHECK_GT(still_pending, 0);
+    };
+  }
+
   // The co-shared border: with the edit modal open on one card, every OTHER card bound to the same
   // (crystal, filter) pair is outlined to say the in-flight edit will reach it too. That outline is
   // the one card-chrome colour not reachable from the scene above, because it needs a modal open.

--- a/test/gui/references/_thresholds.json
+++ b/test/gui/references/_thresholds.json
@@ -1,7 +1,7 @@
 {
   "groups": {
     "capture_harness": {
-      "generated_at": "2026-08-29T11:25:10",
+      "generated_at": "2026-08-29T14:16:09",
       "n_ref_runs": 10,
       "n_calib_runs": 10,
       "scenes": {

--- a/test/gui/references/left_panel_default.jpg
+++ b/test/gui/references/left_panel_default.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b85478db54d322cf55ced3c5308d8177de74ab91348595512b3c0649ac3c12f9
-size 15862
+oid sha256:27dcdbbe7fef11e2d45b080393788ee4dc141110517d271a18c94485af5c2745
+size 18896

--- a/test/gui/references/smoke_fullframe.png
+++ b/test/gui/references/smoke_fullframe.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2c05fd4a57a1af2d0a165785b58ffb27bf7557506e04aa52893d333a81e7837b
-size 109930
+oid sha256:d292ad268d089735aeee387b3607db22d5619a7a20b705f8729fea9fe41d6220
+size 109890

--- a/test/gui/test_gui_main.cpp
+++ b/test/gui/test_gui_main.cpp
@@ -34,6 +34,7 @@
 #include "gui/log_sink.hpp"
 #include "gui/panels.hpp"
 #include "gui/theme.hpp"
+#include "gui/theme_test_hooks.hpp"
 #include "gui/user_defaults.hpp"
 #include "imgui.h"
 #include "imgui_impl_glfw.h"
@@ -277,6 +278,10 @@ int main(int argc, char** argv) {
   const char* test_filter = nullptr;
   int core_log_level = LUMICE_LOG_INFO;  // Default: INFO
   int gui_log_level = LUMICE_LOG_INFO;
+  // --theme-palette contrast swaps in theme.cpp's test palette after the visual language is
+  // applied, so the same test can be captured twice and the two PNGs diffed. Off by default:
+  // every committed reference image is shot under the production palette.
+  bool use_contrast_palette = false;
   for (int i = 1; i < argc; i++) {
     if (strcmp(argv[i], "--filter") == 0 && i + 1 < argc) {
       test_filter = argv[++i];
@@ -301,6 +306,14 @@ int main(int argc, char** argv) {
     } else if (strcmp(argv[i], "--export-dir") == 0 && i + 1 < argc) {
       // Pin where GuiTestTempPath() writes, so a collector does not have to guess it.
       g_export_dir = argv[++i];
+    } else if (strcmp(argv[i], "--theme-palette") == 0 && i + 1 < argc) {
+      const char* which = argv[++i];
+      if (strcmp(which, "contrast") == 0) {
+        use_contrast_palette = true;
+      } else if (strcmp(which, "default") != 0) {
+        fprintf(stderr, "[FATAL] --theme-palette expects 'default' or 'contrast', got '%s'\n", which);
+        return 1;
+      }
     } else if (strcmp(argv[i], "--fixed-dt") == 0) {
       // Inject deterministic 16.67ms per-frame dt via the test engine and skip
       // the frame-limit sleep (decouples VSync frame-budget semantics from
@@ -437,6 +450,9 @@ int main(int argc, char** argv) {
   io.IniFilename = nullptr;
 
   gui::ApplyVisualLanguage(io);
+  if (use_contrast_palette) {
+    gui::ApplyContrastPaletteForTest(ImGui::GetStyle());
+  }
 
   ImGui_ImplGlfw_InitForOpenGL(window, true);
   ImGui_ImplOpenGL3_Init("#version 330");
@@ -535,6 +551,7 @@ int main(int argc, char** argv) {
   RegisterDefaultsPanelLayoutTests(engine);
   RegisterLensProjectionTests(engine);
   RegisterModalLayoutTests(engine);
+  RegisterThemeCoverageTests(engine);
   ImGuiTestEngine_QueueTests(engine, ImGuiTestGroup_Tests, test_filter);
 
   // Main loop — runs until all tests complete

--- a/test/gui/test_gui_main.cpp
+++ b/test/gui/test_gui_main.cpp
@@ -552,6 +552,7 @@ int main(int argc, char** argv) {
   RegisterLensProjectionTests(engine);
   RegisterModalLayoutTests(engine);
   RegisterThemeCoverageTests(engine);
+  RegisterThemeScanTests(engine);
   ImGuiTestEngine_QueueTests(engine, ImGuiTestGroup_Tests, test_filter);
 
   // Main loop — runs until all tests complete

--- a/test/gui/test_gui_shared.hpp
+++ b/test/gui/test_gui_shared.hpp
@@ -355,5 +355,6 @@ void RegisterLensProjectionTests(ImGuiTestEngine* engine);
 void RegisterModalLayoutTests(ImGuiTestEngine* engine);
 void RegisterDefaultsPanelTests(ImGuiTestEngine* engine);
 void RegisterDefaultsPanelLayoutTests(ImGuiTestEngine* engine);
+void RegisterThemeCoverageTests(ImGuiTestEngine* engine);
 
 #endif  // LUMICE_TEST_GUI_SHARED_HPP

--- a/test/gui/test_gui_shared.hpp
+++ b/test/gui/test_gui_shared.hpp
@@ -356,5 +356,6 @@ void RegisterModalLayoutTests(ImGuiTestEngine* engine);
 void RegisterDefaultsPanelTests(ImGuiTestEngine* engine);
 void RegisterDefaultsPanelLayoutTests(ImGuiTestEngine* engine);
 void RegisterThemeCoverageTests(ImGuiTestEngine* engine);
+void RegisterThemeScanTests(ImGuiTestEngine* engine);
 
 #endif  // LUMICE_TEST_GUI_SHARED_HPP


### PR DESCRIPTION
## 判据

把 GUI 里**没有跟着调色板走**的颜色全部收口，判据是 owner 提出的一句可观察后果：

> **换一套色盘（换皮肤）时，这处颜色跟不跟着变？**
> 跟着变 = 已收口；不跟着变 = 要么是泄漏（修），要么是**有名字的豁免**（登记在案）。

⛔ **本 PR 不交付第二套皮肤**（无主题切换 UI、无浅色主题、无持久化）。第二个色盘只作
**test-only 对照 oracle** 存在。

## 改动

**类 A —— `ImGuiCol` 色槽认领 47/58 → 58/58**
- `theme.hpp` 新增导出 `ApplyStyle(ImGuiStyle&)` seam；逐字移植 `feat/new-gui-layout` 的
  `test_theme_coverage.cpp`（哨兵值 `(-1,-2,-3,-4)` 填满 scratch style，要求无一存活）
- 补齐 11 个此前**被静默钉在 ImGui 原厂值上**的槽——不是"忘了设"：`StyleColorsDark()` 里一批槽是
  从别的槽复制/插值出来的，而 `ApplyPalette` 只改源槽，派生槽再没人碰

**类 B —— 调用点裸字面量逐处 disposition**
- 新增 `scripts/scan_theme_leaks.py`（层 A 通用逐像素比较 `--compare-dirs A B --tolerance T`
  + 层 B `theme_scan` 双色盘编排）与 `test/gui/functional/test_theme_scan.cpp`（8 场景 / 12 张矩形截图）
- **10 处泄漏已收编**；豁免逐条给理由，不默认放过

**两处自造蓝归 accent**
- 新增单一 owner `AccentColor(alpha)`；Composite 勾选框与 Colors 按钮三态改用 `WithAlpha(accent, …)` 派生
- "出现第二个徽章式染色即拆独立 `Palette` 角色"的触发条件已写进 `doc/gui-visual-language.md` §7

**文档**
- §7 改写为豁免类别 + 判据；§4.3 措辞校准为「不要大面积常驻填充；滑条静止态不上色」
  （字面版「强调色只在交互进行中出现」会否掉正解——`theme.cpp:171` 本就把 accent 给了静止的勾选态）

## ⚠️ 两处需要 reviewer 特别看的地方

1. **AC1 交付的是三类豁免，issue 写的是两类**。issue 明确要求收敛为「数据色 / 画布内容色」
   两类、其余一律视为泄漏；实际新增第三类**内容语义色**（`semantic_colors.hpp` 三档 +
   `kGoodBtn*`/`kBtnDestructive*`）。这是 plan 阶段以默认假设登记、经三轮 plan-review 未被否决、
   code-review 判定「不构成未记录偏离」的**记录在案的扩展**。仍然点出来的理由：issue 的整条论证
   正是「§7 的『结构色』因为类别够宽而吸收了泄漏」——所以任何**加宽豁免面**的改动都值得被单独看一眼。
2. **`AccentColor()` 靠读回 `ImGuiCol_CheckMark` 槽位取「当前 accent」**，依赖
   「`CheckMark == p.accent`」这条隐性不变量。若将来二者分歧需同步换源。

## oracle 抓到了手工普查抓不到的两处

- `crystal_renderer.cpp` 的 `glClearColor` —— GL 层调用，**任何 `ImVec4` 字面量 grep 都不会命中**
- Run 按钮的 `PushGoodButtonStyle()` —— 根本不在 issue 的候选清单上

这正是 issue 要求「以 oracle 产出为准、手工清单只用来对照有没有漏」的原因。

## 验证

- `./scripts/test.sh quick` → **RESULT: PASS**（ctest 28s / fast-e2e 92s / gui-correctness 17s，**309/309**）
- `check_policies` / `check_new_refs` / `check_new_gui_tests` / `check_loop_fatal_asserts` /
  `format.sh --check` 全部 exit=0
- code review 独立 reviewer 双视角 → **APPROVE**（0 Critical / 0 Major）
- **AC6 红态探针**：把一处已收编的字面量故意放回，扫描抓到、且**像素增量与被撤销区域精确对应**
  （不是"有东西变了"）；还原后三个数字逐字回绿。没有这一步的全绿不构成收口证据
- 参考图只重拍 `capture_harness/smoke_fullframe.png` 与手工 `visual/left_panel`；
  `modal_layout`/`defaults_panel_layout` 经**零容差逐像素**比对证实不受影响 ⇒ 不重拍。
  `_thresholds.json` 只动 `generated_at`，**阈值零改动**
- 已 rebase 到含 PR #278 的 `main`，并在 rebase 后**重新构建 + 重跑全部闸**（非沿用 rebase 前的绿）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ksvEyRTpnaMRHFEtLhJdy