### PR TITLE
晶体卡片 layout 重排 + 晶体身份可寻址 + Colors 面板编号/失效态

### DIFF
--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -540,7 +540,7 @@ void RenderLeftPanel(float window_height) {
     const auto& src = *g_state.pick_link_source;
     ImGui::PushStyleColor(ImGuiCol_Text, WarningTextColor());
     ImGui::TextWrapped("Pick mode: click an entry to share crystal/filter from Layer %d / Entry %d (Esc to cancel)",
-                       src.layer_idx, src.entry_idx);
+                       DisplayLayerNumber(src.layer_idx), DisplayEntryNumber(src.entry_idx));
     ImGui::PopStyleColor();
     ImGui::Separator();
   }

--- a/src/gui/color_window.cpp
+++ b/src/gui/color_window.cpp
@@ -115,15 +115,14 @@ std::string BuildClassSummary(const GuiState& state, const ColorClassConfig& cls
     }
     const auto& ref = cls.match[i];
     char layer_tag[16];
-    std::snprintf(layer_tag, sizeof(layer_tag), "L%d", ref.layer_idx);
+    std::snprintf(layer_tag, sizeof(layer_tag), "L%d", DisplayLayerNumber(ref.layer_idx));
     out += layer_tag;
-    if (ref.crystal_pool_id >= 0 && static_cast<size_t>(ref.crystal_pool_id) < state.crystals.size()) {
-      const auto& cr = state.crystals[static_cast<size_t>(ref.crystal_pool_id)];
-      out += "·";
-      out += cr.name.empty() ? std::string("crystal#") + std::to_string(ref.crystal_pool_id) : cr.name;
-    } else {
-      out += "·<missing>";
-    }
+    // Same identity string the card and the combos below render, not a second name-or-fallback
+    // spelling of it — the two spellings disagreeing is exactly the defect this collapses. The
+    // summary line does get longer for it; a shorter form, if one is ever wanted, has to be a
+    // variant OF FormatCrystalIdentity (and must still lead with `#N`), not a fresh inline rule.
+    out += "·";
+    out += FormatCrystalIdentity(state, ref.crystal_pool_id);
     if (ref.match_all) {
       out += " · whole";
     } else if (!ref.predicate_text.empty()) {
@@ -309,20 +308,6 @@ std::vector<int> CrystalPoolsInLayer(const GuiState& state, int layer_idx) {
   return out;
 }
 
-const char* CrystalDisplayName(const GuiState& state, int pool_id) {
-  static thread_local std::string buf;
-  if (pool_id < 0 || static_cast<size_t>(pool_id) >= state.crystals.size()) {
-    buf = "<missing>";
-    return buf.c_str();
-  }
-  const auto& cr = state.crystals[static_cast<size_t>(pool_id)];
-  if (!cr.name.empty()) {
-    return cr.name.c_str();
-  }
-  buf = std::string("crystal#") + std::to_string(pool_id);
-  return buf.c_str();
-}
-
 // -------------------- window body --------------------
 
 // T1: no `server` parameter — display push derived by the frame-tail reconciler from the
@@ -374,7 +359,7 @@ void RenderImportFromFilterUI(GuiState& state) {
       const char* crystal_name = CrystalDisplayName(state, p.crystal_pool_id);
       const auto& f = state.filters[static_cast<size_t>(*p.filter_id)];
       char label[256];
-      std::snprintf(label, sizeof(label), "L%d · %s · %s##imp_%zu", p.layer_idx, crystal_name,
+      std::snprintf(label, sizeof(label), "L%d · %s · %s##imp_%zu", DisplayLayerNumber(p.layer_idx), crystal_name,
                     f.name.empty() ? "filter" : f.name.c_str(), i);
       if (ImGui::Selectable(label)) {
         int skipped = 0;
@@ -402,52 +387,93 @@ void RenderRefRow(GuiState& state, ColorClassConfig& cls, size_t ref_idx, bool& 
   ImGui::PushID(static_cast<int>(ref_idx));
   auto& ref = cls.match[ref_idx];
 
-  // Layer combo.
+  // Layer + crystal combos. Both are BeginCombo rather than Combo because their PREVIEW has to be
+  // able to say something no list item says — "the thing this ref stores is gone" — while the list
+  // itself still offers only the values that do exist, so the user can repair the ref in place.
+  // Writing the stored value back into the ref is done ONLY on a click in the list; rendering never
+  // writes (see ResolveColorRef in color_window.hpp for what that rule is guarding against).
+  const ColorRefResolution resolution = ResolveColorRef(state, ref);
   const int layer_count = static_cast<int>(state.layers.size());
-  std::vector<std::string> layer_labels(static_cast<size_t>(layer_count));
-  std::vector<const char*> layer_ptrs(static_cast<size_t>(layer_count));
-  for (int i = 0; i < layer_count; i++) {
-    layer_labels[static_cast<size_t>(i)] = "Layer " + std::to_string(i);
-    layer_ptrs[static_cast<size_t>(i)] = layer_labels[static_cast<size_t>(i)].c_str();
+
+  const bool layer_broken = resolution == ColorRefResolution::kLayerMissing;
+  std::string layer_preview = FormatColorRefLayerLabel(state, ref);
+  if (layer_broken) {
+    layer_preview = ICON_FA_CIRCLE_EXCLAMATION " " + layer_preview;
   }
-  int layer_idx = std::clamp(ref.layer_idx, 0, std::max(0, layer_count - 1));
   ImGui::PushItemWidth(90);
-  if (ImGui::Combo("##layer", &layer_idx, layer_ptrs.data(), layer_count)) {
-    ref.layer_idx = layer_idx;
-    // Reset crystal choice to the new layer's first placement so we never
-    // leave a stale (invalid-for-this-layer) pool id in the ref.
-    const auto pools = CrystalPoolsInLayer(state, layer_idx);
-    if (!pools.empty() && std::find(pools.begin(), pools.end(), ref.crystal_pool_id) == pools.end()) {
-      ref.crystal_pool_id = pools.front();
+  if (layer_broken) {
+    ImGui::PushStyleColor(ImGuiCol_Text, WarningTextColor());
+  }
+  const bool layer_open = ImGui::BeginCombo("##layer", layer_preview.c_str());
+  const bool layer_hovered = !layer_open && ImGui::IsItemHovered();
+  if (layer_broken) {
+    ImGui::PopStyleColor();
+  }
+  if (layer_open) {
+    for (int i = 0; i < layer_count; i++) {
+      const std::string item = "Layer " + std::to_string(DisplayLayerNumber(i));
+      const bool selected = i == ref.layer_idx;
+      if (ImGui::Selectable(item.c_str(), selected)) {
+        ref.layer_idx = i;
+        // Reset crystal choice to the new layer's first placement so we never
+        // leave a stale (invalid-for-this-layer) pool id in the ref.
+        const auto new_pools = CrystalPoolsInLayer(state, i);
+        if (!new_pools.empty() &&
+            std::find(new_pools.begin(), new_pools.end(), ref.crystal_pool_id) == new_pools.end()) {
+          ref.crystal_pool_id = new_pools.front();
+        }
+        // T1: structural (ColorClassStructState.match) → reconciler routes to hard-reset lane.
+      }
+      if (selected) {
+        ImGui::SetItemDefaultFocus();
+      }
     }
-    // T1: structural (ColorClassStructState.match) → reconciler routes to hard-reset lane.
+    ImGui::EndCombo();
+  }
+  if (layer_broken && layer_hovered) {
+    ImGui::SetTooltip("This class still points at layer %d, which no longer exists.\nPick a layer to repair it.",
+                      DisplayLayerNumber(ref.layer_idx));
   }
   ImGui::PopItemWidth();
 
   // Crystal combo (deduped placements in the selected layer).
   ImGui::SameLine();
   const auto pools = CrystalPoolsInLayer(state, ref.layer_idx);
-  std::vector<std::string> crystal_labels(pools.size());
-  std::vector<const char*> crystal_ptrs(pools.size());
-  int current_choice = -1;
-  for (size_t i = 0; i < pools.size(); i++) {
-    crystal_labels[i] = CrystalDisplayName(state, pools[i]);
-    crystal_ptrs[i] = crystal_labels[i].c_str();
-    if (pools[i] == ref.crystal_pool_id) {
-      current_choice = static_cast<int>(i);
-    }
+  const bool crystal_broken = resolution == ColorRefResolution::kCrystalNotInLayer;
+  std::string crystal_preview = FormatColorRefCrystalLabel(state, ref);
+  if (crystal_broken) {
+    crystal_preview = ICON_FA_CIRCLE_EXCLAMATION " " + crystal_preview;
   }
   ImGui::PushItemWidth(120);
-  if (!pools.empty()) {
-    if (current_choice < 0) {
-      current_choice = 0;
-    }
-    if (ImGui::Combo("##crystal", &current_choice, crystal_ptrs.data(), static_cast<int>(pools.size()))) {
-      ref.crystal_pool_id = pools[static_cast<size_t>(current_choice)];
-      // T1: structural → reconciler.
-    }
-  } else {
+  if (pools.empty() && !crystal_broken) {
     ImGui::TextDisabled("<no placements>");
+  } else {
+    if (crystal_broken) {
+      ImGui::PushStyleColor(ImGuiCol_Text, WarningTextColor());
+    }
+    const bool crystal_open = ImGui::BeginCombo("##crystal", crystal_preview.c_str());
+    const bool crystal_hovered = !crystal_open && ImGui::IsItemHovered();
+    if (crystal_broken) {
+      ImGui::PopStyleColor();
+    }
+    if (crystal_open) {
+      for (size_t i = 0; i < pools.size(); i++) {
+        const std::string item = FormatCrystalIdentity(state, pools[i]);
+        const bool selected = pools[i] == ref.crystal_pool_id;
+        if (ImGui::Selectable(item.c_str(), selected)) {
+          ref.crystal_pool_id = pools[i];
+          // T1: structural → reconciler.
+        }
+        if (selected) {
+          ImGui::SetItemDefaultFocus();
+        }
+      }
+      ImGui::EndCombo();
+    }
+    if (crystal_broken && crystal_hovered) {
+      ImGui::SetTooltip("No crystal in this layer is %s.\nPick one to repair the reference.",
+                        FormatCrystalIdentity(state, ref.crystal_pool_id).c_str());
+    }
   }
   ImGui::PopItemWidth();
 
@@ -599,6 +625,44 @@ WindowLocalState& GetLocalState() {
 }
 
 }  // namespace
+
+// Thin `const char*` adapter over FormatCrystalIdentity — ImGui's Combo wants an array of
+// `const char*`, and the identity itself must have exactly one owner (gui_state.hpp). This function
+// contributes nothing but the storage; if you find yourself about to add a branch here, the branch
+// belongs in FormatCrystalIdentity where the card sees it too.
+const char* CrystalDisplayName(const GuiState& state, int pool_id) {
+  static thread_local std::string buf;
+  buf = FormatCrystalIdentity(state, pool_id);
+  return buf.c_str();
+}
+
+ColorRefResolution ResolveColorRef(const GuiState& state, const ColorClassRefConfig& ref) {
+  if (ref.layer_idx < 0 || static_cast<size_t>(ref.layer_idx) >= state.layers.size()) {
+    return ColorRefResolution::kLayerMissing;
+  }
+  const auto pools = CrystalPoolsInLayer(state, ref.layer_idx);
+  if (std::find(pools.begin(), pools.end(), ref.crystal_pool_id) == pools.end()) {
+    return ColorRefResolution::kCrystalNotInLayer;
+  }
+  return ColorRefResolution::kResolved;
+}
+
+std::string FormatColorRefLayerLabel(const GuiState& state, const ColorClassRefConfig& ref) {
+  std::string label = "Layer " + std::to_string(DisplayLayerNumber(ref.layer_idx));
+  if (ResolveColorRef(state, ref) == ColorRefResolution::kLayerMissing) {
+    label += " (deleted)";
+  }
+  return label;
+}
+
+std::string FormatColorRefCrystalLabel(const GuiState& state, const ColorClassRefConfig& ref) {
+  std::string label = FormatCrystalIdentity(state, ref.crystal_pool_id);
+  if (ResolveColorRef(state, ref) == ColorRefResolution::kCrystalNotInLayer) {
+    label += " (not in this layer)";
+  }
+  return label;
+}
+
 
 // task-348.1 fix: poll GetColorClassSignal into a caller-owned buffer sized to
 // state.raypath_color.size(). Resize semantics: new entries default to 1

--- a/src/gui/color_window.hpp
+++ b/src/gui/color_window.hpp
@@ -15,6 +15,7 @@
 //     GetColorClassLaneY(i) keeps binding to the same class.
 
 #include <cstddef>
+#include <string>
 #include <vector>
 
 #include "gui/raypath_segments.hpp"
@@ -25,6 +26,7 @@ namespace lumice::gui {
 struct GuiState;
 struct FilterConfig;
 struct ColorClassConfig;
+struct ColorClassRefConfig;
 
 // Render the non-modal Colors window (Layer 3, floating). No-op when
 // state.color_window_open is false.
@@ -61,6 +63,38 @@ void CompactZOrder(GuiState& state);
 // combine defaults to LUMICE_COLOR_COMBINE_ANY (blueprint case B: one filter
 // UI-row imports to one class with rows OR'd).
 ColorClassConfig BuildClassFromFilter(int layer_idx, int crystal_pool_id, const FilterConfig& f, int& skipped_rows);
+
+// Can this ref still be resolved against the scene as it is now? A ref stores a layer index and a
+// crystal POOL id, and the scene can move out from under both: deleting a layer leaves refs whose
+// layer_idx is past the end, and deleting (or re-pointing) an entry leaves refs naming a crystal
+// that no longer appears in that layer.
+//
+// This exists as a function, and the row renderer calls it, because the previous arrangement had
+// the renderer decide the same question inline AND then hide its own answer: a clamp filled the
+// layer combo with an in-range value that was not the stored one, and a `current_choice = 0`
+// fallback showed the layer's FIRST crystal for a ref pointing at some other one. Both were
+// display-only — nothing was written back — so what reached the scene at commit time was the
+// unclamped, unfallen-back value the user was never shown. The invariant now is that a value the
+// UI cannot honour is displayed as broken, never as some neighbouring value that happens to exist.
+enum class ColorRefResolution {
+  kResolved,           // layer in range AND crystal appears in that layer
+  kLayerMissing,       // layer_idx out of range for the current scene
+  kCrystalNotInLayer,  // layer is fine, but no entry in it uses this crystal pool id
+};
+ColorRefResolution ResolveColorRef(const GuiState& state, const ColorClassRefConfig& ref);
+
+// The text the ref row shows for each of its two combos, in every resolution state. Always carries
+// the STORED value (layer number, `#pool_id`), never a substitute that resolves — the whole point
+// of the pair. The renderer adds the warning glyph and colour; these return the words.
+std::string FormatColorRefLayerLabel(const GuiState& state, const ColorClassRefConfig& ref);
+std::string FormatColorRefCrystalLabel(const GuiState& state, const ColorClassRefConfig& ref);
+
+// `const char*` adapter over FormatCrystalIdentity (gui_state.hpp) for ImGui's combo APIs, which
+// want an array of C strings. Exposed ONLY so a test can pin it to the shared formatter: this is
+// the site that used to carry its own "name if it has one, else crystal#N" spelling while the entry
+// card carried none at all, which is how the Colors window ended up naming crystals the user could
+// not find on any card. The returned pointer is valid until the next call on the same thread.
+const char* CrystalDisplayName(const GuiState& state, int pool_id);
 
 // Validate a per-ref predicate text under the single-atom rule (single Factor,
 // single alternative) — plan §3 decision 3. Empty/whitespace → valid (means

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -1127,9 +1127,15 @@ void CommitAllBuffersImmediate(GuiState& state);
 
 void StartLinkPickMode(GuiState& state, int layer_idx, int entry_idx) {
   if (g_active_modal == ActiveModal::kOpen) {
-    // Commit whichever entry the modal is bound to — that is the one whose buffers are in flight,
-    // and it is not necessarily `entry_idx` (the card rail can arm pick mode on a different card
-    // while a modal is open on another one).
+    // Commit whichever entry the modal is bound to — that is the one whose buffers are in flight.
+    //
+    // Today it is always `entry_idx`: the modal is a blocking popup, so a click aimed at another
+    // card behind it never reaches that card, and the only caller that can run with a modal open is
+    // the modal's own "Link to..." button, which passes the entry the modal is bound to. The commit
+    // is written against g_modal_* rather than against `entry_idx` anyway, because THAT is where
+    // the in-flight buffers belong — reading the argument here would make this correct only for as
+    // long as the two cannot diverge, which is a property of the popup being blocking rather than
+    // of anything in this function.
     CommitAllBuffersImmediate(state);
     g_active_modal = ActiveModal::kNone;
   }

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -635,6 +635,36 @@ static bool RenderWedgeTableRow(const char* label, float* value) {
 static void RenderCrystalModal(GuiState& /*state*/) {
   auto& cr = g_crystal_buf;
 
+  // -- Name --
+  // CrystalConfig::name has been read and written by the document format since long before this
+  // control existed, but nothing in the GUI ever set it, so every crystal created here was
+  // nameless — and the Colours window, which addresses crystals by name, had nothing to show but a
+  // pool index for all of them. This box is the missing half.
+  //
+  // No dirty / commit plumbing is needed for it: g_crystal_buf is a whole CrystalConfig held by
+  // value, and CrystalConfig::operator== already compares `name`, so the existing snapshot-diff
+  // picks the field up on both the staged and immediate paths.
+  ImGui::AlignTextToFramePadding();
+  ImGui::TextUnformatted("Name");
+  ImGui::SameLine();
+  {
+    char name_buf[64];
+    snprintf(name_buf, sizeof(name_buf), "%s", cr.name.c_str());
+    ImGui::SetNextItemWidth(-FLT_MIN);
+    if (ImGui::InputTextWithHint("##crystal_name", "unnamed — shown as its pool id everywhere", name_buf,
+                                 sizeof(name_buf))) {
+      cr.name = name_buf;
+    }
+  }
+  if (ImGui::IsItemHovered()) {
+    ImGui::SetTooltip(
+        "A name for this crystal, shown on its card and wherever a colour class refers to it.\n"
+        "Names need not be unique — the pool id stays visible alongside so two crystals sharing\n"
+        "a name are still tellable apart.");
+  }
+
+  ImGui::Spacing();
+
   // -- Crystal type --
   int type_int = static_cast<int>(cr.type);
   if (ImGui::RadioButton("Prism##modal", &type_int, 0)) {
@@ -1088,6 +1118,22 @@ EditModalTarget GetEditModalTarget() {
     return { -1, -1 };
   }
   return { g_modal_layer_idx, g_modal_entry_idx };
+}
+
+namespace {
+// Defined further down, in the same anonymous namespace as the modal edit buffers it applies.
+void CommitAllBuffersImmediate(GuiState& state);
+}  // namespace
+
+void StartLinkPickMode(GuiState& state, int layer_idx, int entry_idx) {
+  if (g_active_modal == ActiveModal::kOpen) {
+    // Commit whichever entry the modal is bound to — that is the one whose buffers are in flight,
+    // and it is not necessarily `entry_idx` (the card rail can arm pick mode on a different card
+    // while a modal is open on another one).
+    CommitAllBuffersImmediate(state);
+    g_active_modal = ActiveModal::kNone;
+  }
+  state.pick_link_source = GuiState::EntryRef{ layer_idx, entry_idx };
 }
 
 EditTarget GetActiveTabAsEditTarget() {
@@ -1666,9 +1712,7 @@ void RenderEditModals(GuiState& state, GLFWwindow* window) {
       ImGui::SameLine();
       // "Link to..." — commit current buffer, arm pick-mode, close modal.
       if (ImGui::SmallButton("Link to...##share")) {
-        CommitAllBuffersImmediate(state);
-        state.pick_link_source = GuiState::EntryRef{ ly, en };
-        g_active_modal = ActiveModal::kNone;
+        StartLinkPickMode(state, ly, en);
         if (!state.modal_immediate_mode) {
           ImGui::CloseCurrentPopup();
         }

--- a/src/gui/edit_modals.hpp
+++ b/src/gui/edit_modals.hpp
@@ -45,6 +45,20 @@ EditModalTarget GetEditModalTarget();
 // kCard edit requests — do not use for other purposes.
 EditTarget GetActiveTabAsEditTarget();
 
+// Arm the "Link to..." eyedropper on (layer_idx, entry_idx): the next entry card the user clicks
+// becomes the model whose crystal / filter this entry adopts.
+//
+// Two entry points reach this — the entry card's rail button and the edit modal's own
+// "Link to..." — and they must not each carry their own copy of the sequence, because the part
+// that is easy to leave out is invisible when it is missing: if the modal is open, its edit
+// buffers hold changes that have not been applied to the pool yet, and arming pick mode without
+// committing them first silently discards whatever the user just typed. That commit is why this
+// lives in edit_modals (the buffers and the open-modal statics are its), not in panels.
+//
+// Does NOT call ImGui::CloseCurrentPopup(): that is only legal from inside the popup's own scope,
+// so the modal call site adds it and the card call site does not.
+void StartLinkPickMode(GuiState& state, int layer_idx, int entry_idx);
+
 // Reset all modal-internal static state (active modal, edit buffers, pending flags).
 // Called by test teardown (ResetTestState) to prevent state leakage between tests.
 void ResetModalState();

--- a/src/gui/field_editor_registry.cpp
+++ b/src/gui/field_editor_registry.cpp
@@ -118,7 +118,7 @@ FieldEditorEntry FloatField(float* (*access)(GuiState&), FloatDomainFn domain, c
     }
     bool committed = false;
     bool active = false;
-    SliderWithInput(id_base, &drag.working, range.first, range.second, fmt, scale, /*trailing_label=*/false, &committed,
+    SliderWithInput(id_base, &drag.working, range.first, range.second, fmt, scale, LabelPlacement::kNone, &committed,
                     &active);
     drag.was_active = active;
     if (!committed) {
@@ -147,7 +147,7 @@ FieldEditorEntry IntField(int* (*access)(GuiState&), int min_value, int max_valu
     }
     bool committed = false;
     bool active = false;
-    SliderIntWithInput(id_base, &drag.working, min_value, max_value, /*trailing_label=*/false, &committed, &active);
+    SliderIntWithInput(id_base, &drag.working, min_value, max_value, LabelPlacement::kNone, &committed, &active);
     drag.was_active = active;
     if (!committed) {
       return false;

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -1387,9 +1387,11 @@ static FilterExpansionOutcome ExpandFilterToScene(const FilterConfig& f, LUMICE_
 }
 
 std::string FormatOverflowLocator(const FilterOverflowInfo& overflow) {
-  // 1-based Layer/Entry to match the panel header convention (panels.cpp "Layer %d").
-  const std::string pos =
-      "Layer " + std::to_string(overflow.layer_index + 1) + " / Entry " + std::to_string(overflow.entry_index + 1);
+  // 1-based Layer/Entry to match the panel header convention (panels.cpp "Layer %d"). The `+ 1`
+  // itself lives in DisplayLayerNumber / DisplayEntryNumber (gui_state.hpp) — this locator was one
+  // of only two sites that got the base right while four others rendered the same indices 0-based.
+  const std::string pos = "Layer " + std::to_string(DisplayLayerNumber(overflow.layer_index)) + " / Entry " +
+                          std::to_string(DisplayEntryNumber(overflow.entry_index));
   if (!overflow.filter_name.empty()) {
     return "filter \"" + overflow.filter_name + "\", " + pos;
   }
@@ -1490,6 +1492,16 @@ static bool AddColorClasses(const GuiState& state, const std::map<int, int>& cry
     const auto& cls = state.raypath_color[i];
     for (int j = 0; j < static_cast<int>(cls.match.size()); j++) {
       const auto& ref = cls.match[j];
+      // Layer bound, mirroring the crystal check right below it. It was missing, and its absence
+      // was the second half of the display/truth split the Colors window used to have: the row
+      // showed a clamped in-range layer while `dref.layer = ref.layer_idx` handed the unclamped
+      // one straight to the scene. The window now shows the stored value as broken; this is the
+      // matching promise on the commit side, that a broken one is not quietly committed either.
+      if (ref.layer_idx < 0 || static_cast<size_t>(ref.layer_idx) >= state.layers.size()) {
+        GUI_LOG_WARNING("[FileIO] raypath_color[{}].match[{}] references layer {} which is not in the scene; skipped.",
+                        i, j, ref.layer_idx);
+        continue;
+      }
       if (crystal_pool_to_core.find(ref.crystal_pool_id) == crystal_pool_to_core.end()) {
         GUI_LOG_WARNING(
             "[FileIO] raypath_color[{}].match[{}] references crystal pool {} not present in scene; skipped.", i, j,

--- a/src/gui/gui_constants.hpp
+++ b/src/gui/gui_constants.hpp
@@ -1,6 +1,8 @@
 #ifndef LUMICE_GUI_CONSTANTS_HPP
 #define LUMICE_GUI_CONSTANTS_HPP
 
+#include <cstddef>
+
 namespace lumice::gui {
 
 // Layout constants
@@ -72,6 +74,12 @@ constexpr unsigned long long kMinRaysFloor = 5000;
 constexpr float kLabelColWidth = 70.0f;
 constexpr float kInputWidth = 60.0f;
 
+// How many characters of a filter's raypath body the entry card's summary keeps before it cuts to
+// "...". A named constant rather than a literal at each of its two sites, so that the number and
+// the reasoning about the card column it was measured against (FilterSummary in panels.cpp) can be
+// found from either end — the previous literal could only be reached by grepping the function name.
+constexpr size_t kFilterSummaryBodyChars = 16;
+
 // Reference drag track length, in pixels: the horizontal distance a DragFloat traverses to
 // cross its whole domain. It is the width SliderWithInput's slider half gets, so a merged
 // single control keeps the same "how far do I have to drag" feel rather than inheriting
@@ -99,6 +107,17 @@ constexpr float kActiveCardBorder = 2.0f;
 // Border strength of a card that shares its (crystal, filter) pair with the one whose edit modal
 // is open. The accent at this alpha is theme.cpp's established "about to be acted on" marker.
 constexpr float kCoSharedBorderAlpha = 0.55f;
+
+// Border strength of the card the pointer is over. Deliberately the WEAKEST of the three card
+// border states: the other two say something about the open edit modal, this one only says the
+// pointer is here, and a hover that competed with them would make the informative pair harder to
+// distinguish from each other. Consumed by RenderEntryCard.
+constexpr float kCardHoverBorderAlpha = 0.30f;
+
+// Outline drawn over the entry card's "Link to" rail slot when that card shares its
+// (crystal, filter) pair with another. An outline rather than a different glyph: what the button
+// DOES is constant, and sharing is a separate fact drawn on top of it.
+constexpr float kSharedOutlineThickness = 1.5f;
 
 // Opacity of an excluded entry card's thumbnail area — the rendered image, the placeholder that
 // stands in for it, and the frame around both. One constant rather than a per-branch literal so

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -1297,6 +1297,62 @@ struct GuiState {
   }
 };
 
+// ---- Display-side identity / numbering formatters (single owner) ----
+//
+// These four live here rather than in each renderer because every one of them had ALREADY drifted
+// across its call sites before being collected: the layer number was written 1-based in the panel
+// header and file_io's overflow locator but 0-based in three places in the Colors window and in the
+// link badge's tooltip, and the crystal's display name was spelled one way in the Colors window and
+// not spelled at all on the card. A `+ 1` re-typed at each site is what let them disagree; the fix
+// is that no site types it.
+//
+// Placement note for whoever adds the next one: gui_state.hpp is "state structures", and
+// FormatCrystalIdentity is not a pure predicate on a struct the way IsProbZero / AllEntriesDisabled
+// are — it reads GuiState and returns a display string. Four of them is still within what this file
+// carries comfortably. If a fifth and sixth formatting free function want in here, that is the
+// signal to split them out into a gui_formatting.{hpp,cpp} instead of letting this file become
+// "state + formatting toolbox". This sentence is the search anchor for that moment; do not delete it.
+
+// Layer / Entry numbers as the USER sees them. The stored indices are 0-based everywhere (they are
+// vector subscripts); every user-visible rendering of them is 1-based. Both directions of the
+// conversion belong to exactly one function each.
+inline int DisplayLayerNumber(int layer_idx) {
+  return layer_idx + 1;
+}
+inline int DisplayEntryNumber(int entry_idx) {
+  return entry_idx + 1;
+}
+
+inline const char* CrystalTypeName(CrystalType type) {
+  return type == CrystalType::kPrism ? "Prism" : "Pyramid";
+}
+
+// The one spelling of "which crystal is this": `#N` (pool id), then the user's name when it has
+// one, then the type. Both the entry card's first row and the Colors window's crystal combos /
+// class summaries render it, so a user reading `#2 · plate · Prism` in the Colors window can find
+// the same string on a card.
+//
+// `#N` is ALWAYS present and is never replaced by the name, even when there is one: nothing stops
+// two crystals from carrying the same name, and two identical entries in a combo are worse than an
+// id-only label. N is the pool index (GuiState::crystals), which is the key the color refs actually
+// store — it is sparse (the pool is append-only; deleting a card never reclaims its slot) but
+// stable, and compacting it to make the numbers prettier would rewrite every ref's key and make the
+// number move whenever an unrelated card is deleted.
+inline std::string FormatCrystalIdentity(const GuiState& state, int pool_id) {
+  std::string out = "#" + std::to_string(pool_id);
+  if (pool_id < 0 || static_cast<size_t>(pool_id) >= state.crystals.size()) {
+    // The id still leads: a dangling ref's whole diagnostic value is WHICH id dangles.
+    return out + " <missing>";
+  }
+  const CrystalConfig& cr = state.crystals[static_cast<size_t>(pool_id)];
+  if (!cr.name.empty()) {
+    out += " · " + cr.name;
+  }
+  out += " · ";
+  out += CrystalTypeName(cr.type);
+  return out;
+}
+
 // Size guard for ConfigSnapshot. If any field changes here, From/ApplyTo below must
 // be audited for matching changes. Apple Silicon + libc++ only (std::vector size varies
 // across stdlib implementations).

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -181,9 +181,19 @@ std::string FilterSummarySuffix(const FilterConfig& fc) {
 //   - Raypath:    "<raypath_text or *> <In|Out>[ <sym>]"        (e.g. "3-1-5 In PBD")
 //   - EntryExit:  "EE:<entry>-><exit> <In|Out>[ <sym>]"
 //
-// 12-character truncation on the raypath body keeps the card text inside the row
-// it shares with the Edit button. Pinned by
-// `SceneCommitChain.ALongRaypathIsCutToTwelveCharactersOnTheCard` in
+// kFilterSummaryBodyChars-character truncation on the raypath body keeps the card text inside its
+// row. The number is a measurement of the card's value column, not a preference, so it moved when
+// the column did: the column was 121px while an Edit button shared the row with it, and is 151px
+// now that the button is gone, which is 16 body characters plus the ellipsis and the longest
+// direction/symmetry suffix. That is the whole reason the truncation is worth revisiting at all —
+// the button was spending a quarter of the row on making the filter less readable.
+//
+// Approximate on purpose, in both directions: the widest suffix (" Out PBD") overruns by about a
+// pixel, and an EntryExit body can be far longer than any of this, because what actually keeps a
+// value out of the icon rail is the card's clip rect. Truncation only decides where a long value
+// reads as CUT rather than as running off the edge.
+//
+// Pinned by `SceneCommitChain.ALongRaypathIsCutToTheCardsBodyLimit` in
 // test/composition-correctness/gui/test_scene_commit_chain.cpp. Other types
 // emit short prefixes that fit comfortably without truncation; if they ever
 // need truncation, add it per-type.
@@ -208,8 +218,8 @@ std::string FilterSummary(const std::optional<FilterConfig>& f) {
             if (p.raypath_text.empty()) {
               return "*";
             }
-            if (p.raypath_text.size() > 12) {
-              return p.raypath_text.substr(0, 12) + "...";
+            if (p.raypath_text.size() > kFilterSummaryBodyChars) {
+              return p.raypath_text.substr(0, kFilterSummaryBodyChars) + "...";
             }
             return p.raypath_text;
           } else if constexpr (std::is_same_v<T, EntryExitParams>) {
@@ -257,8 +267,8 @@ std::string FilterSummary(const std::optional<FilterConfig>& f) {
     if (first.empty()) {
       first = "*";
     }
-    if (first.size() > 12) {
-      first = first.substr(0, 12) + "...";
+    if (first.size() > kFilterSummaryBodyChars) {
+      first = first.substr(0, kFilterSummaryBodyChars) + "...";
     }
     body = first;
     if (fc.param.size() > 1) {
@@ -279,7 +289,10 @@ namespace {
 }  // namespace
 
 
-// Sole owner of the control-to-trailing-label gap; rationale in panels.hpp.
+// Sole owner of the control-to-label gap: the input->label gap under kTrailing, the
+// label->controls gap under kLeading. Rationale for the VALUE in panels.hpp; the reason it is one
+// named quantity rather than a literal at each site is that the two placements are then GUARANTEED
+// to reserve the same width, so a row switching between them cannot shift its neighbours.
 float LabelColumnGapX() {
   return ImGui::GetStyle().ItemInnerSpacing.x;
 }
@@ -290,13 +303,14 @@ void PushLabelColumnItemWidth() {
 
 // Compute slider width and prepare IDs for the [slider] [input] Label layout.
 // Writes slider_id and input_id buffers, returns the computed slider width.
-// When `reserve_label_col` is false the trailing text label is omitted (table-cell
-// mode): the width no longer reserves kLabelColWidth nor its extra SameLine spacing,
-// so the [slider][input] pair fills the whole cell (GetContentRegionAvail() ==
-// column width inside a BeginTable cell).
+// Under LabelPlacement::kNone the text label is omitted (table-cell mode): the width no longer
+// reserves kLabelColWidth nor its gap, so the [slider][input] pair fills the whole cell
+// (GetContentRegionAvail() == column width inside a BeginTable cell). kLeading and kTrailing return
+// the SAME width — the label column is reserved either way, only the draw order differs.
 static float PrepareSliderLayout(const char* label, char* display_label_out, size_t display_buf_size, char* slider_id,
                                  size_t slider_id_size, char* input_id, size_t input_id_size, char* label_id,
-                                 size_t label_id_size, bool reserve_label_col = true) {
+                                 size_t label_id_size, LabelPlacement label_placement = LabelPlacement::kTrailing,
+                                 float avail_override = 0.0f) {
   // Strip ImGui ID suffix (e.g. "Azimuth##view" → display "Azimuth")
   const char* hash_pos = strstr(label, "##");
   if (hash_pos) {
@@ -315,18 +329,19 @@ static float PrepareSliderLayout(const char* label, char* display_label_out, siz
 
   float spacing = ImGui::GetStyle().ItemSpacing.x;
   float label_gap = LabelColumnGapX();
-  float avail_w = ImGui::GetContentRegionAvail().x;
-  // With the trailing label: subtract kLabelColWidth + the slider→input spacing + the
-  // input→label gap. Without it: only the slider→input spacing.
+  float avail_w = avail_override > 0.0f ? avail_override : ImGui::GetContentRegionAvail().x;
+  // With a label (either side): subtract kLabelColWidth + the slider->input spacing + the
+  // control<->label gap. Without one (kNone, table-cell mode): only the slider->input spacing.
   //
-  // The two gaps are different constants on purpose. The control→label gap comes from
-  // LabelColumnGapX() (see panels.hpp for why that value and not ItemSpacing.x). It
-  // must stay paired with FinishSliderLayout's SameLine below: the label's x is
-  // (right edge − kLabelColWidth) whatever value the pair takes — the term cancels — but the
-  // CONTROL's right edge is this value, so a mismatched pair moves the controls out of their
-  // column while leaving the labels looking correct.
-  float slider_w = reserve_label_col ? (avail_w - kInputWidth - kLabelColWidth - spacing - label_gap) :
-                                       (avail_w - kInputWidth - spacing);
+  // The two gaps are different constants on purpose. The control<->label gap comes from
+  // LabelColumnGapX() (see panels.hpp for why that value and not ItemSpacing.x). It must stay
+  // paired with FinishSliderLayout's SameLine below and with BeginLeadingLabelLayout's cursor
+  // jump: the label's x is (right edge - kLabelColWidth) whatever value the pair takes -- the term
+  // cancels -- but the CONTROL's right edge is this value, so a mismatched pair moves the controls
+  // out of their column while leaving the labels looking correct.
+  float slider_w = label_placement == LabelPlacement::kNone ?
+                       (avail_w - kInputWidth - spacing) :
+                       (avail_w - kInputWidth - kLabelColWidth - spacing - label_gap);
   if (slider_w < 40.0f)
     slider_w = 40.0f;
   return slider_w;
@@ -367,6 +382,25 @@ static void TextWithLabelProbe(const char* display_label, const char* probe_id) 
   ImGui::TextUnformatted(display_label);
 }
 
+// Draw the label BEFORE slider + input, then park the cursor at the start of the control column.
+// The jump is by absolute position rather than SameLine's advance so that a short label and a long
+// one put their controls in the same place — which is the entire reason the label column has a
+// fixed width. Returns nothing; the caller draws the controls at the cursor it leaves behind.
+//
+// The gap term is LabelColumnGapX(), the same owner FinishSliderLayout's SameLine takes: a leading
+// row and a trailing row reserve the same width, so switching a row between them cannot move its
+// neighbours' controls.
+static void BeginLeadingLabelLayout(const char* display_label, const char* label_id) {
+  const ImVec2 line_start = ImGui::GetCursorScreenPos();
+  // Centres the label text against the frame-height controls that follow it, the same way an ImGui
+  // widget's own label is centred. Without it the label sits at the top of the row while the
+  // slider fills it, and a column of leading labels reads as drifting upward.
+  ImGui::AlignTextToFramePadding();
+  TextWithLabelProbe(display_label, label_id);
+  ImGui::SameLine();
+  ImGui::SetCursorScreenPos(ImVec2(line_start.x + kLabelColWidth + LabelColumnGapX(), line_start.y));
+}
+
 // Render the label text after slider + input.
 static void FinishSliderLayout(const char* display_label, const char* label_id) {
   ImGui::SameLine(0.0f, LabelColumnGapX());  // paired with PrepareSliderLayout
@@ -374,16 +408,20 @@ static void FinishSliderLayout(const char* display_label, const char* label_id) 
 }
 
 bool SliderWithInput(const char* label, float* value, float min_val, float max_val, const char* fmt, SliderScale scale,
-                     bool trailing_label, bool* committed, bool* active) {
+                     LabelPlacement label_placement, bool* committed, bool* active, float avail_override) {
   char display_buf[64];
   char slider_id[64];
   char input_id[64];
   char label_id[64];
   float slider_w = PrepareSliderLayout(label, display_buf, sizeof(display_buf), slider_id, sizeof(slider_id), input_id,
-                                       sizeof(input_id), label_id, sizeof(label_id), trailing_label);
+                                       sizeof(input_id), label_id, sizeof(label_id), label_placement,
+                                       avail_override);
 
   const float old_value = *value;
 
+  if (label_placement == LabelPlacement::kLeading) {
+    BeginLeadingLabelLayout(display_buf, label_id);
+  }
   ImGui::PushItemWidth(slider_w);
   RenderNonlinearSlider(slider_id, value, min_val, max_val, fmt, scale);
   const bool slider_committed = ImGui::IsItemDeactivatedAfterEdit();
@@ -406,7 +444,7 @@ bool SliderWithInput(const char* label, float* value, float min_val, float max_v
     *active = slider_active || input_active;
   }
 
-  if (trailing_label) {
+  if (label_placement == LabelPlacement::kTrailing) {
     FinishSliderLayout(display_buf, label_id);
   }
   return *value != old_value;
@@ -446,17 +484,20 @@ bool DragFloatField(const char* label, float* value, float min_val, float max_va
 
 // SliderInt + InputInt + label text, same layout as SliderWithInput.
 // Returns true if value changed.
-bool SliderIntWithInput(const char* label, int* value, int min_val, int max_val, bool trailing_label, bool* committed,
-                        bool* active) {
+bool SliderIntWithInput(const char* label, int* value, int min_val, int max_val, LabelPlacement label_placement,
+                        bool* committed, bool* active) {
   char display_buf[64];
   char slider_id[64];
   char input_id[64];
   char label_id[64];
   float slider_w = PrepareSliderLayout(label, display_buf, sizeof(display_buf), slider_id, sizeof(slider_id), input_id,
-                                       sizeof(input_id), label_id, sizeof(label_id), trailing_label);
+                                       sizeof(input_id), label_id, sizeof(label_id), label_placement);
 
   const int old_value = *value;
 
+  if (label_placement == LabelPlacement::kLeading) {
+    BeginLeadingLabelLayout(display_buf, label_id);
+  }
   ImGui::PushItemWidth(slider_w);
   ImGui::SliderInt(slider_id, value, min_val, max_val, "%d", ImGuiSliderFlags_NoInput);
   const bool slider_committed = ImGui::IsItemDeactivatedAfterEdit();
@@ -479,7 +520,9 @@ bool SliderIntWithInput(const char* label, int* value, int min_val, int max_val,
     *active = slider_active || input_active;
   }
 
-  FinishSliderLayout(display_buf, label_id);
+  if (label_placement == LabelPlacement::kTrailing) {
+    FinishSliderLayout(display_buf, label_id);
+  }
   return *value != old_value;
 }
 
@@ -966,7 +1009,8 @@ bool RenderShapeDistTableRow(const char* label, CrystalConfig& cr, int slot) {
   // Col 1 — center value: slider + input, filling the (stretch) Value column. trailing_label=false
   // because the name already occupies Col 0.
   ImGui::TableNextColumn();
-  changed |= SliderWithInput(label, &dist.center, center_min, center_max, center_fmt, center_scale, false);
+  changed |=
+      SliderWithInput(label, &dist.center, center_min, center_max, center_fmt, center_scale, LabelPlacement::kNone);
 
   // Col 2 — sync group swatch + picker popup. Ahead of Rand/Spread because sync is not a property of
   // randomization: it constrains the row's final value and is equally usable with Rand off. Left
@@ -1127,12 +1171,29 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
     ImGui::PushStyleVar(ImGuiStyleVar_ChildBorderSize, kActiveCardBorder);
   }
 
-  ImGui::BeginChild("##card", ImVec2(0, 0), ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY);
-
-  // Previous-frame hover state controls the alpha of the hover-action buttons
-  // (always-render + alpha transition to keep click paths stable).
+  // ---- Whole-card hover feedback ----
+  // The card opens its edit modal when clicked anywhere, and that was previously invisible: the
+  // three Edit buttons were the only thing on the card saying "this is editable", and they are
+  // gone. A border that brightens under the pointer is what replaces them — it makes the whole
+  // card read as one control, which is what it has always actually been.
+  //
+  // Hover is read from the PREVIOUS frame, and out of the parent window's storage rather than the
+  // child's, because the border colour has to be pushed BEFORE BeginChild — the child paints its
+  // own border, and by the time we are inside it the paint has happened. Same one-frame lag the
+  // hover-revealed buttons ran on; a border is even less sensitive to it than they were.
+  //
+  // It yields to `active` and `co_shared`: those two say something about the open modal, this one
+  // only says "the pointer is here", and stacking a third border strength on top of either would
+  // make the two that carry information harder to tell apart.
+  ImGuiStorage* card_storage = ImGui::GetStateStorage();
   ImGuiID hover_persist_id = ImGui::GetID("##card_hover_persist");
-  bool hover_prev = ImGui::GetStateStorage()->GetBool(hover_persist_id, false);
+  bool hover_prev = card_storage->GetBool(hover_persist_id, false);
+  const bool hover_border = hover_prev && !active && !co_shared;
+  if (hover_border) {
+    ImGui::PushStyleColor(ImGuiCol_Border, AccentColor(kCardHoverBorderAlpha));
+  }
+
+  ImGui::BeginChild("##card", ImVec2(0, 0), ImGuiChildFlags_Borders | ImGuiChildFlags_AutoResizeY);
 
   // Use frame-height spacing so each row reserves room for the Edit button (taller than text);
   // otherwise Row 0-2 buttons would overlap the Weight slider in Row 3.
@@ -1175,101 +1236,89 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
   }
   draw_list->AddRect(thumb_pos, thumb_br, ImGui::GetColorU32(ImGuiCol_Border, thumb_alpha));
 
-  // ---- Participation toggle (always visible) ----
-  // Semantics: "exclude this crystal, then re-run". Turning it off does NOT subtract this
-  // crystal from the current image — it hands its share of the fixed total ray count back to
-  // its siblings on the next run, so the rest of the scene gets MORE samples. That is a
-  // different operation from the Colors panel's per-component eye, which is display-time
-  // subtraction, so the glyph here deliberately is not an eye.
+  // ---- Right column geometry ----
   //
-  // Placement: overlaid on the thumbnail's top-left corner. Unlike Delete/Duplicate this is not
-  // a hover-revealed action — "does this card count?" has to be as scannable as the Weight
-  // number — and the thumbnail corner is the only always-free real estate on the card that does
-  // not push the right column's four rows out of their shared three-column alignment.
-  {
-    // "###" and not "##": the visible glyph flips with the state, and with "##" the id hashes the
-    // whole label, so the button would become a different widget the instant it is clicked —
-    // losing ImGui's active-id continuity and leaving no stable path for a test to address. Same
-    // reasoning as the defaults panel's state-dependent cells.
-    char toggle_id[48];
-    snprintf(toggle_id, sizeof(toggle_id), "%s###enabled_%d_%d", entry.enabled ? ICON_FA_TOGGLE_ON : ICON_FA_TOGGLE_OFF,
-             layer_idx, entry_idx);
-    constexpr float kTogglePad = 3.0f;
-    ImGui::SetCursorScreenPos(ImVec2(thumb_pos.x + kTogglePad, thumb_pos.y + kTogglePad));
-    if (!entry.enabled) {
-      // Theme-owned disabled tone, not a semantic_colors.hpp grade: "excluded" is a state of
-      // this control, not a judgement about the crystal (see that header's scope note).
-      ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-    }
-    const bool toggle_clicked = ImGui::SmallButton(toggle_id);
-    if (!entry.enabled) {
-      ImGui::PopStyleColor();
-    }
-    if (toggle_clicked) {
-      entry.enabled = !entry.enabled;
-    }
-    if (ImGui::IsItemHovered()) {
-      ImGui::SetTooltip("%s", entry.enabled ?
-                                  "Participating. Click to exclude this crystal from the next run — its share of "
-                                  "the total ray count goes to the other crystals (they get more samples)." :
-                                  "Excluded from the next run. Its Weight is kept and takes effect again when you "
-                                  "turn it back on.");
-    }
-  }
+  // Four rows, each `[label kLabelColWidth][gap][value ...]`, sharing one right edge, with a
+  // four-slot icon rail beyond it. The rail's slots are frame-height and the rows are
+  // frame-height-with-spacing, so four slots fill the card's height exactly — the rail is why the
+  // card is four rows tall and not some other number.
+  //
+  // Leading labels (label left, value right) rather than the trailing ones this card used to have:
+  // with the label at the END of the row, the value and its name sat ~190px apart with an Edit
+  // button between them, so reading "what kind of crystal is this" meant crossing the row. See
+  // doc/gui-visual-language.md §5, which names leading labels as the resolution of exactly this.
+  //
+  // The three Edit buttons that used to occupy the middle column are gone. They were never three
+  // things: the modal they opened is ONE modal with a tab bar, and clicking anywhere on the card
+  // already opens it (EditTarget::kCard, resolved to a tab in app_panels.cpp), so each button was a
+  // shortcut to a tab. What they cost was the whole middle column of every row — which is what the
+  // filter summary's 12-character truncation was paying for — plus the ~190px label separation.
+  // What they provided, and what the whole-card hover highlight below has to replace, is the only
+  // visible evidence on the card that any of this is editable at all.
+  float frame_pad_x = ImGui::GetStyle().FramePadding.x;
+  float rail_glyph_w = std::max({ ImGui::CalcTextSize(ICON_FA_TOGGLE_ON).x, ImGui::CalcTextSize(ICON_FA_TOGGLE_OFF).x,
+                                  ImGui::CalcTextSize(ICON_FA_LINK).x, ImGui::CalcTextSize(ICON_FA_COPY).x,
+                                  ImGui::CalcTextSize(ICON_FA_XMARK).x });
+  float rail_btn_w = rail_glyph_w + frame_pad_x * 2.0f;
+  float rail_btn_h = ImGui::GetFrameHeight();
 
-  // Right column — layout matches SliderWithInput's three-column model:
-  //   [text / slider (text_w)] [Edit button / input (kInputWidth)] [row label (kLabelColWidth)]
-  // so Row 1-3 align column boundaries with Row 4 automatically.
-  const float label_gap_x = LabelColumnGapX();
   float right_x = thumb_pos.x + thumb_display_size + spacing_x;
   float avail_w = ImGui::GetContentRegionAvail().x - thumb_display_size - spacing_x;
-  // Same two-different-gaps split as PrepareSliderLayout, and for the same reason: the Weight row
-  // below is drawn by it, so a card whose button rows kept spacing_x on the label side would put
-  // its own four rows in two different columns.
-  float text_w = std::max(40.0f, avail_w - kInputWidth - kLabelColWidth - spacing_x - label_gap_x);
+  float rail_x = right_x + avail_w - rail_btn_w;
+  // Width of one row, label column included. Every row is laid out against this single number, so
+  // the four right edges cannot drift apart and the rail can never be overlapped by a value.
+  float row_w = std::max(kLabelColWidth + kInputWidth, avail_w - rail_btn_w - spacing_x);
+  // Same gap owner the Weight row's own leading label uses (BeginLeadingLabelLayout), so the four
+  // rows put their values in one column rather than two.
+  float value_x = right_x + kLabelColWidth + LabelColumnGapX();
+  float value_w = std::max(20.0f, right_x + row_w - value_x);
 
-  auto emit_row = [&](int row_idx, const char* text_content, const char* btn_id, EditTarget target,
-                      const char* row_label, bool clip_text, const char* tooltip = nullptr) {
+  auto emit_row = [&](int row_idx, const char* row_label, const char* text_content, bool clip_text,
+                      const char* tooltip = nullptr) {
     ImVec2 line_start(right_x, thumb_pos.y + row_h * static_cast<float>(row_idx));
     ImGui::SetCursorScreenPos(line_start);
+    // Same vertical centring the Weight row's leading label gets from BeginLeadingLabelLayout, so
+    // all four labels sit on one grid whether their row holds text or a slider.
+    ImGui::AlignTextToFramePadding();
+    // Same addressable-label probe FinishSliderLayout / BeginLeadingLabelLayout use. This row
+    // shares its label column with the Weight row below, so the alignment invariant is only
+    // checkable if both ends of that column can be located from a real frame.
+    char label_probe_id[64];
+    snprintf(label_probe_id, sizeof(label_probe_id), "##card_%d_%d_row_%d_label", layer_idx, entry_idx, row_idx);
+    TextWithLabelProbe(row_label, label_probe_id);
+    ImGui::SetCursorScreenPos(ImVec2(value_x, line_start.y));
+    ImGui::AlignTextToFramePadding();
     if (clip_text) {
-      ImVec2 clip_min = line_start;
-      ImVec2 clip_max(line_start.x + text_w, line_start.y + ImGui::GetTextLineHeight() + 2.0f);
+      ImVec2 clip_min(value_x, line_start.y);
+      ImVec2 clip_max(value_x + value_w, line_start.y + row_h);
+      // The clip rect, not the character count, is what keeps a value out of the rail. Truncation
+      // exists to make a long value READ well, and is allowed to be approximate because this is
+      // here underneath it.
       ImGui::PushClipRect(clip_min, clip_max, true);
       ImGui::TextUnformatted(text_content);
       ImGui::PopClipRect();
     } else {
       ImGui::TextUnformatted(text_content);
     }
-    // Optional hover tooltip — shows the full multi-row SoP for non-degenerate
-    // filters where the summary line is inherently lossy (only the first row
-    // + "(+N more)" fits). Follows the same "TextUnformatted then IsItemHovered"
-    // pattern as the fa-link badge below.
     if (tooltip != nullptr && ImGui::IsItemHovered()) {
       ImGui::SetTooltip("%s", tooltip);
     }
-    ImGui::SameLine();
-    ImGui::SetCursorScreenPos(ImVec2(line_start.x + text_w + spacing_x, line_start.y));
-    if (ImGui::Button(btn_id, ImVec2(kInputWidth, 0))) {
-      g_edit_request = { target, layer_idx, entry_idx };
-    }
-    ImGui::SameLine(0.0f, label_gap_x);  // paired with text_w above
-    // Same addressable-label probe as FinishSliderLayout — this row shares the label column with
-    // the Weight row below it, so the invariant is only checkable if both ends can be read.
-    char label_probe_id[64];
-    snprintf(label_probe_id, sizeof(label_probe_id), "##card_%d_%d_row_%d_label", layer_idx, entry_idx, row_idx);
-    TextWithLabelProbe(row_label, label_probe_id);
   };
 
-  // Row 1: Crystal type (resolved from pool)
+  // Row 0: which crystal this is. The identity string (`#N · name · type`) is the same one the
+  // Colors window shows, from the same formatter — before it existed, a colour class naming
+  // `crystal#2` referred to something the left panel never printed anywhere.
   const CrystalConfig& crystal_ref = state.crystals[entry.crystal_id];
-  emit_row(0, CrystalTypeName(crystal_ref.type), "Edit##cr", EditTarget::kCrystal, "Crystal", false);
+  const std::string identity = FormatCrystalIdentity(state, entry.crystal_id);
+  // Unconditional tooltip, unlike the Filter row's: a clipped identity has no "degenerate vs not"
+  // distinction to gate on, and a name long enough to clip is exactly when the full one is wanted.
+  emit_row(0, "Crystal", identity.c_str(), true, identity.c_str());
 
-  // Row 2: Axis preset (resolved from pool)
+  // Row 1: Axis preset
   std::string preset = AxisPresetName(crystal_ref);
-  emit_row(1, preset.c_str(), "Edit##ax", EditTarget::kAxis, "Axis", false);
+  emit_row(1, "Axis", preset.c_str(), false);
 
-  // Row 3: Filter summary (may exceed text_w — clip so it doesn't overlap the Edit button).
+  // Row 2: Filter summary (may exceed value_w — clipped above).
   // For non-degenerate SoP (>1 row or >1 factor), build a tooltip listing every
   // row's canonical text so users can see the full predicate without opening
   // the modal.
@@ -1291,9 +1340,10 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
     filter_tooltip_storage = gui::FormatSopExpansionPreview(filter_opt->param);
     filter_tooltip = filter_tooltip_storage.c_str();
   }
-  emit_row(2, filter_text.c_str(), "Edit##fi", EditTarget::kFilter, "Filter", true, filter_tooltip);
+  emit_row(2, "Filter", filter_text.c_str(), true, filter_tooltip);
 
-  // Row 4: Weight — reuse SliderWithInput for [slider][input] layout
+  // Row 3: Weight — SliderWithInput in leading-label mode, so its label lands in the same column
+  // as the three text rows above and its input's right edge on their shared right edge.
   ImGui::SetCursorScreenPos(ImVec2(right_x, thumb_pos.y + row_h * 3.0f));
   char prop_label[32];
   snprintf(prop_label, sizeof(prop_label), "Weight##prop_%d_%d", layer_idx, entry_idx);
@@ -1301,69 +1351,149 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
   // disable-when-inert convention as the layer prob slider. BeginDisabled only blocks
   // interaction; entry.proportion keeps its value, which is what makes the toggle reversible.
   ImGui::BeginDisabled(!entry.enabled);
-  SliderWithInput(prop_label, &entry.proportion, 0.0f, 100.0f, "%.1f");
+  SliderWithInput(prop_label, &entry.proportion, 0.0f, 100.0f, "%.1f", SliderScale::kLinear, LabelPlacement::kLeading,
+                  nullptr, nullptr, row_w);
   ImGui::EndDisabled();
   if (!entry.enabled && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
     ImGui::SetTooltip("Weight is inert while this crystal is excluded. The value is kept.");
   }
 
-  // Hover action buttons: stacked vertically at the right edge of the card —
-  // Delete (×) on top, Duplicate (D) below, separated by kHoverBtnGap. Alpha is
-  // driven by previous-frame hover state; buttons are always in the ImGui tree
-  // so click paths remain stable, only visibility transitions.
+  // ---- Icon rail: four always-visible slots down the right edge ----
   //
-  // Fast-swipe mitigation: vertical stacking (v6/card-layout-v2) prevents a
-  // single horizontal swipe from crossing the always-hit-tested Delete button,
-  // which was the original backlog concern. Confirm dialog / undo intentionally
-  // avoided — v5 verified that BeginDisabled(!hover_prev) and clicked+hover_prev
-  // both break imgui_test_engine MouseMove+Yield+ItemClick timing.
+  // Participating / Link to / Duplicate / Delete, one per row, all four permanently drawn. Delete
+  // and Duplicate used to fade in on hover and Link-to was not on the card at all (it lived inside
+  // the modal, one click deeper). Four constant slots beat "three plus one that comes and goes":
+  // a rail whose slot count changes with hover has no shape to learn, and an action nobody can see
+  // is an action nobody uses.
   //
-  // AutoResizeY first-frame drift (backlog Minor 3): ImGuiChildFlags_AutoResizeY
-  // only auto-fits the Y dimension; X is driven by the parent layout and stable
-  // on the first frame. The Y coordinates (del_y/dup_y) anchor to card_top, not
-  // WindowSize.y, so they are also frame-stable. No positional fix needed.
+  // Delete stays reachable at all times, which the fade previously guarded against. The guard is
+  // now positional: it is the BOTTOM slot, furthest from the toggle at the top, so a fast
+  // horizontal swipe across the card crosses the three harmless slots and not this one. A confirm
+  // step is still deliberately not added — BeginDisabled(!hover_prev) and clicked+hover_prev were
+  // both measured to break imgui_test_engine's MouseMove+Yield+ItemClick timing.
   //
-  // Coordinate strategy:
-  //   x: card_right - btn_w - kHoverBtnPad
-  //   delete y: card_top + kHoverBtnPad
-  //   duplicate y: delete_y + btn_h + kHoverBtnGap
+  // AutoResizeY first-frame drift: the slot y coordinates anchor to thumb_pos.y (the card's first
+  // row), not to WindowSize.y, so they are stable on the first frame like the rows they align with.
+  auto rail_slot_pos = [&](int slot) { return ImVec2(rail_x, thumb_pos.y + row_h * static_cast<float>(slot)); };
+
+  // Slot 0 — participation toggle. Semantics: "exclude this crystal, then re-run". Turning it off
+  // does NOT subtract this crystal from the current image — it hands its share of the fixed total
+  // ray count back to its siblings on the next run, so the rest of the scene gets MORE samples.
+  // That is a different operation from the Colors panel's per-component eye, which is display-time
+  // subtraction, so the glyph here deliberately is not an eye.
+  //
+  // The thumbnail keeps carrying the same fact by dimming (kExcludedThumbAlpha), which is what
+  // makes "is this card in?" answerable from across the panel; moving the toggle off the thumbnail
+  // corner into the rail therefore loses no information.
+  {
+    // "###" and not "##": the visible glyph flips with the state, and with "##" the id hashes the
+    // whole label, so the button would become a different widget the instant it is clicked —
+    // losing ImGui's active-id continuity and leaving no stable path for a test to address. Same
+    // reasoning as the defaults panel's state-dependent cells.
+    char toggle_id[48];
+    snprintf(toggle_id, sizeof(toggle_id), "%s###enabled_%d_%d", entry.enabled ? ICON_FA_TOGGLE_ON : ICON_FA_TOGGLE_OFF,
+             layer_idx, entry_idx);
+    ImGui::SetCursorScreenPos(rail_slot_pos(0));
+    if (!entry.enabled) {
+      // Theme-owned disabled tone, not a semantic_colors.hpp grade: "excluded" is a state of
+      // this control, not a judgement about the crystal (see that header's scope note).
+      ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+    }
+    const bool toggle_clicked = ImGui::Button(toggle_id, ImVec2(rail_btn_w, rail_btn_h));
+    if (!entry.enabled) {
+      ImGui::PopStyleColor();
+    }
+    if (toggle_clicked) {
+      entry.enabled = !entry.enabled;
+    }
+    if (ImGui::IsItemHovered()) {
+      ImGui::SetTooltip("%s", entry.enabled ?
+                                  "Participating. Click to exclude this crystal from the next run — its share of "
+                                  "the total ray count goes to the other crystals (they get more samples)." :
+                                  "Excluded from the next run. Its Weight is kept and takes effect again when you "
+                                  "turn it back on.");
+    }
+  }
+
+  // Slot 1 — Link to... The button's identity is CONSTANT: this glyph, this click behaviour, at all
+  // times. Sharing state is drawn ON TOP of it as an accent outline rather than by swapping the
+  // glyph or the label, because "what does this button do" and "is this card sharing" are two
+  // independent facts and a control that answers both by changing shape answers neither reliably.
+  // (This slot replaces the separate static fa-link badge that used to sit below the hover
+  // buttons — same glyph, same sharing tooltip, now also clickable.)
+  const int shared_count = CountEntriesSharing(state, entry.crystal_id, entry.filter_id);
+  {
+    char link_id[32];
+    snprintf(link_id, sizeof(link_id), ICON_FA_LINK "##link_%d_%d", layer_idx, entry_idx);
+    const ImVec2 slot_pos = rail_slot_pos(1);
+    ImGui::SetCursorScreenPos(slot_pos);
+    if (ImGui::Button(link_id, ImVec2(rail_btn_w, rail_btn_h))) {
+      StartLinkPickMode(state, layer_idx, entry_idx);
+    }
+    if (shared_count >= 2) {
+      // Accent outline: the accent is already the theme's "look here, these belong together" tone,
+      // which is exactly what sharing is. Drawn after the button so it sits over the frame.
+      draw_list->AddRect(slot_pos, ImVec2(slot_pos.x + rail_btn_w, slot_pos.y + rail_btn_h),
+                         ImGui::GetColorU32(AccentColor()), ImGui::GetStyle().FrameRounding, 0,
+                         kSharedOutlineThickness);
+    }
+    if (ImGui::IsItemHovered()) {
+      std::string tip = "Link to... — click, then click another card to adopt its crystal and filter.";
+      if (shared_count >= 2) {
+        std::string list;
+        for (int li = 0; li < static_cast<int>(state.layers.size()); ++li) {
+          for (int ei = 0; ei < static_cast<int>(state.layers[li].entries.size()); ++ei) {
+            const auto& other = state.layers[li].entries[ei];
+            if (other.crystal_id == entry.crystal_id && other.filter_id == entry.filter_id) {
+              if (li == layer_idx && ei == entry_idx) {
+                continue;  // skip self in the tooltip list
+              }
+              if (!list.empty()) {
+                list += "\n";
+              }
+              list += "Layer " + std::to_string(DisplayLayerNumber(li)) + " / Entry " +
+                      std::to_string(DisplayEntryNumber(ei));
+            }
+          }
+        }
+        if (list.empty()) {
+          list = "(no other entries)";
+        }
+        tip += "\n\nShared with:\n" + list;
+      }
+      ImGui::SetTooltip("%s", tip.c_str());
+    }
+  }
+
+  // Slot 2 — Duplicate.
   char dup_id[32];
-  char del_id[32];
   snprintf(dup_id, sizeof(dup_id), ICON_FA_COPY "##dup_%d_%d", layer_idx, entry_idx);
-  snprintf(del_id, sizeof(del_id), ICON_FA_XMARK "##del_%d_%d", layer_idx, entry_idx);
+  ImGui::SetCursorScreenPos(rail_slot_pos(2));
+  bool dup_clicked = ImGui::Button(dup_id, ImVec2(rail_btn_w, rail_btn_h));
+  if (ImGui::IsItemHovered()) {
+    ImGui::SetTooltip("Duplicate this card into an independent copy.");
+  }
 
-  float frame_pad_x = ImGui::GetStyle().FramePadding.x;
-  float dup_glyph_w = ImGui::CalcTextSize(ICON_FA_COPY).x;
-  float del_glyph_w = ImGui::CalcTextSize(ICON_FA_XMARK).x;
-  float btn_w = std::max(dup_glyph_w, del_glyph_w) + frame_pad_x * 2.0f;
-  float btn_h = ImGui::GetFrameHeight();
-  constexpr float kHoverBtnPad = 2.0f;
-  ImVec2 card_win_pos = ImGui::GetWindowPos();
-  ImVec2 card_win_sz = ImGui::GetWindowSize();
-  float btn_x = card_win_pos.x + card_win_sz.x - btn_w - kHoverBtnPad;
-  float del_y = card_win_pos.y + kHoverBtnPad;
-  float dup_y = del_y + btn_h + kHoverBtnGap;
-
-  ImGui::PushStyleVar(ImGuiStyleVar_Alpha, hover_prev ? 1.0f : 0.0f);
-  // Delete button (top): red when enabled (destructive action); auto-greyed when
+  // Slot 3 — Delete: red when enabled (destructive action); auto-greyed when
   // disabled (only one entry in layer — cannot remove last entry).
-  ImGui::SetCursorScreenPos(ImVec2(btn_x, del_y));
+  char del_id[32];
+  snprintf(del_id, sizeof(del_id), ICON_FA_XMARK "##del_%d_%d", layer_idx, entry_idx);
+  ImGui::SetCursorScreenPos(rail_slot_pos(3));
   bool can_delete_entry = state.layers[layer_idx].entries.size() > 1;
   if (can_delete_entry) {
     PushDestructiveStyle();
   } else {
     ImGui::BeginDisabled();
   }
-  bool delete_clicked = ImGui::SmallButton(del_id);
+  bool delete_clicked = ImGui::Button(del_id, ImVec2(rail_btn_w, rail_btn_h));
   if (can_delete_entry) {
     PopDestructiveStyle();
   } else {
     ImGui::EndDisabled();
   }
-  // Duplicate button (below)
-  ImGui::SetCursorScreenPos(ImVec2(btn_x, dup_y));
-  bool dup_clicked = ImGui::SmallButton(dup_id);
-  ImGui::PopStyleVar();
+  if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+    ImGui::SetTooltip("%s", can_delete_entry ? "Delete this card." : "A layer must keep at least one crystal.");
+  }
 
   if (dup_clicked) {
     // Duplicate = clone-to-pool: append new CrystalConfig (and new FilterConfig
@@ -1392,56 +1522,14 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
   }
 
   // Persist hover state for next frame (computed while still inside the child
-  // window so widget hover does not disqualify it).
+  // window so widget hover does not disqualify it), into the PARENT's storage — see the
+  // hover-feedback note above BeginChild for why it has to be readable from out there.
   bool hover_now = ImGui::IsWindowHovered(ImGuiHoveredFlags_ChildWindows);
-  ImGui::GetStateStorage()->SetBool(hover_persist_id, hover_now);
+  card_storage->SetBool(hover_persist_id, hover_now);
 
-  // ---- fa-link badge (static sharing indicator) ----
-  // Drawn AFTER all inner widgets but BEFORE the pick-mode overlay so it shows
-  // through the click-through invisible button. Predicate: (crystal_id,
-  // filter_id) is shared by 2+ entries across all layers (this card included).
-  {
-    const int shared = CountEntriesSharing(state, entry.crystal_id, entry.filter_id);
-    if (shared >= 2) {
-      // Anchor: third slot in the right-edge column, directly below the
-      // hover-revealed Delete (top) / Duplicate (middle) buttons. Stays
-      // visible regardless of hover (it's a persistent state indicator, not
-      // an action). Horizontally centered within the column for visual
-      // alignment with the buttons above.
-      const float glyph_w = ImGui::CalcTextSize(ICON_FA_LINK).x;
-      const float badge_x = btn_x + (btn_w - glyph_w) * 0.5f;
-      const float badge_y = dup_y + btn_h + kHoverBtnGap;
-      ImGui::SetCursorScreenPos(ImVec2(badge_x, badge_y));
-      // Accent: the badge points at a relationship between cards, which is exactly the "look
-      // here, these belong together" job the accent does elsewhere. It was its own lighter blue,
-      // close enough to the accent to look intentional and independent enough to stop following it.
-      ImGui::PushStyleColor(ImGuiCol_Text, AccentColor());
-      ImGui::TextUnformatted(ICON_FA_LINK);
-      ImGui::PopStyleColor();
-      if (ImGui::IsItemHovered()) {
-        std::string list;
-        for (int li = 0; li < static_cast<int>(state.layers.size()); ++li) {
-          for (int ei = 0; ei < static_cast<int>(state.layers[li].entries.size()); ++ei) {
-            const auto& other = state.layers[li].entries[ei];
-            if (other.crystal_id == entry.crystal_id && other.filter_id == entry.filter_id) {
-              if (li == layer_idx && ei == entry_idx) {
-                continue;  // skip self in the tooltip list
-              }
-              if (!list.empty()) {
-                list += "\n";
-              }
-              list += "Layer " + std::to_string(DisplayLayerNumber(li)) + " / Entry " +
-                      std::to_string(DisplayEntryNumber(ei));
-            }
-          }
-        }
-        if (list.empty()) {
-          list = "(no other entries)";
-        }
-        ImGui::SetTooltip("Shared with:\n%s", list.c_str());
-      }
-    }
-  }
+
+  ImVec2 card_win_pos = ImGui::GetWindowPos();
+  ImVec2 card_win_sz = ImGui::GetWindowSize();
 
   // ---- Card-area click handling ----
   // Detect a click anywhere inside the card area via a non-layout-affecting
@@ -1491,6 +1579,9 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
 
   ImGui::EndChild();  // ##card — must be unconditional
 
+  if (hover_border) {
+    ImGui::PopStyleColor();
+  }
   if (active) {
     ImGui::PopStyleVar();
     ImGui::PopStyleColor();

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -422,8 +422,7 @@ bool SliderWithInput(const char* label, float* value, float min_val, float max_v
   char input_id[64];
   char label_id[64];
   float slider_w = PrepareSliderLayout(label, display_buf, sizeof(display_buf), slider_id, sizeof(slider_id), input_id,
-                                       sizeof(input_id), label_id, sizeof(label_id), label_placement,
-                                       avail_override);
+                                       sizeof(input_id), label_id, sizeof(label_id), label_placement, avail_override);
 
   const float old_value = *value;
 
@@ -1296,6 +1295,21 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
     TextWithLabelProbe(row_label, label_probe_id);
     ImGui::SetCursorScreenPos(ImVec2(value_x, line_start.y));
     ImGui::AlignTextToFramePadding();
+    // The value column gets a probe for the same reason the label column does. Its x is computed
+    // HERE (value_x), while the Weight row below reaches the same column through
+    // BeginLeadingLabelLayout's own advance — two copies of one formula, which is exactly the
+    // shape the card's column invariant exists to catch.
+    char value_probe_id[64];
+    snprintf(value_probe_id, sizeof(value_probe_id), "##card_%d_%d_row_%d_value", layer_idx, entry_idx, row_idx);
+    {
+      const ImVec2 probe_size = ImGui::CalcTextSize(text_content);
+      if (probe_size.x > 0.0f && probe_size.y > 0.0f) {
+        const ImVec2 probe_pos = ImGui::GetCursorScreenPos();
+        ImGui::InvisibleButton(value_probe_id, probe_size);
+        ImGui::SameLine(0.0f, 0.0f);
+        ImGui::SetCursorScreenPos(probe_pos);
+      }
+    }
     if (clip_text) {
       ImVec2 clip_min(value_x, line_start.y);
       ImVec2 clip_max(value_x + value_w, line_start.y + row_h);

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -1263,8 +1263,7 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
 
   // Row 1: Crystal type (resolved from pool)
   const CrystalConfig& crystal_ref = state.crystals[entry.crystal_id];
-  const char* type_name = (crystal_ref.type == CrystalType::kPrism) ? "Prism" : "Pyramid";
-  emit_row(0, type_name, "Edit##cr", EditTarget::kCrystal, "Crystal", false);
+  emit_row(0, CrystalTypeName(crystal_ref.type), "Edit##cr", EditTarget::kCrystal, "Crystal", false);
 
   // Row 2: Axis preset (resolved from pool)
   std::string preset = AxisPresetName(crystal_ref);
@@ -1431,7 +1430,8 @@ bool RenderEntryCard(GuiState& state, int layer_idx, int entry_idx) {
               if (!list.empty()) {
                 list += "\n";
               }
-              list += "Layer " + std::to_string(li) + " / Entry " + std::to_string(ei);
+              list += "Layer " + std::to_string(DisplayLayerNumber(li)) + " / Entry " +
+                      std::to_string(DisplayEntryNumber(ei));
             }
           }
         }

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -289,10 +289,18 @@ namespace {
 }  // namespace
 
 
-// Sole owner of the control-to-label gap: the input->label gap under kTrailing, the
-// label->controls gap under kLeading. Rationale for the VALUE in panels.hpp; the reason it is one
-// named quantity rather than a literal at each site is that the two placements are then GUARANTEED
-// to reserve the same width, so a row switching between them cannot shift its neighbours.
+// The horizontal gap between a field's controls and its name — the input->label gap under
+// kTrailing, the label->controls gap under kLeading, and the entry card's value-column offset.
+// One named quantity rather than a literal at each site, for two reasons: the placements are then
+// GUARANTEED to reserve the same width (a row switching between them cannot shift its
+// neighbours), and the choice of style constant lands in one place rather than four.
+//
+// That single-owner property, not the numeric value, is what stops a second convention from
+// existing — which is why the value could be settled independently of the layout work that
+// consumes it. It is settled: ItemInnerSpacing.x, because ImGui's own Combo hardcodes its label at
+// `bb.Max.x + ItemInnerSpacing.x` inside BeginCombo where no caller can reach it, so a hand-built
+// row can only share a vertical line with a combo row by following it. Full rationale in
+// panels.hpp.
 float LabelColumnGapX() {
   return ImGui::GetStyle().ItemInnerSpacing.x;
 }

--- a/src/gui/panels.hpp
+++ b/src/gui/panels.hpp
@@ -59,15 +59,26 @@ void PushLabelColumnItemWidth();
 bool DragFloatField(const char* label, float* value, float min_val, float max_val, const char* fmt = "%.1f",
                     SliderScale scale = SliderScale::kLinear);
 
-// Slider + InputFloat + label text, laid out as: [slider] [input] Label
+// Where SliderWithInput / SliderIntWithInput put the field's name relative to its controls.
+//
+//   kTrailing  [slider] [input] Label   the panel default (Axis / Sun / Simulation / View / Display)
+//   kLeading   Label [slider] [input]   entry-card rows, whose label column is shared with three
+//                                       plain-text rows above it
+//   kNone      [slider] [input]         TABLE-CELL MODE — this is not a "neither of the above"
+//                                       fallback: it is for a caller whose field name already has
+//                                       a dedicated table column of its own (RenderShapeDistTableRow
+//                                       and the defaults panel's field-editor registry), so drawing
+//                                       one here would print the name twice. Dropping the label also
+//                                       drops kLabelColWidth from the width, letting the pair fill
+//                                       the cell.
+//
+// kLeading and kTrailing reserve the SAME geometry — one kLabelColWidth and the same two gaps — and
+// differ only in draw order, so a row can switch between them without any other row moving.
+enum class LabelPlacement { kTrailing, kLeading, kNone };
+
+// Slider + InputFloat + label text, laid out per `label_placement` (default: [slider] [input] Label).
 // Uses a fixed label column width so vertically stacked sliders align.
 // Returns true if value changed.
-//
-// `trailing_label = false` (table-cell mode): omit the trailing text label and let
-// the [slider][input] pair fill the whole content region — used when the field's
-// name already lives in a dedicated table column (see RenderShapeDistTableRow). The
-// default keeps the ~25 existing panel call sites (Axis / Sun / Simulation / View /
-// Display) byte-for-byte unchanged.
 //
 // `committed` (optional out-param, defaults to nullptr so existing call sites are unaffected):
 // set to `ImGui::IsItemDeactivatedAfterEdit()` semantics OR-ed across the slider AND the input
@@ -85,20 +96,29 @@ bool DragFloatField(const char* label, float* value, float min_val, float max_va
 // would be dropped. The distinction cannot be rebuilt at the call site: only this function sees
 // both sub-widgets' `IsItemActive()`, and after it returns ImGui's "last item" is the input box
 // alone.
+//
+// `avail_override` (0 = use the content region, the default): the width the row is allowed to
+// occupy, when the caller owns a strip NARROWER than the content region and the widget cannot see
+// where it ends. The entry card is the case: its right edge is reserved for an icon rail that is
+// drawn by absolute position, so a row sized to the content region would run underneath it. Passing
+// the number is what makes the card's four rows share one right edge by construction rather than by
+// two formulas that have to agree.
 bool SliderWithInput(const char* label, float* value, float min_val, float max_val, const char* fmt = "%.1f",
-                     SliderScale scale = SliderScale::kLinear, bool trailing_label = true, bool* committed = nullptr,
-                     bool* active = nullptr);
+                     SliderScale scale = SliderScale::kLinear,
+                     LabelPlacement label_placement = LabelPlacement::kTrailing, bool* committed = nullptr,
+                     bool* active = nullptr, float avail_override = 0.0f);
 
 // SliderInt + InputInt + label text — SliderWithInput's integer sibling, same layout and the same
-// `trailing_label = false` table-cell mode and the same optional `committed` / `active` out-params.
+// `label_placement` modes and the same optional `committed` / `active` out-params.
 // Returns true if the value changed.
 //
 // Exported (it was file-static in panels.cpp) because the defaults panel's field-editor registry
 // renders integer settings with it: an integer setting has to be edited by the SAME control the
 // main UI uses, or the two disagree about what a valid value is — which is the whole point of that
 // registry.
-bool SliderIntWithInput(const char* label, int* value, int min_val, int max_val, bool trailing_label = true,
-                        bool* committed = nullptr, bool* active = nullptr);
+bool SliderIntWithInput(const char* label, int* value, int min_val, int max_val,
+                        LabelPlacement label_placement = LabelPlacement::kTrailing, bool* committed = nullptr,
+                        bool* active = nullptr);
 
 // ---- Edit request (shared between panels.cpp and app_panels.cpp) ----
 enum class EditTarget { kNone, kCrystal, kAxis, kFilter, kCard };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -255,6 +255,7 @@ if(BUILD_GUI)
     "${PROJ_TEST_DIR}/unit-correctness/gui/test_overlay_labels.cpp"
     "${PROJ_TEST_DIR}/unit-correctness/gui/test_composite_preview.cpp"
     "${PROJ_TEST_DIR}/unit-correctness/gui/test_color_window_logic.cpp"
+    "${PROJ_TEST_DIR}/unit-correctness/gui/test_gui_identity_formatting.cpp"
     "${PROJ_TEST_DIR}/unit-correctness/gui/test_semantic_colors.cpp")
   target_include_directories(gui_unit_test
     PRIVATE ${PROJ_TEST_DIR})

--- a/test/composition-correctness/gui/test_document_roundtrip_chain.cpp
+++ b/test/composition-correctness/gui/test_document_roundtrip_chain.cpp
@@ -262,6 +262,13 @@ const std::vector<FieldProbe>& FieldProbes() {
         }
         return out;
       } },
+    // The GUI had no control for this field until the crystal edit modal grew a Name box, so
+    // although both halves of its serialization have existed since the format did, nothing had
+    // ever put a name into a document and read one back. The name is also what the Colours window
+    // shows for a crystal, so a dropped one turns every colour class's subject back into a bare
+    // pool id.
+    { "crystal.name", [](GuiState& s) { s.crystals[0].name = "plate"; },
+      [](const GuiState& s) { return s.crystals.empty() ? std::string("<no crystal>") : s.crystals[0].name; } },
     { "overlay.alphas",
       [](GuiState& s) {
         s.horizon_alpha = 0.3f;

--- a/test/composition-correctness/gui/test_raypath_color_document_chain.cpp
+++ b/test/composition-correctness/gui/test_raypath_color_document_chain.cpp
@@ -218,6 +218,23 @@ const ColorCase kCases[] = {
       ASSERT_EQ(rc["classes"][0]["match"].size(), 1u);
       EXPECT_EQ(rc["classes"][0]["match"][0]["crystal"].get<int>(), 0);
     } },
+  { "a ref to a layer the scene does not have is dropped",
+    [] {
+      // The default document has one layer, so index 1 is past the end. This is what a class looks
+      // like after the user deletes a scattering layer it pointed into — the ref keeps the index it
+      // was given, and nothing rewrites it. Before the bound was checked here, the index went
+      // straight into LUMICE_ColorClassRef::layer, while the Colors window showed a CLAMPED value,
+      // so the number the user saw and the number the scene received were different numbers.
+      ColorClassConfig cls;
+      cls.match.push_back(MatchAllRef(0, /*layer_idx=*/1));
+      cls.match.push_back(MatchAllRef(0, /*layer_idx=*/0));
+      g_state.raypath_color.push_back(cls);
+    },
+    [](const nlohmann::json& rc) {
+      ASSERT_EQ(rc["classes"].size(), 1u);
+      ASSERT_EQ(rc["classes"][0]["match"].size(), 1u) << "the out-of-range layer ref reached the wire";
+      EXPECT_EQ(rc["classes"][0]["match"][0]["layer"].get<int>(), 0);
+    } },
   { "a predicate with two factors is dropped",
     [] {
       ColorClassConfig cls;

--- a/test/composition-correctness/gui/test_scene_commit_chain.cpp
+++ b/test/composition-correctness/gui/test_scene_commit_chain.cpp
@@ -454,23 +454,30 @@ TEST(SceneCommitChain, EveryFilterShapeHasAnEntryCardSummary) {
             std::string::npos);
 }
 
-// A raypath longer than the card can show is truncated at 12 characters plus an ellipsis, and the
-// 12 is a real constant rather than "whatever fits": panels.cpp's FilterSummary picks it so the card
-// text stays inside the row it shares with the Edit button, which is drawn from a different code
-// path and would simply overlap. Asserted here because the truncation used to be pinned by a
-// gui_test case that was retired with test_gui_interaction.cpp, and nothing replaced it — a
-// silently-widened cut would show up as overlapping text on a card and nowhere else.
-TEST(SceneCommitChain, ALongRaypathIsCutToTwelveCharactersOnTheCard) {
+// A raypath longer than the card can show is truncated at kFilterSummaryBodyChars characters plus
+// an ellipsis, and that number is a measurement of the card's value column rather than "whatever
+// fits" — see the note on FilterSummary in panels.cpp for what it was measured against. Asserted
+// here because the truncation used to be pinned by a gui_test case that was retired with
+// test_gui_interaction.cpp, and nothing replaced it — a silently-widened cut would show up as
+// overrun text on a card and nowhere else.
+//
+// The literals below are written out rather than built from the constant: a test that computes its
+// expectation the same way the code does agrees with the code by construction, including when both
+// are wrong. Widening the column is a deliberate act and updating these two strings is the cost of
+// it.
+TEST(SceneCommitChain, ALongRaypathIsCutToTheCardsBodyLimit) {
   FilterConfig fc;
   RaypathParams rp;
-  rp.raypath_text = "1-2-3-4-5-6-7-8";  // 15 characters
+  rp.raypath_text = "1-2-3-4-5-6-7-8-9-1";  // 19 characters
   fc.SetRaypath(rp);
   const std::string summary = FilterSummary(std::optional<FilterConfig>{ fc });
-  EXPECT_EQ(summary.rfind("1-2-3-4-5-6-...", 0), 0u) << "got '" << summary << "'";
+  EXPECT_EQ(summary.rfind("1-2-3-4-5-6-7-8-...", 0), 0u) << "got '" << summary << "'";
 
   // ...and one that fits is left alone, so the cut is a bound rather than an unconditional trim.
+  // 15 characters: this one WAS truncated under the pre-widening limit, so it also witnesses that
+  // the column really did grow rather than the test merely following it.
   RaypathParams shorter;
-  shorter.raypath_text = "1-2-3-4-5";  // 9 characters
+  shorter.raypath_text = "1-2-3-4-5-6-7-8";  // 15 characters
   fc.SetRaypath(shorter);
   const std::string untouched = FilterSummary(std::optional<FilterConfig>{ fc });
   EXPECT_EQ(untouched.find("..."), std::string::npos) << "got '" << untouched << "'";

--- a/test/gui/functional/test_color_window.cpp
+++ b/test/gui/functional/test_color_window.cpp
@@ -508,7 +508,9 @@ void RegisterColorWindowTests(ImGuiTestEngine* engine) {
 
       ctx->ItemClick("**/" ICON_FA_FILE_IMPORT " Import from filter");
       ctx->Yield(2);
-      ClickInFocusedPopup(ctx, "L0 \xc2\xb7 cr \xc2\xb7 fx##imp_0");
+      // "L1" (1-based layer) and the crystal rendered as the shared identity string
+      // `#0 · cr · Prism` rather than the bare name.
+      ClickInFocusedPopup(ctx, "L1 \xc2\xb7 #0 \xc2\xb7 cr \xc2\xb7 Prism \xc2\xb7 fx##imp_0");
       ctx->Yield(2);
 
       IM_CHECK_EQ(static_cast<int>(gui::g_state.raypath_color.size()), 1);
@@ -872,7 +874,11 @@ void RegisterColorWindowTests(ImGuiTestEngine* engine) {
       ctx->ItemOpenAll(kColorsWindowRef);
       ctx->Yield(2);
 
-      ComboPick(ctx, "$$0/##body/$$0/##layer", "Layer 1");
+      // "Layer 2", not "Layer 1": the combo's labels are 1-based (DisplayLayerNumber), and the
+      // layer this case means is index 1 — the one holding the OTHER crystal, which is the whole
+      // point of the case. This edit is a semantic re-point, not a cosmetic relabel: before the
+      // numbering was unified, "Layer 1" here addressed index 1, and after it addresses index 0.
+      ComboPick(ctx, "$$0/##body/$$0/##layer", "Layer 2");
       ctx->Yield(2);
       IM_CHECK_EQ(gui::g_state.raypath_color[0].match[0].layer_idx, 1);
       IM_CHECK_EQ(gui::g_state.raypath_color[0].match[0].crystal_pool_id, 1);

--- a/test/gui/functional/test_edit_modal.cpp
+++ b/test/gui/functional/test_edit_modal.cpp
@@ -101,7 +101,7 @@ CommitOutcome RunFilterPresenceToggle(ImGuiTestContext* ctx, bool start_with_fil
   gui::g_state.last_committed_state = gui::GuiState::ConfigSnapshot::From(gui::g_state);
   ctx->Yield(2);
 
-  ctx->ItemClick("**/Edit##fi");
+  OpenCardEditor(ctx, 0, kFilterTabRef);
   ctx->Yield(4);
   ctx->ItemClick("**/###filter_tab");
   ctx->Yield(4);
@@ -171,7 +171,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       gui::g_state.modal_immediate_mode = false;
       ctx->Yield(2);
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       ImGuiWindow* blocking = ImGui::GetTopMostPopupModal();
       IM_CHECK(blocking != nullptr);
@@ -200,7 +200,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       gui::g_state.modal_immediate_mode = true;
       ctx->Yield(2);
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       IM_CHECK(ctx->ItemExists("**/###crystal_tab"));
 
@@ -236,7 +236,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       ctx->Yield(2);
 
       auto open = [ctx]() {
-        ctx->ItemClick("**/Edit##cr");
+        OpenCardEditor(ctx, 0, kCrystalTabRef);
         ctx->Yield(4);
         ImGuiWindow* w = ctx->GetWindowByRef("Edit Entry");
         IM_CHECK(w != nullptr);
@@ -283,7 +283,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       ctx->Yield(2);
       const float orig_h = EntryCrystal().height.center;
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       ctx->ItemInputValue(kHeightInput, orig_h + 4.0f);
       ctx->Yield(2);
@@ -292,7 +292,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(EntryCrystal().height, orig_h + 4.0f);
 
       // Reopen: the value came back from the entry, not from a buffer that outlived the window.
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       IM_CHECK_EQ(EntryCrystal().height, orig_h + 4.0f);
       ctx->ItemInputValue(kHeightInput, orig_h + 5.0f);
@@ -316,7 +316,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       gui::g_state.modal_immediate_mode = true;
       ctx->Yield(2);
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       IM_CHECK(ctx->ItemExists("**/###crystal_tab"));
 
@@ -348,7 +348,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       gui::g_state.modal_immediate_mode = true;
       ctx->Yield(2);
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       ImGuiWindow* w = ctx->GetWindowByRef("Edit Entry");
       IM_CHECK(w != nullptr);
@@ -382,7 +382,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       const ScopedPopups popup_guard(ctx);
       ctx->Yield(2);
 
-      ctx->ItemClick("**/Edit##ax");
+      OpenCardEditor(ctx, 0, kAxisTabRef);
       ctx->Yield(4);
       ctx->ItemClick("**/###axis_tab");
       ctx->Yield(2);
@@ -439,7 +439,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
 
       // Both exits unbind: a Cancel that left the target set would keep a card highlighted with no
       // modal on screen.
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       IM_CHECK(gui::IsEditModalOpen());
       IM_CHECK_EQ(gui::GetEditModalTarget().layer_idx, 0);
@@ -452,7 +452,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
         return;
       }
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       ctx->ItemClick(kOk);
       ctx->Yield(2);
@@ -496,7 +496,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       const gui::CrystalConfig baseline = EntryCrystal();
 
       // Cancel first, so the OK half below starts from a known-unchanged entry.
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(3);
       ctx->ItemInputValue(kHeightInput, baseline.height.center + 3.0f);
       ctx->Yield(2);
@@ -504,7 +504,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       ctx->Yield(2);
       IM_CHECK(EntryCrystal() == baseline);
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(3);
       ctx->ItemInputValue(kHeightInput, 5.0f);
       ctx->Yield(2);
@@ -534,7 +534,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       gui::g_state.dirty = false;
       ctx->Yield();
 
-      ctx->ItemClick("**/Edit##fi");
+      OpenCardEditor(ctx, 0, kFilterTabRef);
       ctx->Yield(4);
       ctx->ItemClick(kOk);
       ctx->Yield(2);
@@ -570,7 +570,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       gui::g_state.last_committed_state = gui::GuiState::ConfigSnapshot::From(gui::g_state);
       ctx->Yield();
 
-      ctx->ItemClick("**/Edit##fi");
+      OpenCardEditor(ctx, 0, kFilterTabRef);
       ctx->Yield(4);
       ctx->ItemClick("**/Remove Filter##filter");
       ctx->Yield(2);
@@ -624,7 +624,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       ctx->Yield(2);
       const float orig_h = EntryCrystal().height.center;
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       ctx->ItemInputValue(kHeightInput, orig_h + 2.5f);
       ctx->Yield(2);
@@ -659,7 +659,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       ctx->Yield();
       const float orig_h = EntryCrystal().height.center;
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       ctx->ItemClick("**/Immediate##edit_modal");
       ctx->Yield(6);
@@ -705,7 +705,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       gui::g_state.modal_immediate_mode = true;
       ctx->Yield(2);
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       ctx->ItemClick("**/###filter_tab");
       ctx->Yield(4);
@@ -764,7 +764,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       const ScopedPopups popup_guard(ctx);
       ctx->Yield(2);
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       IM_CHECK(ctx->ItemExists("**/##modal_preview_interact"));
       // The right pane resolved to a non-zero width, or the tab bar would not have been submitted.
@@ -807,7 +807,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       ctx->Yield(2);
       const float orig_h = EntryCrystal().height.center;
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       IM_CHECK(!TabIsDirty(ctx, "**/###crystal_tab"));
       IM_CHECK(!TabIsDirty(ctx, "**/###axis_tab"));
@@ -830,7 +830,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       ctx->Yield(2);
       ctx->ItemClick(kCancel);
       ctx->Yield(2);
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       IM_CHECK(!TabIsDirty(ctx, "**/###crystal_tab"));
 
@@ -839,7 +839,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       ctx->Yield(2);
       ctx->ItemClick(kOk);
       ctx->Yield(2);
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       IM_CHECK(!TabIsDirty(ctx, "**/###crystal_tab"));
       ctx->ItemClick(kCancel);
@@ -848,7 +848,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       // Immediate mode: every edit is already applied, so no tab may claim to be dirty.
       gui::g_state.modal_immediate_mode = true;
       ctx->Yield(2);
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       ctx->ItemInputValue(kHeightInput, orig_h + 4.0f);
       ctx->Yield(2);
@@ -872,7 +872,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       gui::g_state.modal_immediate_mode = false;
       ctx->Yield(2);
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       ctx->ItemClick("**/###filter_tab");
       ctx->Yield(4);
@@ -1100,7 +1100,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
         IM_CHECK_EQ(static_cast<int>(gui::ClassifyAxisPreset(cr.zenith, cr.azimuth, cr.roll)),
                     static_cast<int>(preset));
 
-        ctx->ItemClick("**/Edit##cr");
+        OpenCardEditor(ctx, 0, kCrystalTabRef);
         ctx->Yield(3);
         ctx->ItemClick("**/Reset View##modal");
         ctx->Yield(2);
@@ -1173,7 +1173,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
         ResetTestState();
         const ScopedPopups popup_guard(ctx);
         ctx->Yield(2);
-        ctx->ItemClick("**/Edit##cr");
+        OpenCardEditor(ctx, 0, kCrystalTabRef);
         ctx->Yield(3);
         ctx->ItemClick("**/###axis_tab");
         ctx->Yield(2);
@@ -1235,7 +1235,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       ResetTestState();
       const ScopedPopups popup_guard(ctx);
       ctx->Yield(2);
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(3);
 
       // Snapshot AFTER the drag, so the baseline is the dragged pose rather than the open-time one.
@@ -1277,7 +1277,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       cr.zenith = gui::AxisDist{ gui::AxisDistType::kGauss, 0.0f, 150.0f };  // legal for Gauss (max 180)
       ctx->Yield(2);
 
-      ctx->ItemClick("**/Edit##ax");
+      OpenCardEditor(ctx, 0, kAxisTabRef);
       ctx->Yield(4);
       ctx->ItemClick("**/###axis_tab");
       ctx->Yield(2);
@@ -1314,7 +1314,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       cr.zenith = gui::AxisDist{ gui::AxisDistType::kUniform, 0.0f, 90.0f };
       ctx->Yield(2);
 
-      ctx->ItemClick("**/Edit##ax");
+      OpenCardEditor(ctx, 0, kAxisTabRef);
       ctx->Yield(4);
       ctx->ItemClick("**/###axis_tab");
       ctx->Yield(2);
@@ -1344,7 +1344,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       gui::g_state.modal_immediate_mode = true;
       ctx->Yield(2);
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       IM_CHECK(ctx->ItemExists(kHeightInput));
       IM_CHECK(!ctx->ItemExists("**/##Prism H##modal_cr_input"));
@@ -1412,7 +1412,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
         EntryCrystal().type = row.type;
         ctx->Yield();
 
-        ctx->ItemClick("**/Edit##cr");
+        OpenCardEditor(ctx, 0, kCrystalTabRef);
         ctx->Yield(3);
         ctx->ItemInputValue(row.input, row.typed);
         ctx->Yield();
@@ -1456,7 +1456,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
         }
       }
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       IM_CHECK((ctx->ItemInfo("**/##spread_Height##modal_cr").ItemFlags & ImGuiItemFlags_Disabled) != 0);
 
@@ -1490,7 +1490,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       gui::g_state.modal_immediate_mode = true;
       ctx->Yield(2);
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       ctx->ItemOpen("**/Face Distance##modal");  // default-collapsed
       ctx->Yield(2);
@@ -1537,7 +1537,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       ctx->Yield(2);
 
       // A non-default baseline, so "back to defaults" has something to differ from.
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(3);
       ctx->ItemInputValue(kHeightInput, 5.0f);
       ctx->Yield();
@@ -1555,7 +1555,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       const gui::CrystalConfig before_modal = EntryCrystal();
 
       // First: Reset All followed by Cancel must leave the entry untouched.
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(3);
       ctx->ItemClick("**/Reset All##modal_cr");
       ctx->Yield();
@@ -1564,7 +1564,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       IM_CHECK(EntryCrystal() == before_modal);
 
       // Then: the same Reset All followed by OK does commit it.
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(3);
       ctx->ItemInputValue(kHeightInput, 2.0f);
       ctx->Yield();
@@ -1627,7 +1627,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
 
       gui::g_state.modal_layout_vertical = false;
       ctx->Yield(2);
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       gui::g_state.modal_layout_vertical = true;
       ctx->Yield(6);
@@ -1715,7 +1715,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
         // Same flag-flip dance as the case above, for the same reason.
         gui::g_state.modal_layout_vertical = !vertical;
         ctx->Yield(2);
-        ctx->ItemClick("**/Edit##cr");
+        OpenCardEditor(ctx, 0, kCrystalTabRef);
         ctx->Yield(4);
         gui::g_state.modal_layout_vertical = vertical;
         ctx->Yield(6);
@@ -1796,7 +1796,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       gui::g_state.modal_immediate_mode = true;
       ctx->Yield(2);
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       ctx->ItemOpen("**/Face Distance##modal");
       ctx->Yield(2);
@@ -1864,7 +1864,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       gui::g_state.modal_immediate_mode = true;
       ctx->Yield(2);
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       ctx->ItemOpen("**/Face Distance##modal");
       ctx->Yield(2);
@@ -1921,7 +1921,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       EntryCrystal().face_distance[1].sync_group = 2;
       const gui::CrystalConfig baseline = EntryCrystal();
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       ctx->ItemOpen("**/Face Distance##modal");
       ctx->Yield(2);
@@ -1965,7 +1965,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       EntryCrystal().height.sync_group = 4;
       EntryCrystal().type = gui::CrystalType::kPrism;
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       ctx->ItemClick("**/Pyramid##modal");
       ctx->Yield(3);
@@ -2016,7 +2016,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       const gui::ShapeDist leader_before = EntryCrystal().face_distance[0];
       const gui::ShapeDist member_before = EntryCrystal().face_distance[1];
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       ctx->ItemOpen("**/Face Distance##modal");
       ctx->Yield(2);
@@ -2083,7 +2083,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       cr.face_distance[1] = gui::ShapeDist{ gui::ShapeDistType::kUniform, 1.5f, 0.3f };
       cr.face_distance[1].sync_group = 2;  // slot 5 — the lowest slot the user can reach
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       ctx->ItemOpen("**/Face Distance##modal");
       ctx->Yield(2);
@@ -2177,7 +2177,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(EntryCrystal().height.sync_group, 1);
       IM_CHECK_EQ(EntryCrystal().face_distance[0].sync_group, 1);
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       ctx->ItemOpen("**/Face Distance##modal");
       ctx->Yield(2);
@@ -2313,7 +2313,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       // Face 5 joining group 1 snapshots from whatever the GUI thinks the leader is, so the value
       // that lands in the row IS the GUI's answer — read through a real click rather than by calling
       // the predicate.
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       ctx->ItemOpen("**/Face Distance##modal");
       ctx->Yield(2);
@@ -2366,7 +2366,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       ctx->Yield(2);
       EntryCrystal().type = gui::CrystalType::kPyramid;
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       ctx->ItemOpen("**/Face Distance##modal");
       ctx->Yield(2);
@@ -2412,7 +2412,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       gui::g_state.modal_immediate_mode = false;  // OK is what commits; this is the full user path
       ctx->Yield(2);
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       ctx->ItemOpen("**/Face Distance##modal");
       ctx->Yield(2);

--- a/test/gui/functional/test_entry_management.cpp
+++ b/test/gui/functional/test_entry_management.cpp
@@ -54,51 +54,6 @@ namespace {
 // run about the wrong thing.
 constexpr int kThumbnailFrames = 10;
 
-// The n-th entry card's window, in submission order.
-//
-// A card's widgets cannot be addressed by a path. RenderScatteringSection pushes the layer index
-// and RenderEntryCard the entry index, so every card's Edit button carries the same LABEL and a
-// different id — which is exactly the case a label wildcard cannot resolve (it stops at the first
-// match) and a literal path cannot either (the ids live under a BeginChild whose name ImGui
-// generates). What is unambiguous is the child window each card opens: they are submitted in card
-// order, so the n-th of them is the n-th card.
-ImGuiWindow* CardWindow(int index) {
-  ImGuiContext& g = *ImGui::GetCurrentContext();
-  int seen = 0;
-  for (ImGuiWindow* w : g.Windows) {
-    if (w->WasActive && (w->Flags & ImGuiWindowFlags_ChildWindow) != 0 && std::strstr(w->Name, "##card") != nullptr) {
-      if (seen == index) {
-        return w;
-      }
-      ++seen;
-    }
-  }
-  return nullptr;
-}
-
-// The blank area of a card, in screen coordinates.
-//
-// There is no widget there to click, and that is the point of the proposition: RenderEntryCard
-// hit-tests the card rectangle itself so the whole card is a target, and a test that clicked a
-// button instead would not exercise it. The thumbnail is the blank half — it is drawn into the
-// draw list rather than submitted as an item — and this stays inside its left edge, clear of the
-// right column's four rows of widgets and of the Delete/Duplicate stack at the card's right edge.
-//
-// Vertically it takes three quarters of the card's own height, which under the current layout
-// lands in the thumbnail's lower half — the card is the thumbnail plus window padding, so the
-// two are not independent quantities, but neither is the correspondence enforced anywhere. A
-// fixed offset from the top would not do: the top-left corner used to be blank and no longer is,
-// because the participation toggle is overlaid there, and while it does correctly keep the card's
-// click handler off itself (IsAnyItemHovered), a helper still pointing at that corner reports it
-// as "nothing to click" and silently turns three unrelated cases into a click on the toggle.
-// Anything added to a card's corners in future needs this same second look — the constraint is
-// that the returned point hits no item, and no compiler or gate enforces it.
-ImVec2 CardBlankSpot(int index) {
-  ImGuiWindow* w = CardWindow(index);
-  IM_CHECK_RETV(w != nullptr, ImVec2(0, 0));
-  return ImVec2(w->Pos.x + 30.0f, w->Pos.y + w->Size.y * 0.75f);
-}
-
 // A second entry in layer 0, bound to a pool slot of its own.
 void AddSecondEntryOnItsOwnSlot(ImGuiTestContext* ctx) {
   gui::CrystalConfig second;
@@ -591,19 +546,23 @@ void RegisterEntryManagementTests(ImGuiTestEngine* engine) {
   // Opening the modal from a card.
   // ================================================================================
 
-  // P66. Each of the three Edit buttons is a shortcut to one tab, not three ways to open the same
-  // one — the whole point of having three is that the user lands where they were going.
+  // P66. Opening a card and picking a tab lands on that tab's body — each of the three, from a
+  // cold open, without the previous tab's controls left standing.
+  //
+  // This used to be stated of three per-tab Edit buttons on the card ("each is a shortcut to one
+  // tab, not three ways to open the same one"). The buttons are gone; what is left is the path
+  // every user now takes, and it still has to land where it was going.
   {
-    ImGuiTest* t = IM_REGISTER_TEST(engine, "entry_management", "each_edit_button_opens_the_modal_on_its_own_tab");
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "entry_management", "opening_a_card_on_a_tab_lands_on_that_tabs_body");
     t->TestFunc = [](ImGuiTestContext* ctx) {
       struct Shortcut {
-        const char* button;
+        const char* tab_ref;
         const char* tab_content;  // an item that exists only while that tab's body is up
       };
       const Shortcut kShortcuts[] = {
-        { "Edit##cr", "**/##Height##modal_cr_input" },
-        { "Edit##ax", "**/Zenith/##Mean_input" },
-        { "Edit##fi", "**/##row_text_0" },
+        { kCrystalTabRef, "**/##Height##modal_cr_input" },
+        { kAxisTabRef, "**/Zenith/##Mean_input" },
+        { kFilterTabRef, "**/##row_text_0" },
       };
 
       for (const Shortcut& s : kShortcuts) {
@@ -615,10 +574,9 @@ void RegisterEntryManagementTests(ImGuiTestEngine* engine) {
         // closes the modal regardless, so that click has nothing left to do once this iteration
         // has already failed.
         const ScopedPopups popup_guard(ctx);
-        ctx->ItemClick((std::string("**/") + s.button).c_str());
-        ctx->Yield(4);
+        OpenCardEditor(ctx, 0, s.tab_ref);
         if (!ctx->ItemExists(s.tab_content)) {
-          IM_ERRORF("%s did not land on the tab that owns %s", s.button, s.tab_content);
+          IM_ERRORF("opening on %s did not land on the tab that owns %s", s.tab_ref, s.tab_content);
         }
         if (ctx->IsError()) {
           break;
@@ -701,7 +659,7 @@ void RegisterEntryManagementTests(ImGuiTestEngine* engine) {
       ctx->Yield(2);
       const ScopedPopups popup_guard(ctx);
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       IM_CHECK(gui::IsEditModalOpen());
       const float orig_h = gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id].height.center;
@@ -743,7 +701,7 @@ void RegisterEntryManagementTests(ImGuiTestEngine* engine) {
       IM_CHECK_EQ(gui::CountEntriesSharing(gui::g_state, shared_cid, std::nullopt), 2);
       const float shared_h = gui::g_state.crystals[shared_cid].height.center;
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       IM_CHECK(ctx->ItemExists("**/Unlink##share"));
       ctx->ItemClick("**/Unlink##share");
@@ -776,7 +734,7 @@ void RegisterEntryManagementTests(ImGuiTestEngine* engine) {
       const ScopedPopups popup_guard(ctx);
       AddSecondEntryOnItsOwnSlot(ctx);
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       const float orig_h = gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id].height.center;
       ctx->ItemInputValue("**/##Height##modal_cr_input", orig_h + 2.0f);
@@ -831,7 +789,7 @@ void RegisterEntryManagementTests(ImGuiTestEngine* engine) {
         AddSecondEntryOnItsOwnSlot(ctx);
         const int cid_before = gui::g_state.layers[0].entries[1].crystal_id;
 
-        ctx->ItemClick("**/Edit##cr");
+        OpenCardEditor(ctx, 0, kCrystalTabRef);
         ctx->Yield(4);
         ctx->ItemClick("**/Link to...##share");
         ctx->Yield(4);
@@ -902,7 +860,7 @@ void RegisterEntryManagementTests(ImGuiTestEngine* engine) {
       const int source_cid_before = gui::g_state.layers[0].entries[0].crystal_id;
       IM_CHECK_NE(target_cid, source_cid_before);
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       ctx->ItemClick("**/Link to...##share");
       ctx->Yield(4);
@@ -959,7 +917,7 @@ void RegisterEntryManagementTests(ImGuiTestEngine* engine) {
       ctx->Yield(3);
       IM_CHECK_EQ(gui::CountEntriesSharing(gui::g_state, 0, std::nullopt), 2);
 
-      ctx->ItemClick("**/Edit##fi");
+      OpenCardEditor(ctx, 0, kFilterTabRef);
       ctx->Yield(4);
       ctx->ItemInputValue("**/##row_text_0", "3-5");
       ctx->Yield(2);
@@ -993,7 +951,7 @@ void RegisterEntryManagementTests(ImGuiTestEngine* engine) {
       ctx->Yield(3);
       IM_CHECK_EQ(gui::CountEntriesSharing(gui::g_state, 0, gui::g_state.layers[0].entries[0].filter_id), 2);
 
-      ctx->ItemClick("**/Edit##fi");
+      OpenCardEditor(ctx, 0, kFilterTabRef);
       ctx->Yield(4);
       ctx->ItemClick("**/Remove Filter##filter");
       ctx->Yield(2);

--- a/test/gui/functional/test_entry_management.cpp
+++ b/test/gui/functional/test_entry_management.cpp
@@ -1205,30 +1205,57 @@ void RegisterEntryManagementTests(ImGuiTestEngine* engine) {
     };
   }
 
-  // A card's four rows are one three-column grid: Crystal/Axis/Filter are hand-built
-  // [text][Edit button][label] rows in RenderEntryCard, Weight is a SliderWithInput, and the
-  // comment above emit_row states outright that the four are meant to share their column
-  // boundaries. They are drawn by two different pieces of code that each compute the boundary
-  // from their own copy of the same formula, so the claim is exactly as strong as those two
-  // copies agreeing — which nothing else checks.
+  // A card's four rows are one two-column grid: Crystal/Axis/Filter are hand-built
+  // [label][value text] rows in RenderEntryCard, Weight is a SliderWithInput under
+  // LabelPlacement::kLeading. Both columns are reached by TWO different pieces of code — the hand-
+  // built rows place the value at `value_x`, while the Weight row gets there through
+  // BeginLeadingLabelLayout's own cursor advance — so the claim that the four share their column
+  // boundaries is exactly as strong as those two computations agreeing, which nothing else checks.
+  //
+  // Measured from real frames on both ends (label probe and value probe are pixel-neutral
+  // InvisibleButtons over the text; see TextWithLabelProbe / the value probe in panels.cpp), not
+  // derived from the layout constants — deriving either edge from kLabelColWidth +
+  // LabelColumnGapX() would compare the layout code against itself.
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "entry_management", "a_cards_four_rows_share_their_column_boundaries");
     t->TestFunc = [](ImGuiTestContext* ctx) {
       ResetTestState();
       ctx->Yield(3);
-      // One card, so the Edit buttons' labels are unambiguous for the wildcard search below.
+      // One card, so the probe ids below are unambiguous for the wildcard search.
       IM_CHECK_EQ(gui::g_state.layers[0].entries.size(), (size_t)1);
 
       // Collected before anything is asserted: every ImGuiTestContext action opens with
       // `if (IsError()) return;`, so an assertion between two ItemInfo calls would leave the rest
       // of the rows unmeasured and report the first offender as if it were the only one.
-      std::vector<LabelColumnRow> rows;
-      rows.push_back(MeasureWidgetRow(ctx, "Crystal", "**/Edit##cr", "**/##card_0_0_row_0_label"));
-      rows.push_back(MeasureWidgetRow(ctx, "Axis", "**/Edit##ax", "**/##card_0_0_row_1_label"));
-      rows.push_back(MeasureWidgetRow(ctx, "Filter", "**/Edit##fi", "**/##card_0_0_row_2_label"));
-      rows.push_back(MeasureWidgetRow(ctx, "Weight", "**/##Weight##prop_0_0_input", "**/##Weight##prop_0_0_label"));
+      struct CardRow {
+        const char* name;
+        float label_left;
+        float value_left;
+      };
+      std::vector<CardRow> rows;
+      rows.push_back({ "Crystal", ctx->ItemInfo("**/##card_0_0_row_0_label").RectFull.Min.x,
+                       ctx->ItemInfo("**/##card_0_0_row_0_value").RectFull.Min.x });
+      rows.push_back({ "Axis", ctx->ItemInfo("**/##card_0_0_row_1_label").RectFull.Min.x,
+                       ctx->ItemInfo("**/##card_0_0_row_1_value").RectFull.Min.x });
+      rows.push_back({ "Filter", ctx->ItemInfo("**/##card_0_0_row_2_label").RectFull.Min.x,
+                       ctx->ItemInfo("**/##card_0_0_row_2_value").RectFull.Min.x });
+      rows.push_back({ "Weight", ctx->ItemInfo("**/##Weight##prop_0_0_label").RectFull.Min.x,
+                       ctx->ItemInfo("**/##Weight##prop_0_0_slider").RectFull.Min.x });
 
-      CheckLabelColumn("entry card", rows);
+      // Pure comparison from here on — nothing drives ctx again, so a non-fatal report per
+      // offending row is safe and lets one run name every row that disagrees.
+      constexpr float kTolPx = 1.0f;
+      const CardRow& ref = rows[0];
+      for (size_t i = 1; i < rows.size(); ++i) {
+        if (ImFabs(rows[i].label_left - ref.label_left) > kTolPx) {
+          IM_ERRORF("entry card: label left edge %s=%.1f vs %s=%.1f (delta %.1f px)", rows[i].name, rows[i].label_left,
+                    ref.name, ref.label_left, rows[i].label_left - ref.label_left);
+        }
+        if (ImFabs(rows[i].value_left - ref.value_left) > kTolPx) {
+          IM_ERRORF("entry card: value left edge %s=%.1f vs %s=%.1f (delta %.1f px)", rows[i].name, rows[i].value_left,
+                    ref.name, ref.value_left, rows[i].value_left - ref.value_left);
+        }
+      }
     };
   }
 }

--- a/test/gui/functional/test_entry_management.cpp
+++ b/test/gui/functional/test_entry_management.cpp
@@ -900,6 +900,76 @@ void RegisterEntryManagementTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // The card's rail carries a Link-to button of its own, and it has to arm the SAME pick mode the
+  // modal's does. The two are one function (StartLinkPickMode) precisely so they cannot answer
+  // differently, and this case is what would notice if one of them grew its own copy again: the
+  // sibling case above drives the modal's button through the same assertions.
+  //
+  // Where they legitimately differ is the modal-buffer commit, which only the modal's button can
+  // reach — a card's rail is unclickable while a modal is up, since the modal blocks. That branch
+  // stays covered by link_to_arms_pick_mode_and_says_so_above_the_cards.
+  {
+    ImGuiTest* t =
+        IM_REGISTER_TEST(engine, "entry_management", "the_cards_link_button_arms_the_same_pick_mode_the_modal_does");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+      const ScopedPopups popup_guard(ctx);
+      AddSecondEntryOnItsOwnSlot(ctx);
+      const int target_cid = gui::g_state.layers[0].entries[1].crystal_id;
+      IM_CHECK_NE(target_cid, gui::g_state.layers[0].entries[0].crystal_id);
+
+      // No modal anywhere in this path — that is the point of putting the action on the card.
+      ctx->ItemClick("**/" ICON_FA_LINK "##link_0_0");
+      ctx->Yield(4);
+      IM_CHECK(!gui::IsEditModalOpen());
+      IM_CHECK(gui::g_state.pick_link_source.has_value());
+      IM_CHECK_EQ(gui::g_state.pick_link_source->layer_idx, 0);
+      IM_CHECK_EQ(gui::g_state.pick_link_source->entry_idx, 0);
+
+      // And it is a real pick, not just an armed flag: clicking the other card completes the link.
+      ctx->MouseMoveToPos(CardBlankSpot(1));
+      ctx->MouseClick(0);
+      ctx->Yield(6);
+      IM_CHECK(!gui::g_state.pick_link_source.has_value());
+      IM_CHECK_EQ(gui::g_state.layers[0].entries[0].crystal_id, target_cid);
+    };
+  }
+
+  // A name typed in the modal reaches the crystal, and Cancel leaves it alone. CrystalConfig::name
+  // has been in the document format all along with no control anywhere in the GUI writing it, so
+  // this is the first path that ever puts one there — and it is what the Colours window shows when
+  // it names a crystal.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "entry_management", "a_name_typed_in_the_modal_reaches_the_crystal");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+      const ScopedPopups popup_guard(ctx);
+      const int cid = gui::g_state.layers[0].entries[0].crystal_id;
+      IM_CHECK(gui::g_state.crystals[cid].name.empty());
+
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
+      ctx->Yield(4);
+      ctx->ItemInputValue("**/##crystal_name", "plate");
+      ctx->Yield(2);
+      ctx->ItemClick("**/" ICON_FA_CHECK " OK##edit_modal");
+      ctx->Yield(2);
+      IM_CHECK_STR_EQ(gui::g_state.crystals[cid].name.c_str(), "plate");
+      // The identity string every crystal-naming surface renders now carries it, id still leading.
+      IM_CHECK_STR_EQ(gui::FormatCrystalIdentity(gui::g_state, cid).c_str(), "#0 · plate · Prism");
+
+      // Cancel is a discard like every other field on this tab, not a special case.
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
+      ctx->Yield(4);
+      ctx->ItemInputValue("**/##crystal_name", "column");
+      ctx->Yield(2);
+      ctx->ItemClick("**/" ICON_FA_XMARK " Cancel##edit_modal");
+      ctx->Yield(2);
+      IM_CHECK_STR_EQ(gui::g_state.crystals[cid].name.c_str(), "plate");
+    };
+  }
+
   // A linked group shares its filter atomically: adding one to either card must bind both, or the
   // group silently stops being a group and the two cards start simulating different things while
   // still claiming to be linked.

--- a/test/gui/functional/test_entry_management.cpp
+++ b/test/gui/functional/test_entry_management.cpp
@@ -114,31 +114,61 @@ bool CaptureCardRect(ImGuiTestContext* ctx, int index, std::vector<unsigned char
   return true;
 }
 
-// Pixels that differ between two same-sized RGBA captures, counted only inside the outermost
-// `ring` rows and columns. The highlight under test is a BORDER colour, so it lives exactly there;
-// restricting the count to the ring is what keeps the card's interior — thumbnail included — out
-// of the comparison, so nothing the thumbnail cache does between two captures can reach it.
+// Pixels that differ between two same-sized RGBA captures, counted separately for each of the four
+// `ring`-deep strips along the rectangle's edge.
 //
-// Depth is device pixels, so `ring` covers one logical pixel of border on a Retina framebuffer and
-// two on a plain one; ImGui draws the child border one logical pixel wide.
-int EdgeRingDiff(const std::vector<unsigned char>& a, const std::vector<unsigned char>& b, int w, int h, int ring) {
+// Per side rather than as one total, because that is what makes the comparison say "a BORDER
+// changed" instead of "some pixel changed". A border wraps the card, so a real one moves all four
+// counts; anything local — a tooltip's corner, a redrawn glyph, one widget's own highlight — lands
+// on one side and leaves the other three at zero. Measured: with the highlight disabled, hovering
+// still moves a 28x2 blob on one edge, which a single "> 0" total would have accepted as proof.
+//
+// The interior is excluded entirely, so nothing the thumbnail cache does between two captures can
+// reach the judgement. Depth is device pixels: `ring` covers one logical pixel of border on a
+// Retina framebuffer and two on a plain one, and ImGui draws the child border one logical pixel
+// wide.
+struct RingDiff {
+  int left = -1;
+  int right = -1;
+  int top = -1;
+  int bottom = -1;
+
+  bool AllZero() const { return left == 0 && right == 0 && top == 0 && bottom == 0; }
+  bool AllChanged() const { return left > 0 && right > 0 && top > 0 && bottom > 0; }
+};
+
+RingDiff EdgeRingDiff(const std::vector<unsigned char>& a, const std::vector<unsigned char>& b, int w, int h,
+                      int ring) {
+  RingDiff out;
   if (a.size() != b.size() || w <= 2 * ring || h <= 2 * ring) {
-    return -1;
+    return out;
   }
-  int diff = 0;
+  out = RingDiff{ 0, 0, 0, 0 };
+  auto differs = [&](int x, int y) {
+    const size_t i = (static_cast<size_t>(y) * static_cast<size_t>(w) + static_cast<size_t>(x)) * 4;
+    return a[i] != b[i] || a[i + 1] != b[i + 1] || a[i + 2] != b[i + 2];
+  };
   for (int y = 0; y < h; ++y) {
-    const bool edge_row = y < ring || y >= h - ring;
-    for (int x = 0; x < w; ++x) {
-      if (!edge_row && x >= ring && x < w - ring) {
-        continue;
+    for (int x = 0; x < ring; ++x) {
+      if (differs(x, y)) {
+        ++out.left;
       }
-      const size_t i = (static_cast<size_t>(y) * static_cast<size_t>(w) + static_cast<size_t>(x)) * 4;
-      if (a[i] != b[i] || a[i + 1] != b[i + 1] || a[i + 2] != b[i + 2]) {
-        ++diff;
+      if (differs(w - 1 - x, y)) {
+        ++out.right;
       }
     }
   }
-  return diff;
+  for (int x = ring; x < w - ring; ++x) {
+    for (int y = 0; y < ring; ++y) {
+      if (differs(x, y)) {
+        ++out.top;
+      }
+      if (differs(x, h - 1 - y)) {
+        ++out.bottom;
+      }
+    }
+  }
+  return out;
 }
 
 // Somewhere that is not a card. The highlight is driven by the card child window's own hover
@@ -1020,9 +1050,14 @@ void RegisterEntryManagementTests(ImGuiTestEngine* engine) {
   // time the test coroutine runs at the end of the frame, nothing records whether it was ever
   // applied. Only the framebuffer does.
   //
-  // The control capture is what makes the comparison mean anything. Two captures taken with the
-  // pointer in the SAME place must be identical on the ring; if they are not, the ring is noisy and
-  // a difference measured across a pointer move would prove nothing. Assert that first, then move.
+  // Two things make the comparison mean something, and both were added after a red-state probe
+  // showed the obvious version of this case passing with the highlight compiled out.
+  //
+  // First, a control capture: two captures taken with the pointer in the SAME place must be
+  // identical on the ring, or the ring is noisy and a difference measured across a pointer move
+  // proves nothing. Second, the difference is required on ALL FOUR sides. Hovering moves a small
+  // blob on one edge even with the highlight gone — a total ">0" accepted that blob as proof, and
+  // a border is the one thing that cannot be local.
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "entry_management", "hovering_a_card_lights_its_border");
     t->TestFunc = [](ImGuiTestContext* ctx) {
@@ -1045,7 +1080,7 @@ void RegisterEntryManagementTests(ImGuiTestEngine* engine) {
       IM_CHECK(CaptureCardRect(ctx, 0, cold_b, w_b, h_b));
       IM_CHECK_EQ(w, w_b);
       IM_CHECK_EQ(h, h_b);
-      IM_CHECK_EQ(EdgeRingDiff(cold_a, cold_b, w, h, kRing), 0);
+      IM_CHECK(EdgeRingDiff(cold_a, cold_b, w, h, kRing).AllZero());
 
       ctx->MouseMoveToPos(CardBlankSpot(0));
       // The card writes its hover state into ImGuiStorage at the END of the frame it is hovered and
@@ -1057,7 +1092,7 @@ void RegisterEntryManagementTests(ImGuiTestEngine* engine) {
       IM_CHECK(CaptureCardRect(ctx, 0, hot, w_hot, h_hot));
       IM_CHECK_EQ(w, w_hot);
       IM_CHECK_EQ(h, h_hot);
-      IM_CHECK_GT(EdgeRingDiff(cold_b, hot, w, h, kRing), 0);
+      IM_CHECK(EdgeRingDiff(cold_b, hot, w, h, kRing).AllChanged());
 
       // And it goes back: a highlight that never clears would be a card stuck looking hovered.
       ctx->MouseMoveToPos(PointOffEveryCard());
@@ -1068,7 +1103,7 @@ void RegisterEntryManagementTests(ImGuiTestEngine* engine) {
       IM_CHECK(CaptureCardRect(ctx, 0, cooled, w_c, h_c));
       IM_CHECK_EQ(w, w_c);
       IM_CHECK_EQ(h, h_c);
-      IM_CHECK_EQ(EdgeRingDiff(cold_b, cooled, w, h, kRing), 0);
+      IM_CHECK(EdgeRingDiff(cold_b, cooled, w, h, kRing).AllZero());
     };
   }
 

--- a/test/gui/functional/test_entry_management.cpp
+++ b/test/gui/functional/test_entry_management.cpp
@@ -38,8 +38,11 @@
 // two cards independent; or a new layer that receives no rays at all because the layer above it
 // still passes none on.
 
+#include <algorithm>
+#include <cmath>
 #include <cstring>
 #include <string>
+#include <vector>
 
 #include "IconsFontAwesome6.h"
 #include "gui/edit_modals.hpp"  // IsEditModalOpen — the toggle must not also trip the card's click handler
@@ -75,6 +78,75 @@ void AddSecondEntryOnItsOwnSlot(ImGuiTestContext* ctx) {
 struct ScopedColorWindow {
   ~ScopedColorWindow() { gui::g_state.color_window_open = false; }
 };
+
+// Read one card's own rectangle back out of the default framebuffer.
+//
+// The theme_scan suite does this same rect arithmetic in ExportRegion, but it writes a PNG for a
+// human to look at and drops the pixels; the hover case below has to compare two captures, so this
+// one keeps them. Coordinates: ImGui screen space → framebuffer, which means scaling by the Retina
+// factor and flipping the origin (GL reads from the bottom-left, ImGui measures from the top-left).
+bool CaptureCardRect(ImGuiTestContext* ctx, int index, std::vector<unsigned char>& out, int& w_out, int& h_out) {
+  ImGuiWindow* card = CardWindow(index);
+  IM_CHECK_RETV(card != nullptr, false);
+  g_fullframe_capture.Reset();
+  const ImGuiIO& io = ImGui::GetIO();
+  const float sx = io.DisplayFramebufferScale.x;
+  const float sy = io.DisplayFramebufferScale.y;
+  const float fb_w = io.DisplaySize.x * sx;
+  const float fb_h = io.DisplaySize.y * sy;
+  const ImVec2 vp_pos = ImGui::GetMainViewport()->Pos;
+  const float x0 = std::max(0.0f, (card->Pos.x - vp_pos.x) * sx);
+  const float y0 = std::max(0.0f, (card->Pos.y - vp_pos.y) * sy);
+  const float x1 = std::min(fb_w, (card->Pos.x - vp_pos.x + card->Size.x) * sx);
+  const float y1 = std::min(fb_h, (card->Pos.y - vp_pos.y + card->Size.y) * sy);
+  g_fullframe_capture.rect_x = static_cast<int>(std::lround(x0));
+  g_fullframe_capture.rect_y = static_cast<int>(std::lround(fb_h - y1));
+  g_fullframe_capture.rect_w = static_cast<int>(std::lround(x1 - x0));
+  g_fullframe_capture.rect_h = static_cast<int>(std::lround(y1 - y0));
+  g_fullframe_capture.requested.store(true);
+  for (int i = 0; i < 10 && !g_fullframe_capture.done.load(); ++i) {
+    ctx->Yield();
+  }
+  IM_CHECK_RETV(g_fullframe_capture.done.load(), false);
+  out = g_fullframe_capture.pixels;
+  w_out = g_fullframe_capture.width;
+  h_out = g_fullframe_capture.height;
+  return true;
+}
+
+// Pixels that differ between two same-sized RGBA captures, counted only inside the outermost
+// `ring` rows and columns. The highlight under test is a BORDER colour, so it lives exactly there;
+// restricting the count to the ring is what keeps the card's interior — thumbnail included — out
+// of the comparison, so nothing the thumbnail cache does between two captures can reach it.
+//
+// Depth is device pixels, so `ring` covers one logical pixel of border on a Retina framebuffer and
+// two on a plain one; ImGui draws the child border one logical pixel wide.
+int EdgeRingDiff(const std::vector<unsigned char>& a, const std::vector<unsigned char>& b, int w, int h, int ring) {
+  if (a.size() != b.size() || w <= 2 * ring || h <= 2 * ring) {
+    return -1;
+  }
+  int diff = 0;
+  for (int y = 0; y < h; ++y) {
+    const bool edge_row = y < ring || y >= h - ring;
+    for (int x = 0; x < w; ++x) {
+      if (!edge_row && x >= ring && x < w - ring) {
+        continue;
+      }
+      const size_t i = (static_cast<size_t>(y) * static_cast<size_t>(w) + static_cast<size_t>(x)) * 4;
+      if (a[i] != b[i] || a[i + 1] != b[i + 1] || a[i + 2] != b[i + 2]) {
+        ++diff;
+      }
+    }
+  }
+  return diff;
+}
+
+// Somewhere that is not a card. The highlight is driven by the card child window's own hover
+// state, so any point outside every card leaves all of them cold.
+ImVec2 PointOffEveryCard() {
+  const ImGuiViewport* vp = ImGui::GetMainViewport();
+  return ImVec2(vp->Pos.x + vp->Size.x * 0.7f, vp->Pos.y + vp->Size.y * 0.5f);
+}
 
 }  // namespace
 
@@ -933,6 +1005,70 @@ void RegisterEntryManagementTests(ImGuiTestEngine* engine) {
       ctx->Yield(6);
       IM_CHECK(!gui::g_state.pick_link_source.has_value());
       IM_CHECK_EQ(gui::g_state.layers[0].entries[0].crystal_id, target_cid);
+    };
+  }
+
+  // The card's only remaining statement that anything on it can be edited.
+  //
+  // Three Edit buttons used to make that statement, and clicking the card itself made none — it is
+  // an invisible interaction. Removing the buttons is a net LOSS of discoverability unless the
+  // whole-card hover highlight replaces them, so "the highlight actually draws" is the load-bearing
+  // half of that trade, not a cosmetic detail.
+  //
+  // Read back in pixels rather than asserted on a style variable, because there is no variable left
+  // to read: the border colour is pushed before BeginChild and popped after EndChild, so by the
+  // time the test coroutine runs at the end of the frame, nothing records whether it was ever
+  // applied. Only the framebuffer does.
+  //
+  // The control capture is what makes the comparison mean anything. Two captures taken with the
+  // pointer in the SAME place must be identical on the ring; if they are not, the ring is noisy and
+  // a difference measured across a pointer move would prove nothing. Assert that first, then move.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "entry_management", "hovering_a_card_lights_its_border");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      ctx->Yield(2);
+      const ScopedPopups popup_guard(ctx);
+
+      constexpr int kRing = 2;
+      ctx->MouseMoveToPos(PointOffEveryCard());
+      ctx->Yield(4);
+
+      std::vector<unsigned char> cold_a;
+      std::vector<unsigned char> cold_b;
+      int w = 0;
+      int h = 0;
+      int w_b = 0;
+      int h_b = 0;
+      IM_CHECK(CaptureCardRect(ctx, 0, cold_a, w, h));
+      ctx->Yield(3);
+      IM_CHECK(CaptureCardRect(ctx, 0, cold_b, w_b, h_b));
+      IM_CHECK_EQ(w, w_b);
+      IM_CHECK_EQ(h, h_b);
+      IM_CHECK_EQ(EdgeRingDiff(cold_a, cold_b, w, h, kRing), 0);
+
+      ctx->MouseMoveToPos(CardBlankSpot(0));
+      // The card writes its hover state into ImGuiStorage at the END of the frame it is hovered and
+      // reads it back on the NEXT one, so the highlight trails the pointer by a frame by design.
+      ctx->Yield(4);
+      std::vector<unsigned char> hot;
+      int w_hot = 0;
+      int h_hot = 0;
+      IM_CHECK(CaptureCardRect(ctx, 0, hot, w_hot, h_hot));
+      IM_CHECK_EQ(w, w_hot);
+      IM_CHECK_EQ(h, h_hot);
+      IM_CHECK_GT(EdgeRingDiff(cold_b, hot, w, h, kRing), 0);
+
+      // And it goes back: a highlight that never clears would be a card stuck looking hovered.
+      ctx->MouseMoveToPos(PointOffEveryCard());
+      ctx->Yield(4);
+      std::vector<unsigned char> cooled;
+      int w_c = 0;
+      int h_c = 0;
+      IM_CHECK(CaptureCardRect(ctx, 0, cooled, w_c, h_c));
+      IM_CHECK_EQ(w, w_c);
+      IM_CHECK_EQ(h, h_c);
+      IM_CHECK_EQ(EdgeRingDiff(cold_b, cooled, w, h, kRing), 0);
     };
   }
 

--- a/test/gui/functional/test_filter_editor.cpp
+++ b/test/gui/functional/test_filter_editor.cpp
@@ -47,7 +47,7 @@ const char* const kAddRow = "**/+ Add OR row##summand_add";
 // Open the entry's Edit modal on its Filter tab. Four frames because the tab's SetSelected only
 // takes effect on the frame after the popup opens.
 void OpenFilterModal(ImGuiTestContext* ctx) {
-  ctx->ItemClick("**/Edit##fi");
+  OpenCardEditor(ctx, 0, kFilterTabRef);
   ctx->Yield(4);
 }
 

--- a/test/gui/functional/test_gui_face_number_overlay.cpp
+++ b/test/gui/functional/test_gui_face_number_overlay.cpp
@@ -40,7 +40,7 @@ void RegisterFaceNumberOverlayTests(ImGuiTestEngine* engine) {
       ResetTestState();
       lumice::gui::ResetLastCrystalMesh();
       ctx->Yield(2);
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
 
       const auto* mesh = lumice::gui::GetLastCrystalMesh();

--- a/test/gui/functional/test_gui_preview_animation.cpp
+++ b/test/gui/functional/test_gui_preview_animation.cpp
@@ -57,7 +57,7 @@ void RegisterPreviewAnimationTests(ImGuiTestEngine* engine) {
           gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id]));
       ctx->Yield(2);
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       const std::vector<float> before = SnapshotPreviewVertices();
 
@@ -84,7 +84,7 @@ void RegisterPreviewAnimationTests(ImGuiTestEngine* engine) {
           gui::g_state.crystals[gui::g_state.layers[0].entries[0].crystal_id]));
       ctx->Yield(2);
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       const std::vector<float> baseline = SnapshotPreviewVertices();
 
@@ -141,7 +141,7 @@ void RegisterPreviewAnimationTests(ImGuiTestEngine* engine) {
       ctx->Yield(2);
 
       // First session: advance well past two ticks so the internal seed has moved off the fixed seed.
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       ctx->Yield(kFramesPastOneTick * 2);
       const std::vector<float> advanced = SnapshotPreviewVertices();
@@ -151,7 +151,7 @@ void RegisterPreviewAnimationTests(ImGuiTestEngine* engine) {
 
       // Reopen the same entry: the first built frame must match the fixed-seed reference exactly,
       // proving the ticker reset rather than resuming the prior session's seed.
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
       const std::vector<float> reopened = SnapshotPreviewVertices();
 
@@ -181,7 +181,7 @@ void RegisterPreviewAnimationTests(ImGuiTestEngine* engine) {
       RandomizeEntry0FaceDistance();
       ctx->Yield(2);
 
-      ctx->ItemClick("**/Edit##cr");
+      OpenCardEditor(ctx, 0, kCrystalTabRef);
       ctx->Yield(4);
 
       float rot_before[16];

--- a/test/gui/references/_thresholds.json
+++ b/test/gui/references/_thresholds.json
@@ -1,7 +1,7 @@
 {
   "groups": {
     "capture_harness": {
-      "generated_at": "2026-08-30T04:00:08",
+      "generated_at": "2026-08-30T06:41:19",
       "n_ref_runs": 10,
       "n_calib_runs": 10,
       "scenes": {
@@ -64,7 +64,7 @@
       }
     },
     "modal_layout": {
-      "generated_at": "2026-08-14T04:53:46",
+      "generated_at": "2026-08-30T06:34:10",
       "n_ref_runs": 10,
       "n_calib_runs": 10,
       "scenes": {

--- a/test/gui/references/_thresholds.json
+++ b/test/gui/references/_thresholds.json
@@ -1,7 +1,7 @@
 {
   "groups": {
     "capture_harness": {
-      "generated_at": "2026-08-30T06:41:19",
+      "generated_at": "2026-08-30T13:00:08",
       "n_ref_runs": 10,
       "n_calib_runs": 10,
       "scenes": {

--- a/test/gui/references/left_panel_default.jpg
+++ b/test/gui/references/left_panel_default.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6ba55032022956dda3027519bb645e79093e43688de0fb76fd33b35e0cbc5686
-size 18979
+oid sha256:1ebea77f3ac0debeac3f7a78a7f7a7282276a1b2e5fcaa1228932373e8c51256
+size 18621

--- a/test/gui/references/left_panel_default.jpg
+++ b/test/gui/references/left_panel_default.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1ebea77f3ac0debeac3f7a78a7f7a7282276a1b2e5fcaa1228932373e8c51256
-size 18621
+oid sha256:e09461c48b64a3e227f17e7a8d307df0c4516030031325407dbb3de6c06df00a
+size 18502

--- a/test/gui/references/modal_layout_crystal_prism.png
+++ b/test/gui/references/modal_layout_crystal_prism.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ab50c4cb7ac389064bfabc0bdc30dad02181a18c1a340b275d2832dbbf42f95e
-size 38224
+oid sha256:2588ac065321be1da8aad0186743eb4b90f2731939a20028308fce244489ce60
+size 42870

--- a/test/gui/references/modal_layout_crystal_pyramid.png
+++ b/test/gui/references/modal_layout_crystal_pyramid.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0eba34f262c70c63e909da4d386f6f3fdded1dbca24133a0c5214c27729ebe0a
-size 59786
+oid sha256:a56f324693405faef742fa9fb52344c739d5e2e90c12215922f08b7f08f5e4a1
+size 64221

--- a/test/gui/references/smoke_fullframe.png
+++ b/test/gui/references/smoke_fullframe.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d8dd4bf0758fcd2e47850307bb603ff1cac0b6eda444b6685d22d8953da8b82f
-size 109213
+oid sha256:e9d130598beff55fe35f9ec54db274e6312e49c22a7f6f402b1142572cf99d04
+size 107409

--- a/test/gui/references/smoke_fullframe.png
+++ b/test/gui/references/smoke_fullframe.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8e9b37eb270f4bda6b2bdb778cf019312f4fbba30ea24bc90d5d522148026f49
-size 109146
+oid sha256:d8dd4bf0758fcd2e47850307bb603ff1cac0b6eda444b6685d22d8953da8b82f
+size 109213

--- a/test/gui/test_gui_main.cpp
+++ b/test/gui/test_gui_main.cpp
@@ -127,6 +127,44 @@ std::filesystem::path GuiTestTempPath(const std::string& filename) {
   return dir / filename;
 }
 
+ImGuiWindow* CardWindow(int index) {
+  ImGuiContext& g = *ImGui::GetCurrentContext();
+  int seen = 0;
+  for (ImGuiWindow* w : g.Windows) {
+    if (w->WasActive && (w->Flags & ImGuiWindowFlags_ChildWindow) != 0 && std::strstr(w->Name, "##card") != nullptr) {
+      if (seen == index) {
+        return w;
+      }
+      ++seen;
+    }
+  }
+  return nullptr;
+}
+
+ImVec2 CardBlankSpot(int index) {
+  ImGuiWindow* w = CardWindow(index);
+  IM_CHECK_RETV(w != nullptr, ImVec2(0, 0));
+  return ImVec2(w->Pos.x + 30.0f, w->Pos.y + w->Size.y * 0.75f);
+}
+
+void OpenCardEditor(ImGuiTestContext* ctx, int index, const char* tab_ref) {
+  ctx->MouseMoveToPos(CardBlankSpot(index));
+  ctx->MouseClick(ImGuiMouseButton_Left);
+  // Four, not one: the click sets an EditRequest that the next frame's app_panels pass turns into
+  // an open modal, and the modal's first frame is when its tab bar is first submitted — the tab
+  // click below has nothing to hit before then.
+  ctx->Yield(4);
+  // A card clicked while the modal is CLOSED always resolves to the Crystal tab (app_panels.cpp
+  // pins EditTarget::kCrystal on that branch), so clicking the tab would be a no-op. Skipping it is
+  // not just tidiness: every frame spent here is a frame the modal is up, and the crystal preview's
+  // animation ticker runs off frame time — the cases that assert on its FIRST built frame have
+  // roughly a tick's worth of budget between opening the modal and reading the mesh.
+  if (std::strcmp(tab_ref, kCrystalTabRef) != 0) {
+    ctx->ItemClick(tab_ref);
+    ctx->Yield(2);
+  }
+}
+
 void ResetTestState() {
   // Document state (delegates to DoNew: g_state, g_preview, g_crystal_mesh_id/hash)
   gui::DoNew();

--- a/test/gui/test_gui_shared.hpp
+++ b/test/gui/test_gui_shared.hpp
@@ -211,6 +211,53 @@ std::filesystem::path GuiTestTempPath(const std::string& filename);
 // ========== Shared functions (defined in test_gui_main.cpp) ==========
 
 void ResetTestState();
+
+// ---- Entry card addressing ----
+//
+// ImGuiWindow is forward-declared rather than included for the same reason IsDisabled is defined
+// out of line below: it lives in imgui_internal.h, and a header every suite includes is the wrong
+// place to drag that in. A caller that dereferences the returned pointer includes it itself.
+//
+// A card's widgets cannot be addressed by a path. RenderScatteringSection pushes the layer index
+// and RenderEntryCard the entry index, so every card's controls carry the same LABEL and a
+// different id — which is exactly the case a label wildcard cannot resolve (it stops at the first
+// match) and a literal path cannot either (the ids live under a BeginChild whose name ImGui
+// generates). What is unambiguous is the child window each card opens: they are submitted in card
+// order, so the n-th of them is the n-th card.
+struct ImGuiWindow;
+ImGuiWindow* CardWindow(int index);
+
+// The blank area of a card, in screen coordinates.
+//
+// There is no widget there, and that is the point: RenderEntryCard hit-tests the card rectangle
+// itself so the whole card is a target. The thumbnail is the blank half — it is drawn into the
+// draw list rather than submitted as an item — and this stays inside its left edge, clear of the
+// right column's four rows of widgets and of the icon rail at the card's right edge.
+//
+// Vertically it takes three quarters of the card's own height, which under the current layout
+// lands in the thumbnail's lower half — the card is the thumbnail plus window padding, so the
+// two are not independent quantities, but neither is the correspondence enforced anywhere. A
+// fixed offset from the top would not do: the top-left corner was blank, then was not (the
+// participation toggle was overlaid there for a while), and is blank again now that the toggle
+// moved into the rail. Anything added to a card's corners in future needs this same second look —
+// the constraint is that the returned point hits no item, and no compiler or gate enforces it.
+ImVec2 CardBlankSpot(int index);
+
+// The unified edit modal's three tab ids. Spelled once here rather than at each of the ~65 places
+// that open a tab, because they are also what OpenCardEditor dispatches on.
+constexpr const char* kCrystalTabRef = "**/###crystal_tab";
+constexpr const char* kAxisTabRef = "**/###axis_tab";
+constexpr const char* kFilterTabRef = "**/###filter_tab";
+
+// Open card `index`'s editor on `tab_ref`, the way a user does it: click the card, then pick the
+// tab. There is no other way left — the card used to carry one Edit button per tab, and the tab
+// bar was reachable only after one of them had been pressed. The buttons are gone (they were
+// shortcuts into a single tabbed modal, and they cost the middle column of every card row), so
+// every case that used to press one goes through here.
+//
+// Requires the modal to be CLOSED: it is a blocking popup, so a click aimed at a card behind it
+// does not reach the card. Cases that reopen the modal already close it first.
+void OpenCardEditor(ImGuiTestContext* ctx, int index, const char* tab_ref = kCrystalTabRef);
 // Pump frames until texture_upload_count has advanced past `baseline_upload_count`, or the
 // wall-clock budget runs out. Returns whether it advanced.
 //

--- a/test/unit-correctness/gui/test_gui_identity_formatting.cpp
+++ b/test/unit-correctness/gui/test_gui_identity_formatting.cpp
@@ -1,0 +1,167 @@
+// The four display formatters every panel now shares, and the ref-resolution decision the Colours
+// window's two combos make.
+//
+// These are grouped in one file because they are one defect family, not four functions. A user
+// reported that a colour class named a crystal and a layer that could not be found anywhere in the
+// left panel. Three independent things were true at once:
+//
+//   * The layer number was rendered 1-based in the panel header and file_io's overflow locator and
+//     0-based in four other places, so "Layer 1" meant different layers depending on which widget
+//     said it.
+//   * The crystal was addressed by a name the GUI had no control for, so every crystal created in
+//     the GUI was unnamed and the Colours window fell back to `crystal#N` — an N that appears on no
+//     card, and that is a POOL index, so it is not even the card's position in its layer.
+//   * A ref whose layer or crystal no longer existed was rendered with a clamped / first-in-list
+//     substitute, so the window showed a value that resolves while the scene received the stored
+//     one that does not.
+//
+// Each case below asserts against a hand-written expectation, never against a second call of the
+// function under test — the point is the exact string a user reads, so the string is written out.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "gui/app.hpp"
+#include "gui/color_window.hpp"
+#include "gui/gui_state.hpp"
+#include "lumice.h"
+
+namespace gui = lumice::gui;
+
+namespace {
+
+// A scene the resolution cases can break in specific ways: two layers, the second holding a crystal
+// the first does not.
+void SeedTwoLayerScene() {
+  gui::DoNew();
+  gui::g_state.crystals[0].name = "plate";
+
+  gui::CrystalConfig second;
+  second.name = "column";
+  second.type = gui::CrystalType::kPyramid;
+  gui::g_state.crystals.push_back(second);
+
+  gui::Layer layer1;
+  gui::EntryCard entry;
+  entry.crystal_id = 1;
+  layer1.entries.push_back(entry);
+  gui::g_state.layers.push_back(layer1);
+}
+
+gui::ColorClassRefConfig Ref(int layer_idx, int crystal_pool_id) {
+  gui::ColorClassRefConfig ref;
+  ref.layer_idx = layer_idx;
+  ref.crystal_pool_id = crystal_pool_id;
+  ref.match_all = true;
+  return ref;
+}
+
+}  // namespace
+
+// ---- Layer / entry numbering ----
+
+// Stored indices are 0-based (they are vector subscripts) and every user-visible rendering of them
+// is 1-based. These two assertions look trivial and are the whole point: the conversion existed as a
+// re-typed `+ 1` at six sites, four of which had it missing.
+TEST(DisplayNumbering, IndexZeroIsTheFirstOneTheUserSees) {
+  EXPECT_EQ(gui::DisplayLayerNumber(0), 1);
+  EXPECT_EQ(gui::DisplayEntryNumber(0), 1);
+  EXPECT_EQ(gui::DisplayLayerNumber(4), 5);
+  EXPECT_EQ(gui::DisplayEntryNumber(4), 5);
+}
+
+// ---- Crystal identity ----
+
+TEST(CrystalIdentity, LeadsWithThePoolIdThenTheNameThenTheType) {
+  gui::DoNew();
+  gui::g_state.crystals[0].name = "plate";
+  EXPECT_EQ(gui::FormatCrystalIdentity(gui::g_state, 0), "#0 · plate · Prism");
+}
+
+// The id is never dropped in favour of the name. Nothing stops two crystals sharing a name, and two
+// identical entries in a combo are worse to choose between than two id-led ones.
+TEST(CrystalIdentity, KeepsThePoolIdEvenWhenTwoCrystalsShareAName) {
+  gui::DoNew();
+  gui::g_state.crystals[0].name = "twin";
+  gui::CrystalConfig second;
+  second.name = "twin";
+  gui::g_state.crystals.push_back(second);
+
+  const std::string a = gui::FormatCrystalIdentity(gui::g_state, 0);
+  const std::string b = gui::FormatCrystalIdentity(gui::g_state, 1);
+  EXPECT_EQ(a, "#0 · twin · Prism");
+  EXPECT_EQ(b, "#1 · twin · Prism");
+  EXPECT_NE(a, b) << "two same-named crystals must still be distinguishable in a combo";
+}
+
+TEST(CrystalIdentity, AnUnnamedCrystalIsIdAndTypeWithNoEmptySegment) {
+  gui::DoNew();
+  gui::CrystalConfig pyramid;
+  pyramid.type = gui::CrystalType::kPyramid;
+  gui::g_state.crystals.push_back(pyramid);
+  EXPECT_EQ(gui::FormatCrystalIdentity(gui::g_state, 1), "#1 · Pyramid");
+}
+
+// A dangling ref's whole diagnostic value is WHICH id dangles, so the id leads even here.
+TEST(CrystalIdentity, ADanglingPoolIdStillShowsTheIdItStored) {
+  gui::DoNew();
+  EXPECT_EQ(gui::FormatCrystalIdentity(gui::g_state, 7), "#7 <missing>");
+  EXPECT_EQ(gui::FormatCrystalIdentity(gui::g_state, -1), "#-1 <missing>");
+}
+
+// The anti-drift pin. CrystalDisplayName is the Colours window's `const char*` adapter and is the
+// site that historically carried its own spelling; if a branch is ever added back to it, the card
+// and the Colours window start naming the same crystal differently again and this goes red.
+TEST(CrystalIdentity, TheColorsWindowAdapterSpellsItExactlyLikeTheSharedFormatter) {
+  SeedTwoLayerScene();
+  gui::CrystalConfig unnamed;
+  gui::g_state.crystals.push_back(unnamed);  // pool id 2, no name
+
+  for (int pool_id : { -1, 0, 1, 2, 9 }) {
+    SCOPED_TRACE(pool_id);
+    EXPECT_EQ(std::string(gui::CrystalDisplayName(gui::g_state, pool_id)),
+              gui::FormatCrystalIdentity(gui::g_state, pool_id));
+  }
+}
+
+// ---- Colour-ref resolution ----
+
+TEST(ColorRefResolution, ARefIntoALayerThatHoldsItsCrystalResolves) {
+  SeedTwoLayerScene();
+  EXPECT_EQ(gui::ResolveColorRef(gui::g_state, Ref(1, 1)), gui::ColorRefResolution::kResolved);
+  EXPECT_EQ(gui::FormatColorRefLayerLabel(gui::g_state, Ref(1, 1)), "Layer 2");
+  EXPECT_EQ(gui::FormatColorRefCrystalLabel(gui::g_state, Ref(1, 1)), "#1 · column · Pyramid");
+}
+
+// The layer half of the display/truth split. The window used to clamp this index for display only:
+// a ref storing layer 1 in a one-layer scene rendered as layer 0 while the scene received 1.
+TEST(ColorRefResolution, AMissingLayerIsNamedByTheNumberTheRefActuallyStores) {
+  gui::DoNew();  // one layer
+  const gui::ColorClassRefConfig ref = Ref(1, 0);
+  EXPECT_EQ(gui::ResolveColorRef(gui::g_state, ref), gui::ColorRefResolution::kLayerMissing);
+
+  const std::string label = gui::FormatColorRefLayerLabel(gui::g_state, ref);
+  EXPECT_EQ(label, "Layer 2 (deleted)");
+  EXPECT_NE(label, "Layer 1") << "the label showed the layer the ref would be clamped to, not the one it stores";
+}
+
+// The crystal half of the same split: a pool id absent from the chosen layer used to render as that
+// layer's FIRST crystal, silently, while the ref kept pointing somewhere else.
+TEST(ColorRefResolution, ACrystalAbsentFromTheLayerIsNamedByTheIdTheRefStores) {
+  SeedTwoLayerScene();
+  const gui::ColorClassRefConfig ref = Ref(0, 1);  // crystal 1 lives in layer 1, not layer 0
+  EXPECT_EQ(gui::ResolveColorRef(gui::g_state, ref), gui::ColorRefResolution::kCrystalNotInLayer);
+
+  const std::string label = gui::FormatColorRefCrystalLabel(gui::g_state, ref);
+  EXPECT_EQ(label, "#1 · column · Pyramid (not in this layer)");
+  EXPECT_EQ(label.find("plate"), std::string::npos) << "the label named layer 0's first crystal instead of the ref's";
+}
+
+// A ref can be broken in both halves at once; the layer is the outer question, so it wins the
+// report. Otherwise a ref pointing into a deleted layer would be described by which crystals that
+// (non-existent) layer does not contain.
+TEST(ColorRefResolution, AMissingLayerIsReportedBeforeAMissingCrystal) {
+  gui::DoNew();
+  EXPECT_EQ(gui::ResolveColorRef(gui::g_state, Ref(3, 9)), gui::ColorRefResolution::kLayerMissing);
+}


### PR DESCRIPTION
## 起因

用户报告：Colors 面板加 ref 时，选择的 layer 和 crystal 在左侧晶体卡片上找不到对应物。核查确认了三个白盒缺陷，并借同一次改动把卡片 layout 重排到位（两者抢同一块地皮，分开做会把卡片行 0 的排版改两遍）。

## 修的三个缺陷

**① layer 编号两套基数。** 卡片头 `"Layer %d", layer_idx + 1` 是 1-based（`panels.cpp`），而 Colors 的 layer combo / Import 弹窗 / class 摘要都是 0-based（`color_window.cpp`）。同一份文档，左边叫 "Layer 2" 的东西在 Colors 里叫 "Layer 1"——两个名字都存在，所以不报错、不可疑，只是静默指向错的那一层。Entry 编号同族（link tooltip、pick-mode 提示条）。1-based 本就是本仓写下来的约定（`file_io.cpp` 的 overflow 定位串注释 + 单测），这 6 处只是没跟上。

**② 晶体身份不可寻址**（比缺编号严重）。`CrystalDisplayName` 无名时回落 `crystal#<pool_id>`，而 `CrystalConfig::name` **只在读文件时被赋值**，GUI 里没有任何控件写它 ⇒ GUI 建的文档每个晶体都无名。该 pool id 卡片上不显示，卡片也没有任何序号；且 pool 只增不减（删条目从不回收槽），所以 id 连"第几张卡"都不是。用户没有任何途径回答 "`crystal#1` 是哪一张卡片"。

**③ Colors ref 显示值 ≠ 真值。** layer combo 的 `std::clamp` 结果只用于显示不写回；crystal combo 在 ref 不属于当前层时静默显示该层第一个晶体。而 `AddColorClasses` 只校验 crystal 悬空、不校验 layer 越界 ⇒ 界面显示一层、送进 core 的是另一层。

## 改了什么

- **卡片重排**：去掉三个 Edit 按钮（卡片点击本就打开同一个带 TabBar 的 modal，它们只是 tab 快捷方式）、标签前置、右缘 4 格常驻 icon rail（participating / link-to / duplicate / delete）、文本跨占原 [值+输入] 两列。link-to 从 modal 内提到卡片上，少一步。
- **身份串** `#N · name · type`，卡片与 Colors 由**同一个** `FormatCrystalIdentity` 产出。id 常驻不被 name 取代（无机制阻止重名，重名后 combo 会出现两个完全相同的选项，比 `crystal#N` 更糟）。
- **`CrystalConfig::name` 首次可在 GUI 编辑**（Crystal modal），`.lmc`/JSON 双路径往返保真。
- **编号统一 1-based**，6 处站点全取自共享 formatter，不是各撒一个 `+1`。
- **Colors ref 失效态显式化**：`ResolveColorRef` / `FormatColorRef*Label` 把判定与渲染物理分离（可脱离 ImGui context 测试），悬空时显示警示色 + 实际存值，不再拿看起来正常的值顶替。`AddColorClasses` 补 layer 越界校验。

Axis 行内容**不动**，保留 `Column / Plate / Parry / Lowitz / Random / Custom`——学界通行的 axis orientation 标签。

## 验收（`doc/gui-layout-architecture.md` §8 的强制程序）

重排既有界面前须机械量出两个数，这正是上次 GUI 重排被内测否决时缺的：

- **操作步数**：改 Axis / 改 Filter 各 +1（少了 tab 快捷方式），Link to −1，删除/复制少一次悬停唤出，其余不变。
- **一屏可见字段只增不减**：`FilterSummary` 原有的 12 字符截断存在的理由，注释原文是 *"keeps the card text inside the row it shares with the Edit button"*——即 Edit 按钮在直接花钱买"信息看不见"。本 PR 放宽了它。

**AC3（可发现性不得净损失）**：删按钮后补了整卡 hover 边框反馈。第一版断言是**假绿**——把 `hover_border` 强制 false 后测试照样过，被红态探针抓出，根因是判据量错了东西（"环上总差异 > 0"是代理量，局部 28×2 像素斑块即可满足）。改为四条边独立计数、要求四边全变。

## 与 task-465（#281）的集成

465 把行末标签间距收敛为单一 owner `LabelColumnGapX()` = `ItemInnerSpacing.x`(4px)，与本分支平行的私有 owner 改在同一函数区域。rebase 时删除私有 owner、全部改读 `LabelColumnGapX()`——卡片 label→value 间距因此 8px → 4px，是真实几何变化。

两处 git 无法察觉、需人工判断：`BeginLeadingLabelLayout` 的定义会被 HEAD 侧整段覆盖（两个调用点引用不存在的函数，编译期才炸）；465 的卡片列对齐测试引用了已删除的 `Edit##cr`——**重写而非删除**，因为它要防的缺陷形态仍在（行 0-2 的值列位置由 `emit_row` 算、Weight 行由 `BeginLeadingLabelLayout` 算，仍是两份各自计算同一公式），改为断言四行标签左缘 + 值左缘双列对齐，两端均取自真实帧。

参考图：`left_panel`（visual 组不在 regen `GROUPS` 里，按文档手工重拍）+ `capture_harness/fullframe`（脚本，10/10 逐像素一致，阈值不变）。`modal_layout` 的变化来自新增的 Name 输入框，与 gap 无关。

## 验证

- `./scripts/test.sh quick` **RESULT: PASS**（ctest 7/7、fast-e2e 86 passed、gui_test 315/315）
- code review 两轮，round 2 **APPROVE**（0 Critical / 0 Major）
- 红态探针自证：AC7 两条（commit 侧删越界校验 / 显示侧改回旧 clamp，均转红且只打中该打中的）、AC3 一条（第一版判据被证伪后改判据）

## 已知边界

- 卡片侧身份串一致性靠 `left_panel` 参考图承担，比 Colors 侧的断言弱一档：卡片 Row 0 用 `TextUnformatted` 绘制，gui_test 读不到该文本。不为凑自动化断言给生产代码加只为测试存在的可寻址控件。
- Crystal Name 输入框固定 64 字节缓冲，历史文档中 ≥64 字节的名字在 modal 内静默截断显示（不影响底层 `cr.name`）。
- 有意不做：全 app 统一前置标签、Axis 行富余宽度填充、filter name 的 GUI 编辑入口。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrNng4e5weEV99WMHEQw5S
