### PR TITLE
fix(gui): Overlay 表格人工验收三条修复

### DIFF
--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -825,13 +825,12 @@ void RenderOverlaysTab() {
       continue;  // Empty fold cell: this overlay has no field the others lack.
     }
     ImGui::TableSetColumnIndex(5);
-    // The angle list is offered only while the circles are actually drawn — editing the angles of
-    // something invisible is a control with no feedback. The radius has no such gate: the markers'
-    // own Line checkbox is right there in the same row.
-    const bool circles_shown = g_state.show_sun_circles_line || g_state.show_sun_circles_label;
-    if (row.fold == OverlayFold::kSunCircleAngles && !circles_shown) {
-      continue;
-    }
+    // Unconditional, for both folds. Whether a row offers one is a property of the ROW — of whether
+    // it owns a field the others lack — and the fold cells of the four rows sit in one column,
+    // directly above one another. A cell left empty by anything else than "this row has no extra
+    // field" says the wrong thing in that column, which is what a condition on the circles being
+    // drawn used to say here: it read as the angle editor having gone missing, not as a considered
+    // state (test_overlay_controls.cpp pins this across both switches).
     if (ImGui::SmallButton((std::string(ICON_FA_ELLIPSIS) + row.fold_id).c_str())) {
       ImGui::OpenPopup(row.fold_id);
     }

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -698,8 +698,20 @@ void RenderSunCirclesAnglePopup() {
 // uncut name (doc/gui-visual-language.md §4.4).
 void RenderZenithNadirRadiusPopup() {
   const FieldEditorConstraint zn_r_c = ConstraintFor("overlay_zenith_nadir_radius_px", g_state);
-  SliderWithInput("Radius##zenith_nadir", &g_state.zenith_nadir_radius_px, static_cast<float>(zn_r_c.min_value),
-                  static_cast<float>(zn_r_c.max_value), zn_r_c.fmt, zn_r_c.scale);
+  // The same control the four alpha cells of this table use, one row above. It was a
+  // [slider][input][label] triple, which is a second answer to "how is a bounded float edited
+  // here?" given a cell's width away from the first one.
+  //
+  // The name has to be drawn here rather than passed in: DragFloatField folds its whole label
+  // argument into the widget id ("##" + label), so nothing of it is ever displayed. Worth drawing
+  // — the alpha cells get their name from the column header they sit under, and a fold has no
+  // header, so without this the popup would hold one bare number.
+  ImGui::AlignTextToFramePadding();
+  ImGui::TextUnformatted("Radius");
+  ImGui::SameLine();
+  ImGui::SetNextItemWidth(100.0f);
+  DragFloatField("Radius##zenith_nadir", &g_state.zenith_nadir_radius_px, static_cast<float>(zn_r_c.min_value),
+                 static_cast<float>(zn_r_c.max_value), zn_r_c.fmt, zn_r_c.scale);
 }
 
 // What a row's fold holds, when it holds anything. Two of the four overlays have a field the others
@@ -781,7 +793,11 @@ void RenderOverlaysTab() {
     return;
   }
   ImGui::TableSetupColumn("##color", ImGuiTableColumnFlags_WidthFixed, swatch_w);
-  ImGui::TableSetupColumn("Overlay", ImGuiTableColumnFlags_WidthStretch);
+  // Id only, no header text: this column's header would sit directly under the "Overlay" the
+  // group's own CollapsingHeader already carries, and a word repeated one line below itself reads
+  // as a second, different thing. The other four headers name what their cells hold, which the
+  // group title does not say.
+  ImGui::TableSetupColumn("##name", ImGuiTableColumnFlags_WidthStretch);
   ImGui::TableSetupColumn("Line", ImGuiTableColumnFlags_WidthFixed, std::max(check_w, ImGui::CalcTextSize("Line").x));
   ImGui::TableSetupColumn("Label", ImGuiTableColumnFlags_WidthFixed, std::max(check_w, ImGui::CalcTextSize("Label").x));
   ImGui::TableSetupColumn("Alpha", ImGuiTableColumnFlags_WidthFixed, kAlphaColWidth);

--- a/test/gui/functional/test_overlay_controls.cpp
+++ b/test/gui/functional/test_overlay_controls.cpp
@@ -158,71 +158,110 @@ void RegisterOverlayControlTests(ImGuiTestEngine* engine) {
   // The other half of "empty cell is the information": the fold column. Only two of the four rows
   // have a field the others lack, and only those two offer the button — a fold button on every row
   // would say the opposite of what this layout is for.
+  //
+  // Read in the DEFAULT document state, both sun-circle switches off, and that is the point: which
+  // rows offer a fold is a property of the ROWS — of which of them owns a field the others lack —
+  // and not of any other control's current value. Opening the one this case is named for is part of
+  // the same claim: a button that is offered but leads nowhere is not an offer.
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "overlay_controls", "only_the_rows_with_an_extra_field_offer_a_fold");
     t->TestFunc = [](ImGuiTestContext* ctx) {
       ResetTestState();
-      // The angle fold is gated on the circles being drawn (see the case below); turn them on so
-      // this case measures the fold column and not that gate.
-      gui::g_state.show_sun_circles_line = true;
+      const ScopedPopups popup_guard(ctx);
       ctx->Yield(3);
-      // Named ref for the reason the case above gives: without it a fold button scrolled out of
-      // view would satisfy the negative checks as readily as one that is not offered.
-      const ScopedRef panel_ref(ctx, "//##RightPanel");
+      IM_CHECK(!gui::g_state.show_sun_circles_line);
+      IM_CHECK(!gui::g_state.show_sun_circles_label);
 
-      IM_CHECK(!ctx->ItemExists("**/###horizon_fold"));
-      IM_CHECK(!ctx->ItemExists("**/###grid_fold"));
-      IM_CHECK(ctx->ItemExists("**/###sun_circles_fold"));
-      IM_CHECK(ctx->ItemExists("**/###zenith_nadir_fold"));
+      {
+        // Named ref for the reason the case above gives: without it a fold button scrolled out of
+        // view would satisfy the negative checks as readily as one that is not offered. Scoped to
+        // just this block because the editor it opens is a different window, which a
+        // panel-prefixed ref would exclude.
+        const ScopedRef panel_ref(ctx, "//##RightPanel");
 
-      gui::g_state.show_sun_circles_line = false;
+        IM_CHECK(!ctx->ItemExists("**/###horizon_fold"));
+        IM_CHECK(!ctx->ItemExists("**/###grid_fold"));
+        IM_CHECK(ctx->ItemExists("**/###sun_circles_fold"));
+        IM_CHECK(ctx->ItemExists("**/###zenith_nadir_fold"));
+
+        ctx->ItemClick("**/###sun_circles_fold");
+      }
+      ctx->Yield(3);
+      // A preset button, i.e. the angle editor really is on screen and not merely a button that
+      // consumed a click.
+      IM_CHECK(ctx->ItemExists("**/9\xc2\xb0"));
+
+      ctx->KeyPress(ImGuiKey_Escape);
       ctx->Yield(2);
     };
   }
 
-  // P32. The angle editor is offered only while a sun-circle overlay is actually being drawn —
-  // editing the angle list of something invisible is a control with no feedback.
+  // P32, restated. Reaching the angle editor is a property of the Angular Dist. row itself — the
+  // row owns a field the others lack, so it offers a fold — and not of whether the circles happen
+  // to be drawn at the moment. All four combinations of the row's two switches, because "reachable
+  // regardless" is a claim about the whole square and not about the one corner a new document
+  // opens in.
+  //
+  // It used to be the opposite claim: the button appeared only once a sun-circle overlay was on.
+  // Stacked vertically that condition had nothing to be read against; in the table its cell sits
+  // directly above an unconditional fold on the Zenith/Nadir row, and an empty cell there reads as
+  // the feature having gone missing rather than as a considered condition. There is deliberately
+  // no !ItemExists assertion left in this case — the invariant is that the fold is offered in
+  // every state, so any surviving negative check would be re-asserting the gate somewhere else.
   {
     ImGuiTest* t =
-        IM_REGISTER_TEST(engine, "overlay_controls", "the_angle_editor_is_offered_only_while_the_circles_show");
+        IM_REGISTER_TEST(engine, "overlay_controls", "the_angle_editor_is_reachable_regardless_of_the_circles_toggle");
     t->TestFunc = [](ImGuiTestContext* ctx) {
       ResetTestState();
       const ScopedPopups popup_guard(ctx);
       ctx->Yield(3);
-      // Everything this case looks up lives in the right panel, and it is named rather than left to
-      // the default ref because the negative checks below depend on it. The Overlay group is the
-      // last one in a scrollable panel; a wildcard lookup resolves an item by its LABEL, and the
-      // engine records no label for a clipped item, so a clipped button reads exactly like an
-      // absent one. The engine recovers by panning the window, but only when the ref names the
-      // window to pan. Without it, `!ItemExists` would be satisfied by "scrolled out of view" as
-      // readily as by "not offered", and whether the case passes would turn on whether some earlier
-      // ItemClick happened to scroll the panel first.
-      //
-      // Scoped as an object rather than a matching SetRef("") at the tail, for the same reason
-      // ScopedPopups above is: several of the IM_CHECKs this ref covers are exactly the ones a real
-      // regression would trip, and a fatal one exits the lambda before a tail-of-function SetRef("")
-      // would run, leaving the ref pinned for the rest of the test process.
-      const ScopedRef panel_ref(ctx, "//##RightPanel");
       IM_CHECK(!gui::g_state.show_sun_circles_line);
       IM_CHECK(!gui::g_state.show_sun_circles_label);
-      IM_CHECK(!ctx->ItemExists("**/###sun_circles_fold"));
 
-      // Either switch is enough — the lines and the labels are two ways of showing the same set.
-      ctx->ItemClick("**/##sun_circles_line");
+      // Both helpers name the right panel for their lookup, for the reason the cases above give: a
+      // fold button scrolled out of view is indistinguishable from one that is not offered unless
+      // the ref names the window the engine may pan. Neither helper reports a failure itself — it
+      // returns, and the caller checks — so a failure is fatal to the CASE instead of merely
+      // ending the helper and leaving the rest of the case driving an invalid state.
+      auto click_in_panel = [ctx](const char* item) {
+        const ScopedRef panel_ref(ctx, "//##RightPanel");
+        ctx->ItemClick(item);
+      };
+      auto editor_opens = [ctx]() -> bool {
+        {
+          const ScopedRef panel_ref(ctx, "//##RightPanel");
+          if (!ctx->ItemExists("**/###sun_circles_fold")) {
+            return false;
+          }
+          ctx->ItemClick("**/###sun_circles_fold");
+        }
+        ctx->Yield(3);
+        // Released before the lookup: the editor is a popup, a different window.
+        const bool opened = ctx->ItemExists("**/9\xc2\xb0");
+        ctx->KeyPress(ImGuiKey_Escape);
+        ctx->Yield(2);
+        return opened;
+      };
+
+      IM_CHECK(editor_opens());  // neither switch: the state a new document opens in
+
+      click_in_panel("**/##sun_circles_line");
       ctx->Yield(3);
       IM_CHECK(gui::g_state.show_sun_circles_line);
-      IM_CHECK(ctx->ItemExists("**/###sun_circles_fold"));
+      IM_CHECK(editor_opens());  // lines only
 
-      ctx->ItemClick("**/##sun_circles_line");
+      click_in_panel("**/##sun_circles_label");
       ctx->Yield(3);
-      IM_CHECK(!ctx->ItemExists("**/###sun_circles_fold"));
+      IM_CHECK(gui::g_state.show_sun_circles_label);
+      IM_CHECK(editor_opens());  // lines and labels
 
-      ctx->ItemClick("**/##sun_circles_label");
+      click_in_panel("**/##sun_circles_line");
       ctx->Yield(3);
-      IM_CHECK(ctx->ItemExists("**/###sun_circles_fold"));
+      IM_CHECK(!gui::g_state.show_sun_circles_line);
+      IM_CHECK(editor_opens());  // labels only
 
-      ctx->ItemClick("**/##sun_circles_label");
-      ctx->Yield(3);
+      click_in_panel("**/##sun_circles_label");
+      ctx->Yield(2);
     };
   }
 

--- a/test/gui/functional/test_overlay_controls.cpp
+++ b/test/gui/functional/test_overlay_controls.cpp
@@ -34,10 +34,17 @@
 // name, or a 22-degree halo circle added twice and drawn at double brightness.
 
 #include <algorithm>
+#include <cstring>
 #include <string>
 #include <vector>
 
 #include "gui/gui_state.hpp"
+// imgui_internal.h is normally an anti-pattern in this suite. One claim below has no public
+// reading: what text a table's HEADER draws. A blank header submits no addressable item, and the
+// word this one stopped drawing ("Overlay") is still on screen one line above it as the group's
+// CollapsingHeader — so a "**/Overlay" lookup answers about the wrong widget whether the header is
+// blank or not. TableGetColumnName reads the name the column was actually set up with.
+#include "imgui_internal.h"
 #include "test_gui_shared.hpp"
 
 namespace {
@@ -152,6 +159,28 @@ void RegisterOverlayControlTests(ImGuiTestEngine* engine) {
       IM_CHECK_NE(ctx->ItemInfo("**/##horizon_label").ID, (ImGuiID)0);
       IM_CHECK_NE(ctx->ItemInfo("**/##grid_label").ID, (ImGuiID)0);
       IM_CHECK_NE(ctx->ItemInfo("**/##sun_circles_label").ID, (ImGuiID)0);
+
+      // The header row. The name column draws none, because the group's own CollapsingHeader
+      // already says "Overlay" one line above it and a word repeated directly under itself reads as
+      // a second, different thing. Stated together with the four that DO draw one, so "blank"
+      // cannot be satisfied by a header row that failed to render at all. The table is found by the
+      // same three-seed id the swatch lookup above reconstructs.
+      const ImGuiTestItemInfo any_row = ctx->ItemInfo("**/##horizon_line");
+      ImGuiTable* table = nullptr;
+      if (any_row.Window != nullptr) {
+        table = ImGui::TableFindByID(ImGui::GetIDWithSeed("##OverlaysTable", nullptr, any_row.Window->ID));
+      }
+      IM_CHECK(table != nullptr);
+      // Everything from "##" on is id, not text — what a header draws is what comes before it.
+      auto header_text = [table](int column_n) {
+        const char* name = ImGui::TableGetColumnName(table, column_n);
+        const char* id_part = std::strstr(name, "##");
+        return std::string(name, id_part != nullptr ? static_cast<size_t>(id_part - name) : std::strlen(name));
+      };
+      IM_CHECK(header_text(1).empty());
+      IM_CHECK_EQ(header_text(2), std::string("Line"));
+      IM_CHECK_EQ(header_text(3), std::string("Label"));
+      IM_CHECK_EQ(header_text(4), std::string("Alpha"));
     };
   }
 
@@ -347,17 +376,20 @@ void RegisterOverlayControlTests(ImGuiTestEngine* engine) {
         // Named ref so the negative check reads "not submitted inline" and not "scrolled past" —
         // see the case above. Released before the popup, which is a different window.
         const ScopedRef panel_ref(ctx, "//##RightPanel");
-        IM_CHECK(!ctx->ItemExists("**/##Radius##zenith_nadir_input"));  // folded away, not shown inline
+        // The selector lost SliderWithInput's "_input" half along with the control: the radius is
+        // the same DragFloatField the alpha cells use now, and that submits ONE item whose id is
+        // "##" + the label it was handed.
+        IM_CHECK(!ctx->ItemExists("**/##Radius##zenith_nadir"));  // folded away, not shown inline
         ctx->ItemClick("**/###zenith_nadir_fold");
       }
       ctx->Yield(3);
 
       // Both ends of the declared domain (2..20 px), so the popup's control is the registry's
       // control and not a second opinion about the range.
-      ctx->ItemInputValue("**/##Radius##zenith_nadir_input", 100.0f);
+      ctx->ItemInputValue("**/##Radius##zenith_nadir", 100.0f);
       ctx->Yield();
       IM_CHECK_EQ(gui::g_state.zenith_nadir_radius_px, 20.0f);
-      ctx->ItemInputValue("**/##Radius##zenith_nadir_input", -5.0f);
+      ctx->ItemInputValue("**/##Radius##zenith_nadir", -5.0f);
       ctx->Yield();
       IM_CHECK_EQ(gui::g_state.zenith_nadir_radius_px, 2.0f);
 

--- a/test/gui/references/_thresholds.json
+++ b/test/gui/references/_thresholds.json
@@ -1,7 +1,7 @@
 {
   "groups": {
     "capture_harness": {
-      "generated_at": "2026-08-29T14:16:09",
+      "generated_at": "2026-08-29T21:28:45",
       "n_ref_runs": 10,
       "n_calib_runs": 10,
       "scenes": {

--- a/test/gui/references/smoke_fullframe.png
+++ b/test/gui/references/smoke_fullframe.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d292ad268d089735aeee387b3607db22d5619a7a20b705f8729fea9fe41d6220
-size 109890
+oid sha256:5abe57049c69ca297778a0875b475c4ef0feb1121feefc1789cf4cbf6e3aaa08
+size 109148


### PR DESCRIPTION
修掉 **owner 人工验收 PR #277（Overlay 六列表格）时上手发现的三条问题**。三条互相独立、都很小。

## 1. `Angular Dist.` 的折叠 `⋯` 在默认状态下根本不出现

⭐ **这个门不是 #277 引入的**，必须先说清楚，否则会修错方向。#277 之前的老代码有一模一样的门：

```cpp
if (g_state.show_sun_circles_line || g_state.show_sun_circles_label) {
  if (ImGui::Button("Edit Angles...##overlay")) { ... }
```

而 `show_sun_circles_line` / `show_sun_circles_label` **都默认 `false`**
（`gui_state.hpp:1025-1026`）⇒ 新文档上角度编辑器无从进入。
⇒ #277 的 AC4「行为等价」**字面为真，这不是移植缺陷**。

**真正变化的是这个门的代价**：老的竖直堆叠形态里，这颗条件按钮埋在 Angular Distance 那一块里，
旁边没有可比对象；新表格把四个折叠单元格放进**同一列、上下对齐**，而 `Zenith/Nadir` 的 `⋯`
**是无门的** ⇒ 不对称第一次变得可见，读起来就是「这个功能没了」。

**处置：去掉门**，两个折叠行完全对称。描述旧机制的注释**随门一起删除**——
机制没了注释还在，就是一块假路标。新注释陈述的是新不变量：
**「是否提供折叠是行的属性」**（该行有没有别人没有的字段），
所以那一列里的空单元格只能表示这一件事。

## 2. `Zenith/Nadir` 折叠里的半径仍是 `SliderWithInput`

同一张表里一行之隔的四个 alpha 已经是 `DragFloatField`，半径还是 slider+input+label 三件套——
「这里的有界浮点怎么编辑」在一个单元格的距离内给了两个答案。

**处置**：改用 `DragFloatField`。可见文字 "Radius" 需**单独画**（`TextUnformatted` + `SameLine`）——
`DragFloatField` 把整个 label 参数折进 widget id（`"##" + label`），永不显示。
保留这段文字的理由：alpha 单元格的名字来自列头，而折叠没有列头，不画就只剩一个裸数字。
域约束（`ConstraintFor` 的 min/max/fmt/scale）与无条件 `clamp` 行为不变。

## 3. 表头 "Overlay" 与组名重复

整组已经在 `CollapsingHeader("Overlay")` 底下，列头再写一遍 ⇒ 同屏出现两次，
且一个词出现在自己下面一行会被读成第二个不同的东西。

**处置**：名称列表头置空（`"##name"`）。名称列是**唯一的 stretch 列**，宽度不由列头文字决定
⇒ **列宽预算零改动**；其余四个列头照旧（它们说的是各自单元格装什么，组名说不了这个）。

## 为什么 #277 的全绿没拦住第 1 条

#277 的 AC5 量的是「一屏可见字段集合」与「常见操作步数」，
而**默认状态的截图里所有 overlay 开关都是关的** ⇒ 那一行「可见」，
但真正要用的控件不可达。**「行在场」与「控件可达」是两个命题**，当时只测了前一个。

⇒ 本 PR 的 AC5 要求补的正是**默认状态下的折叠可达性**用例，
且**先在未拆门的代码上确认它是红的**（否则它证明不了自己有牙），再拆门转绿。

## 验证

- `./scripts/test.sh quick` → **RESULT: PASS**（**309/309**）；`test.sh full` 亦通过
- `check_policies` / `check_new_refs` / `check_new_gui_tests` / `check_loop_fatal_asserts` /
  `format.sh --check` 全部 exit=0
- code review **APPROVE**（0 Critical / 0 Major）
- 以上闸在合并前由 drive owner **独立重新构建 + 重跑一遍**，非沿用 runner 自报
- 参考图只重拍 `capture_harness/smoke_fullframe.png`（43.16 dB → inf）；
  `lens_proj` / `modal_layout` / `defaults_panel_layout` 实测**零漂移**未重拍；
  `_thresholds.json` 只动 `generated_at`，**阈值仍锁 40.0 未放宽**

## 已知偏离（如实记录）

AC3 的断言手段与 plan 设想不同：plan 拟用单参数 `TableGetColumnName(1)` 判空串，
实测该重载依赖 `GImGui->CurrentTable`（测试跑在 `BeginTable`/`EndTable` 之外取不到），
且它存的是完整字符串 `"##name"` 而非空串 ⇒ 改用 `imgui_internal.h` 的 `TableFindByID` +
双参数重载并自行截 `"##"` 前缀。plan 已把该断言标为推测非事实，属推测被实测纠正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ksvEyRTpnaMRHFEtLhJdy