### PR TITLE
fix(gui): 行末标签列左缘对齐 + 间距收敛为单一 owner

### DIFF
--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -893,7 +893,7 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
 
   // ---- View Group ----
   if (ImGui::CollapsingHeader("View", ImGuiTreeNodeFlags_DefaultOpen)) {
-    ImGui::PushItemWidth(-(kLabelColWidth + ImGui::GetStyle().ItemInnerSpacing.x));
+    PushLabelColumnItemWidth();
     ImGui::SeparatorText("Lens");
     // Use BeginCombo + Selectable to honour kLensTypePresentationOrder (gui_state.hpp).
     // The enum value (r.lens_type) is preserved unchanged; only the display order differs.
@@ -994,7 +994,7 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
 
   // ---- Display Group ----
   if (ImGui::CollapsingHeader("Display", ImGuiTreeNodeFlags_DefaultOpen)) {
-    ImGui::PushItemWidth(-(kLabelColWidth + ImGui::GetStyle().ItemInnerSpacing.x));
+    PushLabelColumnItemWidth();
     ImGui::SeparatorText("Rendering");
     // Rust-tinted input: changing Resolution re-runs the simulation and discards accumulated rays.
     // The warning is the point — see doc/gui-visual-language.md §7.

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -893,7 +893,7 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
 
   // ---- View Group ----
   if (ImGui::CollapsingHeader("View", ImGuiTreeNodeFlags_DefaultOpen)) {
-    ImGui::PushItemWidth(-(kLabelColWidth + ImGui::GetStyle().ItemSpacing.x));
+    ImGui::PushItemWidth(-(kLabelColWidth + ImGui::GetStyle().ItemInnerSpacing.x));
     ImGui::SeparatorText("Lens");
     // Use BeginCombo + Selectable to honour kLensTypePresentationOrder (gui_state.hpp).
     // The enum value (r.lens_type) is preserved unchanged; only the display order differs.
@@ -994,7 +994,7 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
 
   // ---- Display Group ----
   if (ImGui::CollapsingHeader("Display", ImGuiTreeNodeFlags_DefaultOpen)) {
-    ImGui::PushItemWidth(-(kLabelColWidth + ImGui::GetStyle().ItemSpacing.x));
+    ImGui::PushItemWidth(-(kLabelColWidth + ImGui::GetStyle().ItemInnerSpacing.x));
     ImGui::SeparatorText("Rendering");
     // Rust-tinted input: changing Resolution re-runs the simulation and discards accumulated rays.
     // The warning is the point — see doc/gui-visual-language.md §7.

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -258,12 +258,11 @@ bool SliderWithPresetEdit(const char* label, float* value, float min_val, float 
   float spacing = ImGui::GetStyle().ItemSpacing.x;
   float avail_w = ImGui::GetContentRegionAvail().x;
   // mirrors PrepareSliderLayout: reserve the label column + the slider->input spacing + the
-  // input->label gap (ItemInnerSpacing.x, the gap ImGui's own Combo hardcodes — see there) with a
-  // trailing label; without it, still reserve the one slider->input spacing (SameLine at the
-  // input below adds it) — omitting it overflows the cell by one ItemSpacing.x and clips the arrow.
-  float slider_w = trailing_label ?
-                       (avail_w - kInputWidth - kLabelColWidth - spacing - ImGui::GetStyle().ItemInnerSpacing.x) :
-                       (avail_w - kInputWidth - spacing);
+  // input->label gap (LabelColumnGapX(), see panels.hpp) with a trailing label; without it, still
+  // reserve the one slider->input spacing (SameLine at the input below adds it) — omitting it
+  // overflows the cell by one ItemSpacing.x and clips the arrow.
+  float slider_w = trailing_label ? (avail_w - kInputWidth - kLabelColWidth - spacing - LabelColumnGapX()) :
+                                    (avail_w - kInputWidth - spacing);
   if (slider_w < 40.0f)
     slider_w = 40.0f;
 
@@ -310,7 +309,9 @@ bool SliderWithPresetEdit(const char* label, float* value, float min_val, float 
   *value = std::clamp(*value, min_val, max_val);
 
   if (trailing_label) {
-    ImGui::SameLine();
+    // Same gap as the width formula above reserved. A bare SameLine() would use ItemSpacing.x and
+    // land this label a few pixels off the column every other trailing label sits in.
+    ImGui::SameLine(0.0f, LabelColumnGapX());
     ImGui::TextUnformatted(display_buf);
   }
   return changed;

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -257,11 +257,13 @@ bool SliderWithPresetEdit(const char* label, float* value, float min_val, float 
 
   float spacing = ImGui::GetStyle().ItemSpacing.x;
   float avail_w = ImGui::GetContentRegionAvail().x;
-  // mirrors PrepareSliderLayout: reserve the label column + 2 spacings (slider->input, input->label)
-  // with a trailing label; without it, still reserve the one slider->input spacing (SameLine at the
+  // mirrors PrepareSliderLayout: reserve the label column + the slider->input spacing + the
+  // input->label gap (ItemInnerSpacing.x, the gap ImGui's own Combo hardcodes — see there) with a
+  // trailing label; without it, still reserve the one slider->input spacing (SameLine at the
   // input below adds it) — omitting it overflows the cell by one ItemSpacing.x and clips the arrow.
-  float slider_w =
-      trailing_label ? (avail_w - kInputWidth - kLabelColWidth - spacing * 2) : (avail_w - kInputWidth - spacing);
+  float slider_w = trailing_label ?
+                       (avail_w - kInputWidth - kLabelColWidth - spacing - ImGui::GetStyle().ItemInnerSpacing.x) :
+                       (avail_w - kInputWidth - spacing);
   if (slider_w < 40.0f)
     slider_w = 40.0f;
 

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -305,11 +305,20 @@ static float PrepareSliderLayout(const char* label, char* display_label_out, siz
   snprintf(label_id, label_id_size, "##%s_label", label);
 
   float spacing = ImGui::GetStyle().ItemSpacing.x;
+  float label_gap = ImGui::GetStyle().ItemInnerSpacing.x;
   float avail_w = ImGui::GetContentRegionAvail().x;
-  // With the trailing label: subtract kLabelColWidth + 2 SameLine spacings
-  // (slider→input, input→label). Without it: only the slider→input spacing.
-  float slider_w =
-      reserve_label_col ? (avail_w - kInputWidth - kLabelColWidth - spacing * 2) : (avail_w - kInputWidth - spacing);
+  // With the trailing label: subtract kLabelColWidth + the slider→input spacing + the
+  // input→label gap. Without it: only the slider→input spacing.
+  //
+  // The two gaps are different constants on purpose. The control→label gap is ItemInnerSpacing.x
+  // because ImGui's own Combo uses that one and hardcodes it inside BeginCombo, so a combo row and
+  // a row built here can only put their labels on the same vertical line if this side moves. It
+  // must stay paired with FinishSliderLayout's SameLine below: the label's x is
+  // (right edge − kLabelColWidth) whatever value the pair takes — the term cancels — but the
+  // CONTROL's right edge is this value, so a mismatched pair moves the controls out of their
+  // column while leaving the labels looking correct.
+  float slider_w = reserve_label_col ? (avail_w - kInputWidth - kLabelColWidth - spacing - label_gap) :
+                                       (avail_w - kInputWidth - spacing);
   if (slider_w < 40.0f)
     slider_w = 40.0f;
   return slider_w;
@@ -352,7 +361,7 @@ static void TextWithLabelProbe(const char* display_label, const char* probe_id) 
 
 // Render the label text after slider + input.
 static void FinishSliderLayout(const char* display_label, const char* label_id) {
-  ImGui::SameLine();
+  ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);  // paired with PrepareSliderLayout
   TextWithLabelProbe(display_label, label_id);
 }
 
@@ -1203,9 +1212,13 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
   // Right column — layout matches SliderWithInput's three-column model:
   //   [text / slider (text_w)] [Edit button / input (kInputWidth)] [row label (kLabelColWidth)]
   // so Row 1-3 align column boundaries with Row 4 automatically.
+  const float label_gap_x = ImGui::GetStyle().ItemInnerSpacing.x;
   float right_x = thumb_pos.x + thumb_display_size + spacing_x;
   float avail_w = ImGui::GetContentRegionAvail().x - thumb_display_size - spacing_x;
-  float text_w = std::max(40.0f, avail_w - kInputWidth - kLabelColWidth - spacing_x * 2);
+  // Same two-different-gaps split as PrepareSliderLayout, and for the same reason: the Weight row
+  // below is drawn by it, so a card whose button rows kept spacing_x on the label side would put
+  // its own four rows in two different columns.
+  float text_w = std::max(40.0f, avail_w - kInputWidth - kLabelColWidth - spacing_x - label_gap_x);
 
   auto emit_row = [&](int row_idx, const char* text_content, const char* btn_id, EditTarget target,
                       const char* row_label, bool clip_text, const char* tooltip = nullptr) {
@@ -1232,7 +1245,7 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
     if (ImGui::Button(btn_id, ImVec2(kInputWidth, 0))) {
       g_edit_request = { target, layer_idx, entry_idx };
     }
-    ImGui::SameLine();
+    ImGui::SameLine(0.0f, label_gap_x);  // paired with text_w above
     // Same addressable-label probe as FinishSliderLayout — this row shares the label column with
     // the Weight row below it, so the invariant is only checkable if both ends can be read.
     char label_probe_id[64];
@@ -1653,7 +1666,7 @@ void RenderSceneControls(GuiState& state) {
   if (ImGui::IsItemHovered()) {
     ImGui::SetTooltip("Angular diameter of the sun disk");
   }
-  ImGui::PushItemWidth(-(kLabelColWidth + ImGui::GetStyle().ItemSpacing.x));
+  ImGui::PushItemWidth(-(kLabelColWidth + ImGui::GetStyle().ItemInnerSpacing.x));
   // Combo carries kSpectrumCount presets + "Custom..." tail (item count = kSpectrumComboItemCount).
   // Built once from kSpectrumNames so adding/renaming a preset only requires editing kSpectrumNames.
   static const char* const* kSpectrumComboItems = [] {
@@ -1691,7 +1704,7 @@ void RenderSceneControls(GuiState& state) {
   }
 
   ImGui::SeparatorText("Simulation");
-  ImGui::PushItemWidth(-(kLabelColWidth + ImGui::GetStyle().ItemSpacing.x));
+  ImGui::PushItemWidth(-(kLabelColWidth + ImGui::GetStyle().ItemInnerSpacing.x));
   Checkbox("Infinite rays", &state.sim.infinite);
   if (ImGui::IsItemHovered()) {
     ImGui::SetTooltip("Run simulation continuously until manually stopped");

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -315,37 +315,45 @@ static float PrepareSliderLayout(const char* label, char* display_label_out, siz
   return slider_w;
 }
 
-// Give the row-trailing label text an addressable ID, without changing a single pixel.
+// Draw a row-trailing label that the GUI test engine can locate, without changing a single pixel.
 //
 // The three-column rows draw their trailing label with TextUnformatted, which submits its item
-// under id 0 — so the GUI test engine cannot locate it and cannot report its rectangle. That is
-// exactly the quantity the label-column alignment invariant is about, and deriving it from the
-// preceding widget's rectangle plus the spacing constant would compare the layout code against
-// itself. So the text is drawn first, then the cursor is put back on it and an InvisibleButton of
-// the same size is submitted over it: InvisibleButton draws nothing (RenderNavCursor is the only
-// thing it could draw, and it cannot fire here — see below), and IMGUI_TEST_ENGINE_ITEM_INFO in
-// its body is what makes the rectangle readable from a test.
+// under id 0 — so a test cannot ask where it is. That position is exactly the quantity the
+// label-column alignment invariant is about, and deriving it from the preceding widget's
+// rectangle plus a spacing constant would compare the layout code against itself. So an
+// InvisibleButton of the label's own size is submitted at the label's own position first: it
+// draws nothing, and the IMGUI_TEST_ENGINE_ITEM_INFO in its body is what makes the rectangle
+// readable. Its horizontal extent is the text's, exactly — same cursor x, same CalcTextSize —
+// which is the axis the invariant is stated on; vertically it sits on the line box rather than on
+// the glyph box, because the text's baseline offset is only applied inside TextEx.
 //
-// Why it does not perturb the app: without ImGuiButtonFlags_EnableNav, ImGui 1.91's
+// Order matters and is not interchangeable. ImGui derives a line's height from the LAST item
+// submitted on it (ItemSize reads DC.CurrLineSize, which the previous ItemSize zeroed), so a
+// probe submitted after the text ends the row on the probe's text-height box instead of the
+// row's frame-height box — one pixel per row, accumulating down the panel into a visible shift.
+// Submitting the probe first and then handing the line back (SameLine restores CurrLineSize and
+// the baseline offset from the probe's PrevLine values; SetCursorScreenPos puts x back) leaves
+// TextUnformatted as the item that closes the line, exactly as before.
+//
+// Why it does not perturb navigation: without ImGuiButtonFlags_EnableNav, ImGui 1.91's
 // InvisibleButton adds its item with ImGuiItemFlags_NoNav (imgui_widgets.cpp), so it takes no Tab
-// stop and no nav focus — the keyboard traversal order of every panel that uses these rows is
-// unchanged, and the nav cursor it would otherwise render can never be drawn. It is submitted
-// last on its line, so its ItemSize repeats the newline the text already performed and leaves the
-// cursor where the text left it.
-static void EmitLabelProbe(const char* probe_id, const ImVec2& label_min, const ImVec2& label_max) {
-  const ImVec2 size(label_max.x - label_min.x, label_max.y - label_min.y);
-  if (size.x <= 0.0f || size.y <= 0.0f) {
-    return;  // InvisibleButton asserts on a zero extent; an empty label has nothing to address.
+// stop and no nav focus — the keyboard traversal order of every panel built from these rows is
+// unchanged, and the nav cursor it would otherwise render can never be drawn.
+static void TextWithLabelProbe(const char* display_label, const char* probe_id) {
+  const ImVec2 size = ImGui::CalcTextSize(display_label);
+  if (size.x > 0.0f && size.y > 0.0f) {  // InvisibleButton asserts on a zero extent
+    const ImVec2 pos = ImGui::GetCursorScreenPos();
+    ImGui::InvisibleButton(probe_id, size);
+    ImGui::SameLine(0.0f, 0.0f);
+    ImGui::SetCursorScreenPos(pos);
   }
-  ImGui::SetCursorScreenPos(label_min);
-  ImGui::InvisibleButton(probe_id, size);
+  ImGui::TextUnformatted(display_label);
 }
 
 // Render the label text after slider + input.
 static void FinishSliderLayout(const char* display_label, const char* label_id) {
   ImGui::SameLine();
-  ImGui::TextUnformatted(display_label);
-  EmitLabelProbe(label_id, ImGui::GetItemRectMin(), ImGui::GetItemRectMax());
+  TextWithLabelProbe(display_label, label_id);
 }
 
 bool SliderWithInput(const char* label, float* value, float min_val, float max_val, const char* fmt, SliderScale scale,
@@ -1225,12 +1233,11 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
       g_edit_request = { target, layer_idx, entry_idx };
     }
     ImGui::SameLine();
-    ImGui::TextUnformatted(row_label);
     // Same addressable-label probe as FinishSliderLayout — this row shares the label column with
     // the Weight row below it, so the invariant is only checkable if both ends can be read.
     char label_probe_id[64];
     snprintf(label_probe_id, sizeof(label_probe_id), "##card_%d_%d_row_%d_label", layer_idx, entry_idx, row_idx);
-    EmitLabelProbe(label_probe_id, ImGui::GetItemRectMin(), ImGui::GetItemRectMax());
+    TextWithLabelProbe(row_label, label_probe_id);
   };
 
   // Row 1: Crystal type (resolved from pool)

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -279,6 +279,15 @@ namespace {
 }  // namespace
 
 
+// Sole owner of the control-to-trailing-label gap; rationale in panels.hpp.
+float LabelColumnGapX() {
+  return ImGui::GetStyle().ItemInnerSpacing.x;
+}
+
+void PushLabelColumnItemWidth() {
+  ImGui::PushItemWidth(-(kLabelColWidth + LabelColumnGapX()));
+}
+
 // Compute slider width and prepare IDs for the [slider] [input] Label layout.
 // Writes slider_id and input_id buffers, returns the computed slider width.
 // When `reserve_label_col` is false the trailing text label is omitted (table-cell
@@ -305,14 +314,13 @@ static float PrepareSliderLayout(const char* label, char* display_label_out, siz
   snprintf(label_id, label_id_size, "##%s_label", label);
 
   float spacing = ImGui::GetStyle().ItemSpacing.x;
-  float label_gap = ImGui::GetStyle().ItemInnerSpacing.x;
+  float label_gap = LabelColumnGapX();
   float avail_w = ImGui::GetContentRegionAvail().x;
   // With the trailing label: subtract kLabelColWidth + the slider→input spacing + the
   // input→label gap. Without it: only the slider→input spacing.
   //
-  // The two gaps are different constants on purpose. The control→label gap is ItemInnerSpacing.x
-  // because ImGui's own Combo uses that one and hardcodes it inside BeginCombo, so a combo row and
-  // a row built here can only put their labels on the same vertical line if this side moves. It
+  // The two gaps are different constants on purpose. The control→label gap comes from
+  // LabelColumnGapX() (see panels.hpp for why that value and not ItemSpacing.x). It
   // must stay paired with FinishSliderLayout's SameLine below: the label's x is
   // (right edge − kLabelColWidth) whatever value the pair takes — the term cancels — but the
   // CONTROL's right edge is this value, so a mismatched pair moves the controls out of their
@@ -361,7 +369,7 @@ static void TextWithLabelProbe(const char* display_label, const char* probe_id) 
 
 // Render the label text after slider + input.
 static void FinishSliderLayout(const char* display_label, const char* label_id) {
-  ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);  // paired with PrepareSliderLayout
+  ImGui::SameLine(0.0f, LabelColumnGapX());  // paired with PrepareSliderLayout
   TextWithLabelProbe(display_label, label_id);
 }
 
@@ -1212,7 +1220,7 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
   // Right column — layout matches SliderWithInput's three-column model:
   //   [text / slider (text_w)] [Edit button / input (kInputWidth)] [row label (kLabelColWidth)]
   // so Row 1-3 align column boundaries with Row 4 automatically.
-  const float label_gap_x = ImGui::GetStyle().ItemInnerSpacing.x;
+  const float label_gap_x = LabelColumnGapX();
   float right_x = thumb_pos.x + thumb_display_size + spacing_x;
   float avail_w = ImGui::GetContentRegionAvail().x - thumb_display_size - spacing_x;
   // Same two-different-gaps split as PrepareSliderLayout, and for the same reason: the Weight row
@@ -1666,7 +1674,7 @@ void RenderSceneControls(GuiState& state) {
   if (ImGui::IsItemHovered()) {
     ImGui::SetTooltip("Angular diameter of the sun disk");
   }
-  ImGui::PushItemWidth(-(kLabelColWidth + ImGui::GetStyle().ItemInnerSpacing.x));
+  PushLabelColumnItemWidth();
   // Combo carries kSpectrumCount presets + "Custom..." tail (item count = kSpectrumComboItemCount).
   // Built once from kSpectrumNames so adding/renaming a preset only requires editing kSpectrumNames.
   static const char* const* kSpectrumComboItems = [] {
@@ -1704,7 +1712,7 @@ void RenderSceneControls(GuiState& state) {
   }
 
   ImGui::SeparatorText("Simulation");
-  ImGui::PushItemWidth(-(kLabelColWidth + ImGui::GetStyle().ItemInnerSpacing.x));
+  PushLabelColumnItemWidth();
   Checkbox("Infinite rays", &state.sim.infinite);
   if (ImGui::IsItemHovered()) {
     ImGui::SetTooltip("Run simulation continuously until manually stopped");

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -286,8 +286,8 @@ namespace {
 // so the [slider][input] pair fills the whole cell (GetContentRegionAvail() ==
 // column width inside a BeginTable cell).
 static float PrepareSliderLayout(const char* label, char* display_label_out, size_t display_buf_size, char* slider_id,
-                                 size_t slider_id_size, char* input_id, size_t input_id_size,
-                                 bool reserve_label_col = true) {
+                                 size_t slider_id_size, char* input_id, size_t input_id_size, char* label_id,
+                                 size_t label_id_size, bool reserve_label_col = true) {
   // Strip ImGui ID suffix (e.g. "Azimuth##view" → display "Azimuth")
   const char* hash_pos = strstr(label, "##");
   if (hash_pos) {
@@ -302,6 +302,7 @@ static float PrepareSliderLayout(const char* label, char* display_label_out, siz
 
   snprintf(slider_id, slider_id_size, "##%s_slider", label);
   snprintf(input_id, input_id_size, "##%s_input", label);
+  snprintf(label_id, label_id_size, "##%s_label", label);
 
   float spacing = ImGui::GetStyle().ItemSpacing.x;
   float avail_w = ImGui::GetContentRegionAvail().x;
@@ -314,10 +315,37 @@ static float PrepareSliderLayout(const char* label, char* display_label_out, siz
   return slider_w;
 }
 
+// Give the row-trailing label text an addressable ID, without changing a single pixel.
+//
+// The three-column rows draw their trailing label with TextUnformatted, which submits its item
+// under id 0 — so the GUI test engine cannot locate it and cannot report its rectangle. That is
+// exactly the quantity the label-column alignment invariant is about, and deriving it from the
+// preceding widget's rectangle plus the spacing constant would compare the layout code against
+// itself. So the text is drawn first, then the cursor is put back on it and an InvisibleButton of
+// the same size is submitted over it: InvisibleButton draws nothing (RenderNavCursor is the only
+// thing it could draw, and it cannot fire here — see below), and IMGUI_TEST_ENGINE_ITEM_INFO in
+// its body is what makes the rectangle readable from a test.
+//
+// Why it does not perturb the app: without ImGuiButtonFlags_EnableNav, ImGui 1.91's
+// InvisibleButton adds its item with ImGuiItemFlags_NoNav (imgui_widgets.cpp), so it takes no Tab
+// stop and no nav focus — the keyboard traversal order of every panel that uses these rows is
+// unchanged, and the nav cursor it would otherwise render can never be drawn. It is submitted
+// last on its line, so its ItemSize repeats the newline the text already performed and leaves the
+// cursor where the text left it.
+static void EmitLabelProbe(const char* probe_id, const ImVec2& label_min, const ImVec2& label_max) {
+  const ImVec2 size(label_max.x - label_min.x, label_max.y - label_min.y);
+  if (size.x <= 0.0f || size.y <= 0.0f) {
+    return;  // InvisibleButton asserts on a zero extent; an empty label has nothing to address.
+  }
+  ImGui::SetCursorScreenPos(label_min);
+  ImGui::InvisibleButton(probe_id, size);
+}
+
 // Render the label text after slider + input.
-static void FinishSliderLayout(const char* display_label) {
+static void FinishSliderLayout(const char* display_label, const char* label_id) {
   ImGui::SameLine();
   ImGui::TextUnformatted(display_label);
+  EmitLabelProbe(label_id, ImGui::GetItemRectMin(), ImGui::GetItemRectMax());
 }
 
 bool SliderWithInput(const char* label, float* value, float min_val, float max_val, const char* fmt, SliderScale scale,
@@ -325,8 +353,9 @@ bool SliderWithInput(const char* label, float* value, float min_val, float max_v
   char display_buf[64];
   char slider_id[64];
   char input_id[64];
+  char label_id[64];
   float slider_w = PrepareSliderLayout(label, display_buf, sizeof(display_buf), slider_id, sizeof(slider_id), input_id,
-                                       sizeof(input_id), trailing_label);
+                                       sizeof(input_id), label_id, sizeof(label_id), trailing_label);
 
   const float old_value = *value;
 
@@ -353,7 +382,7 @@ bool SliderWithInput(const char* label, float* value, float min_val, float max_v
   }
 
   if (trailing_label) {
-    FinishSliderLayout(display_buf);
+    FinishSliderLayout(display_buf, label_id);
   }
   return *value != old_value;
 }
@@ -397,8 +426,9 @@ bool SliderIntWithInput(const char* label, int* value, int min_val, int max_val,
   char display_buf[64];
   char slider_id[64];
   char input_id[64];
+  char label_id[64];
   float slider_w = PrepareSliderLayout(label, display_buf, sizeof(display_buf), slider_id, sizeof(slider_id), input_id,
-                                       sizeof(input_id), trailing_label);
+                                       sizeof(input_id), label_id, sizeof(label_id), trailing_label);
 
   const int old_value = *value;
 
@@ -424,7 +454,7 @@ bool SliderIntWithInput(const char* label, int* value, int min_val, int max_val,
     *active = slider_active || input_active;
   }
 
-  FinishSliderLayout(display_buf);
+  FinishSliderLayout(display_buf, label_id);
   return *value != old_value;
 }
 
@@ -1196,6 +1226,11 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
     }
     ImGui::SameLine();
     ImGui::TextUnformatted(row_label);
+    // Same addressable-label probe as FinishSliderLayout — this row shares the label column with
+    // the Weight row below it, so the invariant is only checkable if both ends can be read.
+    char label_probe_id[64];
+    snprintf(label_probe_id, sizeof(label_probe_id), "##card_%d_%d_row_%d_label", layer_idx, entry_idx, row_idx);
+    EmitLabelProbe(label_probe_id, ImGui::GetItemRectMin(), ImGui::GetItemRectMax());
   };
 
   // Row 1: Crystal type (resolved from pool)

--- a/src/gui/panels.hpp
+++ b/src/gui/panels.hpp
@@ -10,6 +10,32 @@ namespace lumice::gui {
 // Slider scale modes for SliderWithInput
 enum class SliderScale { kLinear, kSqrt, kLog, kLogLinear };
 
+// ---- Trailing-label column ----
+
+// The one place this repo decides how wide the gap between a row's last control and its
+// row-trailing label is. Every consumer of that gap — the [slider][input] Label rows, the entry
+// card's button rows, the combo rows, and the wedge-angle editor's mirror of the same layout —
+// takes its value from here, so the gap is a single edit rather than a set of copies that happen
+// to agree today.
+//
+// It forwards ImGui's ItemInnerSpacing.x rather than introducing a constant of its own, and that
+// is deliberate: ImGui's own Combo hardcodes ItemInnerSpacing.x between the frame and the label
+// inside BeginCombo, where no caller can reach it. A combo row and a row laid out here can only
+// put their labels on the same vertical line if this side takes that value; a private constant
+// would just be a second source that has to be kept equal to it by hand.
+float LabelColumnGapX();
+
+// PushItemWidth for a control that is followed by nothing but the row-trailing label: takes the
+// full content width minus the label column and the gap above.
+//
+// This exists as a function rather than an expression repeated at each call site because it is
+// the one shape where the whole expression, not just the gap, is identical everywhere it appears
+// (the Spectrum combo, a no-op push around a Checkbox that reads no item width, and the Lens Type
+// / Resolution combos). The [slider][input] Label rows compute a width from the same gap but also
+// subtract the input column and the slider-to-input spacing, so they take LabelColumnGapX()
+// directly and keep their own formula.
+void PushLabelColumnItemWidth();
+
 // One control per value: a single DragFloat where a [slider][input] pair would otherwise sit.
 // Ctrl+click (or, with io.ConfigDragClickToInputText on, a plain click-release) types an exact
 // value, so the input half is not lost, it is folded in. The item id is "##<label>", with no

--- a/test/gui/functional/test_entry_management.cpp
+++ b/test/gui/functional/test_entry_management.cpp
@@ -1005,4 +1005,31 @@ void RegisterEntryManagementTests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(gui::CountEntriesSharing(gui::g_state, 0, std::nullopt), 2);
     };
   }
+
+  // A card's four rows are one three-column grid: Crystal/Axis/Filter are hand-built
+  // [text][Edit button][label] rows in RenderEntryCard, Weight is a SliderWithInput, and the
+  // comment above emit_row states outright that the four are meant to share their column
+  // boundaries. They are drawn by two different pieces of code that each compute the boundary
+  // from their own copy of the same formula, so the claim is exactly as strong as those two
+  // copies agreeing — which nothing else checks.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "entry_management", "a_cards_four_rows_share_their_column_boundaries");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(3);
+      // One card, so the Edit buttons' labels are unambiguous for the wildcard search below.
+      IM_CHECK_EQ(gui::g_state.layers[0].entries.size(), (size_t)1);
+
+      // Collected before anything is asserted: every ImGuiTestContext action opens with
+      // `if (IsError()) return;`, so an assertion between two ItemInfo calls would leave the rest
+      // of the rows unmeasured and report the first offender as if it were the only one.
+      std::vector<LabelColumnRow> rows;
+      rows.push_back(MeasureWidgetRow(ctx, "Crystal", "**/Edit##cr", "**/##card_0_0_row_0_label"));
+      rows.push_back(MeasureWidgetRow(ctx, "Axis", "**/Edit##ax", "**/##card_0_0_row_1_label"));
+      rows.push_back(MeasureWidgetRow(ctx, "Filter", "**/Edit##fi", "**/##card_0_0_row_2_label"));
+      rows.push_back(MeasureWidgetRow(ctx, "Weight", "**/##Weight##prop_0_0_input", "**/##Weight##prop_0_0_label"));
+
+      CheckLabelColumn("entry card", rows);
+    };
+  }
 }

--- a/test/gui/functional/test_scene_controls.cpp
+++ b/test/gui/functional/test_scene_controls.cpp
@@ -488,4 +488,36 @@ void RegisterSceneControlTests(ImGuiTestEngine* engine) {
       }
     };
   }
+
+  // The Scene group's half of the trailing-label column. Two widget families share this group's
+  // three-column rows and neither can see the other: the four sun/simulation rows are hand-built
+  // in panels.cpp, the Spectrum row is an ImGui Combo that places its own label at a spacing
+  // constant hardcoded inside BeginCombo. Both boundaries are asserted, because the two are one
+  // decision: the label column can be squared up by widening the controls of one family only, and
+  // that trades a visible misalignment for a different one.
+  {
+    ImGuiTest* t =
+        IM_REGISTER_TEST(engine, "scene_controls", "the_trailing_label_column_is_one_line_across_row_families");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(3);
+
+      // Collected before anything is asserted: every ImGuiTestContext action opens with
+      // `if (IsError()) return;`, so an assertion between two ItemInfo calls would leave the rest
+      // of the rows unmeasured and report the first offender as if it were the only one.
+      // Addressed under the panel window rather than through "**/": a wildcard resolves by the
+      // debug label an item registers, and BeginCombo registers none — the Spectrum row would be
+      // unreachable, which is the row the invariant is about.
+      ctx->SetRef("//##RightPanel");
+      std::vector<LabelColumnRow> rows;
+      rows.push_back(MeasureWidgetRow(ctx, "Altitude", "##Altitude_input", "##Altitude_label"));
+      rows.push_back(MeasureWidgetRow(ctx, "Diameter", "##Diameter_input", "##Diameter_label"));
+      rows.push_back(MeasureComboRow(ctx, "Spectrum", "Spectrum"));
+      rows.push_back(MeasureWidgetRow(ctx, "Rays(M)", "##Rays(M)_input", "##Rays(M)_label"));
+      rows.push_back(MeasureWidgetRow(ctx, "Max hits", "##Max hits_input", "##Max hits_label"));
+      ctx->SetRef("");
+
+      CheckLabelColumn("scene", rows);
+    };
+  }
 }

--- a/test/gui/functional/test_view_display_controls.cpp
+++ b/test/gui/functional/test_view_display_controls.cpp
@@ -733,4 +733,49 @@ void RegisterViewDisplayControlTests(ImGuiTestEngine* engine) {
       // The background is handed back by ScopedBackground.
     };
   }
+
+  // The View and Display groups' half of the trailing-label column, stated per group because each
+  // group is its own PushItemWidth scope and the two could drift apart without either one being
+  // internally inconsistent. Both families are present in each: hand-built [slider][input] rows
+  // from panels.cpp, and ImGui Combos that place their own label at a spacing constant hardcoded
+  // inside BeginCombo. Control right edges are asserted alongside label left edges — squaring up
+  // the labels by widening one family's controls only would trade one visible misalignment for
+  // another.
+  {
+    ImGuiTest* t =
+        IM_REGISTER_TEST(engine, "view_display_controls", "the_trailing_label_column_is_one_line_across_row_families");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(3);
+
+      // Collected before anything is asserted: every ImGuiTestContext action opens with
+      // `if (IsError()) return;`, so an assertion between two ItemInfo calls would leave the rest
+      // of the rows unmeasured and report the first offender as if it were the only one.
+      // Addressed under the panel window rather than through "**/": a wildcard resolves by the
+      // debug label an item registers, and BeginCombo registers none — the three combo rows would
+      // be unreachable, which are the rows the invariant is about.
+      ctx->SetRef("//##RightPanel");
+      std::vector<LabelColumnRow> view;
+      view.push_back(MeasureComboRow(ctx, "Lens Type", "Lens Type##view"));
+      view.push_back(MeasureWidgetRow(ctx, "FOV", "##FOV##view_input", "##FOV##view_label"));
+      view.push_back(MeasureWidgetRow(ctx, "Elevation", "##Elevation##view_input", "##Elevation##view_label"));
+      view.push_back(MeasureWidgetRow(ctx, "Azimuth", "##Azimuth##view_input", "##Azimuth##view_label"));
+      view.push_back(MeasureWidgetRow(ctx, "Roll", "##Roll##view_input", "##Roll##view_label"));
+
+      std::vector<LabelColumnRow> display;
+      display.push_back(MeasureComboRow(ctx, "Resolution", "Resolution##display"));
+      display.push_back(MeasureWidgetRow(ctx, "EV", "##EV##display_input", "##EV##display_label"));
+      display.push_back(MeasureComboRow(ctx, "Preset", "Preset##display_aspect"));
+      display.push_back(MeasureWidgetRow(ctx, "Alpha", "##Alpha##display_input", "##Alpha##display_label"));
+      display.push_back(
+          MeasureWidgetRow(ctx, "Offset X", "##Offset X##display_bg_input", "##Offset X##display_bg_label"));
+      display.push_back(
+          MeasureWidgetRow(ctx, "Offset Y", "##Offset Y##display_bg_input", "##Offset Y##display_bg_label"));
+      display.push_back(MeasureWidgetRow(ctx, "Zoom", "##Zoom##display_bg_input", "##Zoom##display_bg_label"));
+      ctx->SetRef("");
+
+      CheckLabelColumn("view", view);
+      CheckLabelColumn("display", display);
+    };
+  }
 }

--- a/test/gui/references/_thresholds.json
+++ b/test/gui/references/_thresholds.json
@@ -1,7 +1,7 @@
 {
   "groups": {
     "capture_harness": {
-      "generated_at": "2026-08-29T21:28:45",
+      "generated_at": "2026-08-30T04:00:08",
       "n_ref_runs": 10,
       "n_calib_runs": 10,
       "scenes": {

--- a/test/gui/references/left_panel_default.jpg
+++ b/test/gui/references/left_panel_default.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:27dcdbbe7fef11e2d45b080393788ee4dc141110517d271a18c94485af5c2745
-size 18896
+oid sha256:6ba55032022956dda3027519bb645e79093e43688de0fb76fd33b35e0cbc5686
+size 18979

--- a/test/gui/references/smoke_fullframe.png
+++ b/test/gui/references/smoke_fullframe.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5abe57049c69ca297778a0875b475c4ef0feb1121feefc1789cf4cbf6e3aaa08
-size 109148
+oid sha256:8e9b37eb270f4bda6b2bdb778cf019312f4fbba30ea24bc90d5d522148026f49
+size 109146

--- a/test/gui/test_gui_shared.hpp
+++ b/test/gui/test_gui_shared.hpp
@@ -324,16 +324,157 @@ inline LabelColumnRow MeasureWidgetRow(ImGuiTestContext* ctx, const char* name, 
 // from: BeginCombo registers its item with the NAV rectangle — the drawn frame, label excluded
 // (`ItemAdd(total_bb, id, &bb)`, imgui_widgets.cpp; the test engine records the third argument) —
 // and never calls the test engine's label hook at all, so the label is neither addressable nor
-// inside the reported rectangle. What IS pinned down is where BeginCombo puts it: at
-// `bb.Max.x + style.ItemInnerSpacing.x`, a constant hardcoded in that function. So the frame's
-// right edge is measured and the label's left edge is that plus the one ImGui spacing — no
-// constant from the panel code enters, which is what keeps this from restating the layout code.
-// (Being unable to change that constant from outside is the reason the panel had to move to it.)
+// inside the reported rectangle.
+//
+// So the label's left edge is read off the rendered frame instead: a strip of the default
+// framebuffer immediately right of the combo is captured and scanned column by column for the
+// first one carrying ink. Deriving it instead as `frame right + style.ItemInnerSpacing.x` — the
+// spacing BeginCombo is known to hardcode — would be the layout formula this file exists to
+// check, evaluated a second time: it agrees with the drawn label by construction, and stays in
+// agreement if BeginCombo ever stops putting the label there, or if that spacing changes under
+// the row while the frame stays put. Neither is hypothetical; both are exactly the class of drift
+// the trailing-label invariant is about.
+//
+// The frame's own rectangle is still taken from ItemInfo. That is not the same circularity: it is
+// geometry ImGui reports about the item it drew, not a position this test recomputed.
+//
+// The two families' `label_left` therefore mean slightly different things — a hand-built row
+// reports the text's layout origin (CalcTextSize's box, via the InvisibleButton probe), a combo
+// row reports the leftmost inked pixel of the first glyph. They differ by that glyph's left side
+// bearing, which varies per letter, so it is taken back out below from the font's own metrics
+// rather than absorbed into a wider tolerance — a tolerance wide enough to swallow a per-letter
+// offset would be wide enough to swallow part of the defect being looked for.
 inline LabelColumnRow MeasureComboRow(ImGuiTestContext* ctx, const char* name, const char* combo_ref) {
   LabelColumnRow row;
   row.name = name;
-  row.control_right = ctx->ItemInfo(combo_ref).RectFull.Max.x;
-  row.label_left = row.control_right + ImGui::GetStyle().ItemInnerSpacing.x;
+
+  // A tooltip drawn over the strip would be scanned as if it were the label. The panels measured
+  // here attach tooltips to their combos, so the pointer is parked off-window first — same
+  // reason visual/left_panel and modal_layout do it before their captures. Done before the
+  // geometry is read so the frame rectangle and the captured pixels describe the same frame.
+  ctx->MouseMoveToPos(ImVec2(-100.0f, -100.0f));
+  ctx->Yield(2);
+
+  const ImRect frame = ctx->ItemInfo(combo_ref).RectFull;
+  row.control_right = frame.Max.x;
+
+  // How far right of the frame the label is searched for. A bound on the search, NOT a source for
+  // the answer — the scan stops at the first inked column, so extra width past the label costs
+  // nothing. Deliberately not the panel's own kLabelColWidth: a layout constant has no business
+  // in an assertion about the layout, not even as a loop bound.
+  constexpr float kProbeWidthPx = 96.0f;
+  // Ink test: sum of |Δ| over R/G/B against the row's own background. The panel background and
+  // the label text are far apart (see the measured margin printed below), so this sits well
+  // clear of both the flat background and the faintest antialiased glyph edge.
+  constexpr int kInkThresholdSum = 32;
+  // Physical pixels of the frame→label gap skipped before sampling the background, so the frame
+  // border's own antialiasing cannot be mistaken for it. The gap is 4 logical px at minimum, so
+  // 2 physical columns are skipped even at scale 1.
+  constexpr int kBorderSkipPx = 2;
+
+  const ImGuiIO& io = ImGui::GetIO();
+  const float sx = io.DisplayFramebufferScale.x;
+  const float sy = io.DisplayFramebufferScale.y;
+  const float win_w = io.DisplaySize.x;
+  const float win_h = io.DisplaySize.y;
+  IM_CHECK_RETV(sx > 0.0f && sy > 0.0f && win_w > 0.0f && win_h > 0.0f, row);
+  auto to_px = [](float v) { return static_cast<int>(ImFloor(v + 0.5f)); };
+  const int fb_w = to_px(win_w * sx);
+  const int fb_h = to_px(win_h * sy);
+
+  // ImGui (origin top-left, window coords) -> glReadPixels (origin bottom-left, framebuffer).
+  const ImVec2 vp_pos = ImGui::GetMainViewport()->Pos;
+  const float lx = frame.Max.x - vp_pos.x;
+  const float ly = frame.Min.y - vp_pos.y;
+  const float lh = frame.Max.y - frame.Min.y;
+  const int rx = to_px(lx * sx);
+  const int ry = to_px((win_h - (ly + lh)) * sy);
+  const int rh = to_px(lh * sy);
+  // Clipped to the framebuffer: the panel these rows live in is docked against the right edge of
+  // the window, so the label column can end within a few pixels of it and the full probe width
+  // would not fit. Clipping the search window is harmless (the scan stops at the first ink); what
+  // must not happen is reading outside the readback rectangle.
+  const int rw = ImMin(to_px(kProbeWidthPx * sx), fb_w - rx);
+  IM_CHECK_RETV(rx >= 0 && ry >= 0 && rh > 0, row);
+  IM_CHECK_RETV(rw > kBorderSkipPx + 1, row);
+  IM_CHECK_RETV(ry + rh <= fb_h, row);
+
+  g_fullframe_capture.Reset();
+  g_fullframe_capture.rect_x = rx;
+  g_fullframe_capture.rect_y = ry;
+  g_fullframe_capture.rect_w = rw;
+  g_fullframe_capture.rect_h = rh;
+  g_fullframe_capture.requested.store(true);
+  for (int i = 0; i < 10 && !g_fullframe_capture.done.load(); ++i) {
+    ctx->Yield(1);
+  }
+  IM_CHECK_RETV(g_fullframe_capture.done.load(), row);
+  IM_CHECK_RETV(g_fullframe_capture.width == rw && g_fullframe_capture.height == rh, row);
+  IM_CHECK_RETV(g_fullframe_capture.pixels.size() == static_cast<size_t>(rw) * rh * 4, row);
+
+  // Pixels come back top-down RGBA (ReadbackGlRegionToRgba flips for PNG).
+  const unsigned char* px = g_fullframe_capture.pixels.data();
+  auto channel = [&](int col, int r, int ch) {
+    return static_cast<int>(px[(static_cast<size_t>(r) * rw + col) * 4 + ch]);
+  };
+  // Background is sampled from the frame→label gap of THIS row rather than from a theme constant:
+  // a constant would be a second copy of a value the code under test also reads.
+  const int bg_col = kBorderSkipPx;
+  const int bg_row = rh / 2;
+  const int bg_r = channel(bg_col, bg_row, 0);
+  const int bg_g = channel(bg_col, bg_row, 1);
+  const int bg_b = channel(bg_col, bg_row, 2);
+
+  int hit_col = -1;
+  int max_diff_seen = 0;
+  for (int col = bg_col + 1; col < rw && hit_col < 0; ++col) {
+    for (int r = 0; r < rh; ++r) {
+      const int diff =
+          ImAbs(channel(col, r, 0) - bg_r) + ImAbs(channel(col, r, 1) - bg_g) + ImAbs(channel(col, r, 2) - bg_b);
+      if (diff > max_diff_seen) {
+        max_diff_seen = diff;
+      }
+      if (diff > kInkThresholdSum) {
+        hit_col = col;
+        break;
+      }
+    }
+  }
+  if (hit_col < 0) {
+    // Not silently degraded to a guess: either the label was not drawn or the strip was computed
+    // wrong, and both have to be visible as failures rather than as a plausible number.
+    IM_ERRORF("%s: no label ink found in strip (%d,%d,%d,%d), bg=(%d,%d,%d), max channel sum diff %d", name, rx, ry, rw,
+              rh, bg_r, bg_g, bg_b, max_diff_seen);
+    return row;
+  }
+
+  // Take the first glyph's left side bearing back out, so the result names the text's layout
+  // origin — the same quantity MeasureWidgetRow's probe reports. The bearing comes from the font,
+  // which is a property of the glyph and not of where the label was placed, so this corrects a
+  // units mismatch without reintroducing the layout formula.
+  //
+  // In WHOLE physical pixels, and that is the point rather than a rounding shortcut: `hit_col` is
+  // already a floor (the first pixel column the glyph put any ink in, i.e. the bearing's whole-
+  // pixel part is exactly the number of blank columns it left), so subtracting the bearing's
+  // fractional part as well would count the same flooring twice and bias the answer left by it.
+  // The first character of `combo_ref` is the first character of the drawn label: ImGui cuts the
+  // label at "##", and neither is a legal leading character for one.
+  int bearing_px = 0;
+  if (combo_ref[0] != '\0') {
+    ImFont* font = ImGui::GetFont();
+    const ImFontGlyph* glyph = font ? font->FindGlyph(static_cast<ImWchar>(combo_ref[0])) : nullptr;
+    if (glyph != nullptr && font->FontSize > 0.0f) {
+      bearing_px = static_cast<int>(ImFloor(glyph->X0 * (ImGui::GetFontSize() / font->FontSize) * sx));
+    }
+  }
+  row.label_left = vp_pos.x + static_cast<float>(rx + hit_col - bearing_px) / sx;
+  // Kept rather than removed after bring-up: the residual error of this measurement is one
+  // physical pixel, so what kLabelTolPx has to cover depends on the framebuffer scale of whoever
+  // is running it, and that number is not otherwise visible anywhere in the output.
+  fprintf(stderr,
+          "[label_column] %s: fbscale=(%.1f,%.1f) strip=(%d,%d,%d,%d) bg=(%d,%d,%d) hit_col=%d bearing_px=%d "
+          "label_left=%.2f control_right=%.2f\n",
+          name, sx, sy, rx, ry, rw, rh, bg_r, bg_g, bg_b, hit_col, bearing_px, row.label_left, row.control_right);
   return row;
 }
 
@@ -341,19 +482,28 @@ inline LabelColumnRow MeasureComboRow(ImGuiTestContext* ctx, const char* name, c
 //
 // Non-fatal per row on purpose: the proposition is "all the families agree", so stopping at the
 // first family that does not would report one number and hide which of the others is the odd one
-// — the difference between "combo rows are 4px off" and "everything but combo rows is". The
-// tolerance is sub-pixel: these are positions on a pixel grid, reached by different float
-// arithmetic, so what is being asserted is the same column, not the same bit pattern.
+// — the difference between "combo rows are 4px off" and "everything but combo rows is".
+//
+// The two columns get two tolerances, because they are not measured the same way. Every
+// `control_right` is a rectangle ImGui reported, so the only slack it needs is the sub-pixel kind
+// two different float paths to the same position leave behind. `label_left` is that for the
+// hand-built rows but a pixel scan for the combo rows (MeasureComboRow), and a scan cannot
+// resolve finer than the pixel grid it reads: after the bearing correction its residual error is
+// one physical pixel, i.e. 1.0 logical px on an unscaled display and 0.5 on a 2x one. So the
+// label tolerance is that worst case and no more — it stays 4x below the 4 px inter-family gap
+// this whole helper exists to catch, and widening the control tolerance to match would give away
+// resolution on the one column that never lost any.
 inline void CheckLabelColumn(const char* group, const std::vector<LabelColumnRow>& rows) {
   IM_CHECK_GT(rows.size(), (size_t)1);  // one row cannot disagree with anything
-  constexpr float kTolPx = 0.5f;
+  constexpr float kControlTolPx = 0.5f;
+  constexpr float kLabelTolPx = 1.0f;
   const LabelColumnRow& ref = rows[0];
   for (size_t i = 1; i < rows.size(); ++i) {
-    if (ImFabs(rows[i].control_right - ref.control_right) > kTolPx) {
+    if (ImFabs(rows[i].control_right - ref.control_right) > kControlTolPx) {
       IM_ERRORF("%s: control right edge %s=%.1f vs %s=%.1f (delta %.1f px)", group, rows[i].name, rows[i].control_right,
                 ref.name, ref.control_right, rows[i].control_right - ref.control_right);
     }
-    if (ImFabs(rows[i].label_left - ref.label_left) > kTolPx) {
+    if (ImFabs(rows[i].label_left - ref.label_left) > kLabelTolPx) {
       IM_ERRORF("%s: label left edge %s=%.1f vs %s=%.1f (delta %.1f px)", group, rows[i].name, rows[i].label_left,
                 ref.name, ref.label_left, rows[i].label_left - ref.label_left);
     }

--- a/test/gui/test_gui_shared.hpp
+++ b/test/gui/test_gui_shared.hpp
@@ -289,6 +289,77 @@ void StopPerfSimulation();
 // ReadOnly, say) for the predicate to still mean "the user cannot operate this".
 bool IsDisabled(const ImGuiTestItemInfo& info);
 
+// ========== The trailing-label column ==========
+//
+// Several panels build their rows on one three-column model — [wide control][value][label] — and
+// the claim these helpers exist to check is that the last two boundaries are single vertical
+// lines, no matter which widget family drew the row. Two families share the model and neither can
+// see the other: the hand-built [slider][input] rows in panels.cpp place their own label, while
+// ImGui's Combo places its label itself at a spacing constant hardcoded inside BeginCombo. A row
+// family that picks the other constant lands its controls and its label on lines 4px away from
+// everyone else's, which is a defect no per-family test can state.
+//
+// Both numbers come out of geometry ImGui reports, never out of a constant copied from the panel
+// code — an assertion built from kLabelColWidth and ItemSpacing.x would restate the layout code
+// rather than check it.
+struct LabelColumnRow {
+  const char* name = "";       // for the failure message; the row as a user would name it
+  float control_right = 0.0f;  // right edge of the row's last interactive control
+  float label_left = 0.0f;     // left edge of the row's trailing label
+};
+
+// A hand-built row: the InputFloat/InputInt reports its own frame, and the trailing label is
+// addressable because panels.cpp submits an InvisibleButton of the label's exact horizontal
+// extent over it (see TextWithLabelProbe there).
+inline LabelColumnRow MeasureWidgetRow(ImGuiTestContext* ctx, const char* name, const char* input_ref,
+                                       const char* label_probe_ref) {
+  LabelColumnRow row;
+  row.name = name;
+  row.control_right = ctx->ItemInfo(input_ref).RectFull.Max.x;
+  row.label_left = ctx->ItemInfo(label_probe_ref).RectFull.Min.x;
+  return row;
+}
+
+// A Combo row. ImGui places a combo's trailing label itself, and there is no item to read it
+// from: BeginCombo registers its item with the NAV rectangle — the drawn frame, label excluded
+// (`ItemAdd(total_bb, id, &bb)`, imgui_widgets.cpp; the test engine records the third argument) —
+// and never calls the test engine's label hook at all, so the label is neither addressable nor
+// inside the reported rectangle. What IS pinned down is where BeginCombo puts it: at
+// `bb.Max.x + style.ItemInnerSpacing.x`, a constant hardcoded in that function. So the frame's
+// right edge is measured and the label's left edge is that plus the one ImGui spacing — no
+// constant from the panel code enters, which is what keeps this from restating the layout code.
+// (Being unable to change that constant from outside is the reason the panel had to move to it.)
+inline LabelColumnRow MeasureComboRow(ImGuiTestContext* ctx, const char* name, const char* combo_ref) {
+  LabelColumnRow row;
+  row.name = name;
+  row.control_right = ctx->ItemInfo(combo_ref).RectFull.Max.x;
+  row.label_left = row.control_right + ImGui::GetStyle().ItemInnerSpacing.x;
+  return row;
+}
+
+// Both columns of every row, against the first row's.
+//
+// Non-fatal per row on purpose: the proposition is "all the families agree", so stopping at the
+// first family that does not would report one number and hide which of the others is the odd one
+// — the difference between "combo rows are 4px off" and "everything but combo rows is". The
+// tolerance is sub-pixel: these are positions on a pixel grid, reached by different float
+// arithmetic, so what is being asserted is the same column, not the same bit pattern.
+inline void CheckLabelColumn(const char* group, const std::vector<LabelColumnRow>& rows) {
+  IM_CHECK_GT(rows.size(), (size_t)1);  // one row cannot disagree with anything
+  constexpr float kTolPx = 0.5f;
+  const LabelColumnRow& ref = rows[0];
+  for (size_t i = 1; i < rows.size(); ++i) {
+    if (ImFabs(rows[i].control_right - ref.control_right) > kTolPx) {
+      IM_ERRORF("%s: control right edge %s=%.1f vs %s=%.1f (delta %.1f px)", group, rows[i].name, rows[i].control_right,
+                ref.name, ref.control_right, rows[i].control_right - ref.control_right);
+    }
+    if (ImFabs(rows[i].label_left - ref.label_left) > kTolPx) {
+      IM_ERRORF("%s: label left edge %s=%.1f vs %s=%.1f (delta %.1f px)", group, rows[i].name, rows[i].label_left,
+                ref.name, ref.label_left, rows[i].label_left - ref.label_left);
+    }
+  }
+}
+
 // Hands ImGui's popup stack back when a case leaves, by whichever exit.
 //
 // ResetTestState() reaches everything about a popup this suite opens except the one piece ImGui


### PR DESCRIPTION
## 问题

右侧面板里行末标签列的左缘在不同控件家族之间不对齐：手搭的 `[slider][input] Label` 行与 ImGui 自带的 `Combo + Label` 行，**控件右缘对齐、但标签左缘错开 4px**（`Scene` 组的 `Diameter` vs `Spectrum` 一眼可见）。

**根因**：两族各持一份间距常量，彼此不知道对方。手搭行末走 `ImGui::SameLine()`，间距 = `style.ItemSpacing.x`（8px）；ImGui 的 `BeginCombo` 把标签**硬编码**画在 `bb.Max.x + style.ItemInnerSpacing.x`（4px）处。两族的控件右缘各自被压到同一竖线，所以控件看着是齐的，标签就差了 8 − 4 = 4px。

## 改动

1. **统一到 `ItemInnerSpacing.x`**。方向是被逼定的：Combo 那侧的 4px 在 ImGui 内部硬编码，要反过来改成 8px 就得用 `##id` 隐藏自带标签再手工重画控件 —— 为对齐去重写控件不划算。
2. **间距收敛为单一 owner**：新增 `LabelColumnGapX()` / `PushLabelColumnItemWidth()`（`panels.hpp` 声明、`panels.cpp` 定义），8 个消费点全部从它取值（`PrepareSliderLayout`、`FinishSliderLayout`、`emit_row`、4 处 `PushItemWidth`、`edit_modals.cpp` 的镜像分支）。改一处全部同时变，不再存在"只改了一半"的中间状态 —— 这治的是本缺陷的根因土壤，而不只是把两族的值调成一样。
3. **新增几何回归用例**（`scene_controls` / `view_display_controls` / `entry_management`）+ 可寻址标签探针 `TextWithLabelProbe`。combo 侧的标签左缘取自**真实渲染像素**（整帧回读后逐列扫第一个有 ink 的列，含字形 left-side-bearing 修正与 tooltip 遮挡处理），不是用被测公式自算 —— 后者两侧同源，是自证循环。

## 取证

- **before 实测**：slider 族标签左缘 1512.0px、combo 行 1508.0px，**差 4.0px，combo 偏左**，scene/view/display 三组一致。
- **after 实测**：四组共 21 行，标签左缘与控件右缘各自落在同一竖线上；控件右缘的既有对齐未被牺牲。
- **红态自证**：用例写完、间距未修时两条对齐用例真实变红；单独把 `emit_row` 改回 `ItemSpacing.x`，`entry_management` 立即检出 4px 错位。像素扫描法的自证含正面证据 —— 注入真实像素漂移后新法检出、**旧公式法读数不变（检不出）**，且 `control_right` 未跟着漂（证明注入没绕开验证目标）。
- **探针零像素副作用**：第一版探针（文本在前、探针在后）确实改了像素（`ItemSize` 用最后一个 item 定行高，逐行累积 77430px 不同）；改成"探针在前 + `SameLine(0,0)` 交还行状态 + 文本收尾"后与 pristine HEAD 逐像素比对 **0 差异**。
- 参考图 `smoke_fullframe.png` / `left_panel_default.jpg` 按实测重拍，**阈值一字未动**（`_thresholds.json` 只改 `generated_at`）。owner 化本身零像素影响，未再动参考图。

## 验证

`./scripts/test.sh quick` 净机独占 **RESULT: PASS**（ctest 7/7、fast-e2e 87 items、gui-correctness 312/312），退出码直读未经管道遮蔽。四道差分门禁 + `format.sh --check` 全部 exit 0。

## 已知遗留（已记 backlog，非本 PR 范围）

- `Infinite rays` 的 `Checkbox` 被包在 `PushLabelColumnItemWidth()` 里是**空转**（`Checkbox` 不读 `CalcItemWidth()`）。这是 `main` 上既有的形态，本 PR 只是换成 helper 调用。不在此清理是因为它的根因（Checkbox 不属于标签列对齐族）与"标签放置形态统一"是同一个，合并处置才对。
- 测量设施在异常路径上的两条诊断可读性 Minor（不影响判红判绿、不产生假绿）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhDgEB58Li97Tw6i8J4Mng