### PR TITLE
退役 raypath 逗号连接符：静默算错改为指名改法的拒绝 + 加载期迁移

### DIFF
--- a/doc/gui-guide.md
+++ b/doc/gui-guide.md
@@ -193,6 +193,8 @@ A factor is either a **raypath** or an **entry-exit** token:
 | Length (at most) | `len:<=5` | ray length **≤** 5 |
 | Length (range) | `len:2-3` | ray length in **[2, 3]** |
 
+**`,` is not a raypath connector.** Only `-` joins faces on the same path, and `;` separates alternate paths; a raypath token containing `,` (e.g. `3-5,1-2`) is rejected, with a message naming both. It used to be accepted as a second spelling of `-`, which meant `3-5,1-2` — typed to mean *two* paths — silently became the single four-face path `3-5-1-2` and rendered almost nothing. The `entry:1,2` comma in the table above is different, deliberate syntax: an OR-list on one entry/exit token, not a raypath. A `.lmc` written before this was enforced still loads — the `,` in its raypath tokens is rewritten to `-` on load, keeping the path it had, and the file is normalized the next time you save.
+
 `entry:` / `exit:` / `len:` tokens in the **same row** merge into a single entry-exit factor (so `entry:2 & exit:4 & len:<=5` is one entry-exit predicate, not three). Repeating a token in one row is an error — use the comma list for multiple faces (`entry:2,3`, not `entry:2 & entry:3`).
 
 **Examples**

--- a/src/config/raypath_validation.cpp
+++ b/src/config/raypath_validation.cpp
@@ -12,7 +12,7 @@ namespace lumice {
 namespace {
 
 bool IsSeparator(char c) {
-  return c == '-' || c == ',';
+  return c == '-';
 }
 
 bool AllSeparators(const std::string& text) {
@@ -24,6 +24,13 @@ bool AllSeparators(const std::string& text) {
   return true;
 }
 
+// ⚠️ Cross-file duplicate predicate: `ParseRaypathSegment` (src/gui/raypath_segments.hpp) runs an
+// identical "every character of the token is a digit" test, and the two accept sets MUST stay
+// identical — a validator that accepts what the parser drops (or the reverse) is exactly the
+// two-authority split this separator retirement was written to remove. Sharing one implementation
+// is not possible here: this helper lives in `src/config/`, and AGENTS.md's public-API boundary
+// (enforced by scripts/check_policies.py) forbids `src/gui/` from including config/ or core/
+// headers. So changing either side means changing both, by hand.
 bool TokenAllDigits(const std::string& text, int begin, int end) {
   for (int i = begin; i < end; ++i) {
     if (!std::isdigit(static_cast<unsigned char>(text[i]))) {
@@ -117,6 +124,16 @@ const char* CrystalKindLabel(CrystalKind kind) {
 // syntax-only validator.
 constexpr int kMaxFaceDigits = 3;
 
+// The dedicated message for the retired ',' path connector, used instead of the generic
+// "Invalid raypath". Telling the user which character to type is the entire point: ',' used to be
+// silently normalized to '-', so `3-5,1-2` (meant as two paths) became the single four-face path
+// 3-5-1-2 — legal on a prism, hence green border, hence no diagnostic anywhere. The message names
+// both separators because the two mistakes it has to disambiguate are different: '-' for faces on
+// one path, ';' for alternate paths.
+constexpr const char* kCommaConnectorMessage =
+    "',' is not a path connector: use '-' to join faces on the same path (3-5), "
+    "use ';' to separate different paths (3-5;1-2)";
+
 // Parse the next numeric token starting at `pos`, advancing `pos` past the
 // token and any following separator. Returns true and writes `face` on
 // success; returns false if the token is not a non-negative integer.
@@ -128,7 +145,7 @@ constexpr int kMaxFaceDigits = 3;
 // UB while still reporting the token as illegal).
 bool ExtractNextFace(const std::string& text, size_t& pos, int& face) {
   // Skip any separators.
-  while (pos < text.size() && (text[pos] == '-' || text[pos] == ',')) {
+  while (pos < text.size() && IsSeparator(text[pos])) {
     ++pos;
   }
   if (pos >= text.size()) {
@@ -160,7 +177,9 @@ RaypathValidationResult ValidateRaypathText(const std::string& text, CrystalKind
   if (syntax_state != RaypathValidation::kValid) {
     RaypathValidationResult r;
     r.state = syntax_state;
-    r.message = (syntax_state == RaypathValidation::kInvalid) ? "Invalid raypath" : std::string{};
+    if (syntax_state == RaypathValidation::kInvalid) {
+      r.message = (text.find(',') != std::string::npos) ? kCommaConnectorMessage : "Invalid raypath";
+    }
     return r;
   }
 

--- a/src/config/raypath_validation.hpp
+++ b/src/config/raypath_validation.hpp
@@ -25,12 +25,14 @@ struct RaypathValidationResult {
   std::string message;
 };
 
-/// Validate a raypath text string (dash- or comma-separated face indices).
+/// Validate a raypath text string (dash-separated face indices, e.g. "3-5").
 ///
 /// Rules (evaluated in priority order):
 ///   - Empty string → kValid (means "no raypath filter").
 ///   - Consecutive separators anywhere (e.g. "3--5", "--3") → kInvalid.
-///   - Any token that is not a non-negative integer → kInvalid.
+///   - Any token that is not a non-negative integer → kInvalid. This includes any use of ',',
+///     which is retired legacy syntax: '-' joins faces on the same path and ';' separates
+///     alternate paths (the ';' level lives in the GUI's ValidateRaypathTextMultiSegment).
 ///   - Trailing separator (e.g. "3-5-") → kIncomplete.
 ///   - Leading separator (e.g. "-3") → kIncomplete.
 ///   - All tokens are non-negative integers → kValid.
@@ -52,6 +54,10 @@ RaypathValidation ValidateRaypathText(const std::string& text);
 ///   - Finally each token is checked against the kind-specific legal set via
 ///     `IsLegalFace(kind, face)`; the first token that fails yields a
 ///     "Face N is not legal on this crystal type (Prism/Pyramid)" message.
+///   - A ',' anywhere in the text is a syntax error whose message specifically names '-' and ';'
+///     as the correct separators, rather than the generic "Invalid raypath". Telling the user
+///     which character to type is the point: ',' used to be normalized to '-' silently, so
+///     "3-5,1-2" (meant as two paths) validated as one four-face path and rendered nothing.
 ///
 /// The single-argument `ValidateRaypathText(text)` overload remains unchanged
 /// and performs syntax-only validation (so e.g. `"51"` is still kValid).

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -14,7 +14,6 @@
 #include <map>
 #include <nlohmann/json.hpp>
 #include <optional>
-#include <sstream>
 #include <utility>
 #include <vector>
 
@@ -87,30 +86,6 @@ static_assert(sizeof(kAspectPresetJsonNames) / sizeof(kAspectPresetJsonNames[0])
 
 
 // ========== Shared helpers ==========
-
-std::vector<int> ParseRaypathText(const std::string& text) {
-  std::vector<int> result;
-  // Normalize: replace ',' with '-' so both separators are accepted
-  std::string normalized = text;
-  for (auto& c : normalized) {
-    if (c == ',')
-      c = '-';
-  }
-  std::istringstream iss(normalized);
-  std::string token;
-  while (std::getline(iss, token, '-')) {
-    if (token.empty())
-      continue;
-    try {
-      int val = std::stoi(token);
-      if (val < 0)
-        continue;
-      result.push_back(val);
-    } catch (...) {
-    }
-  }
-  return result;
-}
 
 static const char* AxisDistTypeToString(AxisDistType t) {
   switch (t) {
@@ -1035,6 +1010,28 @@ int TakeFilterNoPredicateDowngradeCount() {
   return n;
 }
 
+// Count of raypath texts rewritten off the retired ',' connector on load. Same TU-local counter
+// shape and same call discipline as the two above.
+static int g_raypath_comma_migrated_count = 0;
+
+int TakeRaypathCommaMigratedCount() {
+  int n = g_raypath_comma_migrated_count;
+  g_raypath_comma_migrated_count = 0;
+  return n;
+}
+
+// The single place that decides both "how is a legacy ',' rewritten" and "does that count". Both
+// readers below need the pair, and they need the same answer; a second spelling of it is a second
+// thing to keep in sync. The two call sites keep their own downstream construction (a SummandText
+// row vs a FromLegacyRaypath fan-out) — those are different types and do not belong in here.
+static std::string MigrateAndCountRaypathComma(const std::string& text) {
+  std::string migrated = MigrateLegacyRaypathCommaConnector(text);
+  if (migrated != text) {
+    ++g_raypath_comma_migrated_count;
+  }
+  return migrated;
+}
+
 // The single disposition point for "the file's filter object states no predicate".
 //
 // Both readers below can end there — a v3 `summands` array that yields no rows, and a legacy form
@@ -1079,7 +1076,7 @@ static std::optional<FilterConfig> ParseFilterFromGuiJson(const json& jf) {
         GUI_LOG_WARNING("[FileIO] Filter summands entry is not a string; skipping row.");
         continue;
       }
-      std::string text = js.get<std::string>();
+      std::string text = MigrateAndCountRaypathComma(js.get<std::string>());
       sop.push_back(SummandText{ text, ParseSummandText(text) });
     }
     // An empty summands array is not a valid state, and the disposition is the one at the bottom
@@ -1130,7 +1127,8 @@ static std::optional<FilterConfig> ParseFilterFromGuiJson(const json& jf) {
       GUI_LOG_WARNING("[FileIO] Unknown filter type '{}', defaulting to raypath", type);
     }
     // FromLegacyRaypath splits ';' multi-segment sugar into canonical OR rows.
-    f.param = FromLegacyRaypath(RaypathParams{ jf.value("raypath_text", RaypathParams{}.raypath_text) });
+    f.param = FromLegacyRaypath(
+        RaypathParams{ MigrateAndCountRaypathComma(jf.value("raypath_text", RaypathParams{}.raypath_text)) });
   }
   return NoFilterIfNoPredicate(std::move(f));
 }
@@ -2576,10 +2574,12 @@ std::string SerializeGuiStateJson(const GuiState& state) {
 
   // Schema version. v=2 added the filter `type` discriminator; v=3
   // (task-serialization-bidirectional) replaces the per-filter degenerate form
-  // with the full sum-of-products "summands" array. Loader is tolerant of older
-  // forms (v=1/v=2 filters upgrade to a SoP), so this is a soft signal, not a
+  // with the full sum-of-products "summands" array. v=4 retires the ',' raypath-token
+  // connector: a ',' inside a raypath token is rejected by the validator, and one found on
+  // load is rewritten to '-' (see MigrateLegacyRaypathCommaConnector). Loader is tolerant of
+  // older forms (v=1/v=2/v=3 all still migrate correctly), so this is a soft signal, not a
   // load gate — the binary kLmcVersion header is the actual gate (see §2.7).
-  root["schema_version"] = 3;
+  root["schema_version"] = 4;
 
   return root.dump(2);
 }
@@ -2596,6 +2596,7 @@ bool DeserializeGuiStateJson(const std::string& json_str, GuiState& state) {
   }
 
   state = GuiState{};
+  g_raypath_comma_migrated_count = 0;
 
   // Layers — on-disk format is v2 inline (each entry embeds its crystal/filter
   // JSON). Load path: append each inline crystal/filter into the runtime
@@ -2824,6 +2825,16 @@ bool DeserializeGuiStateJson(const std::string& json_str, GuiState& state) {
   // Panel state
   state.right_panel_collapsed = root.value("right_panel_collapsed", GuiState{}.right_panel_collapsed);
   state.modal_layout_vertical = root.value("modal_layout_vertical", GuiState{}.modal_layout_vertical);
+
+  // One line per load, not per rewritten row — the count is in the text. Reported here rather than
+  // in each caller so that adding a caller cannot silently drop the notice; this function has
+  // exactly two exits, and the other one (JSON parse failure) precedes any migration.
+  if (g_raypath_comma_migrated_count > 0) {
+    GUI_LOG_WARNING(
+        "[FileIO] This data used the retired ',' raypath connector in {} place(s); rewritten to "
+        "'-' on load (the original path is unchanged). Re-save to store the new spelling.",
+        g_raypath_comma_migrated_count);
+  }
 
   return true;
 }

--- a/src/gui/file_io.hpp
+++ b/src/gui/file_io.hpp
@@ -158,6 +158,13 @@ int TakeShapeDistDowngradeCount();
 // the notice.
 int TakeFilterNoPredicateDowngradeCount();
 
+// Returns the number of raypath texts rewritten since the last call because they used the retired
+// ',' path connector, and resets the counter. Loading rewrites a ',' inside a raypath token to '-'
+// so a document written before the retirement keeps the face path it had then; the rewrite is
+// silent to the state, so this is how a caller learns it happened. Same call discipline as the two
+// above: drain once before a load to discard any stale count, and again after it.
+int TakeRaypathCommaMigratedCount();
+
 // Export preview as PNG (renders via FBO, must be called on GL thread).
 // Thin wrapper over RenderExportToRgba + WriteRgbaBufferToPng.
 bool ExportPreviewPng(const std::filesystem::path& path, PreviewRenderer& renderer, const PreviewViewport& vp);
@@ -190,9 +197,6 @@ std::filesystem::path ShowExportEquirectangularDialog();
 std::filesystem::path ShowExportJsonDialog();
 std::filesystem::path ShowOpenImageDialog();
 
-
-// Parse dash/comma-separated raypath text into face indices (tolerant: skips invalid tokens).
-std::vector<int> ParseRaypathText(const std::string& text);
 
 }  // namespace lumice::gui
 

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -551,8 +551,11 @@ constexpr const char* kRaypathSepStr = "-";
 // task plan §"数据形态" for the explicit core ↔ GUI field-name mapping.
 
 struct RaypathParams {
-  // Dash- or comma-separated face indices; ';'-separated multi-segment OR
+  // Dash-separated face indices (e.g. "3-5"); ';'-separated multi-segment OR
   // (e.g. "3-5; 1-3"). See raypath_segments.hpp for the parser/validator.
+  // ',' is NOT a path connector and is rejected by the validator with a message naming '-' and
+  // ';' (raypath_validation.cpp). A document written before that was enforced may still carry the
+  // legacy ',' connector; DeserializeGuiStateJson rewrites it to '-' on load.
   std::string raypath_text;
 
   friend bool operator==(const RaypathParams& a, const RaypathParams& b) { return a.raypath_text == b.raypath_text; }

--- a/src/gui/raypath_segments.hpp
+++ b/src/gui/raypath_segments.hpp
@@ -220,31 +220,48 @@ inline GuiValidationResult ValidateRaypathTextMultiSegment(const std::string& te
 }
 
 // Parse a single segment (no ';') into a vector of non-negative face indices.
-// Tolerant: skips invalid tokens, matching the existing ParseRaypathText behavior.
+//
+// A segment whose every token is a non-negative integer parses to those integers; a segment
+// carrying ANY token that is not parses to nothing at all — the empty vector — rather than to the
+// integers of its surviving tokens. The scope of that judgement is the segment, not the token, and
+// it has to be: with a per-token rule "3-5,1-2" (the ',' a user types meaning "two paths") splits
+// on '-' into "3" / "5,1" / "2", drops only the middle one, and returns {3, 2} — a plausible-
+// looking two-face path that no one asked for. A malformed segment has no path, not a shorter one.
+//
+// This accept set is deliberately the same as ValidateRaypathText's (config/raypath_validation.cpp,
+// ScanTokens + TokenAllDigits): the validator has always required every token to be all-digits, so
+// nothing it admits is dropped here. Keeping them equal is what stops "the validator says invalid,
+// the parser still draws a path" — see the cross-reference comment on TokenAllDigits; the API
+// boundary in AGENTS.md rules out sharing one implementation, so both sides move together by hand.
 inline std::vector<int> ParseRaypathSegment(const std::string& seg) {
   std::vector<int> ints;
-  // Normalize ',' → '-' so both separators work.
-  std::string normalized = seg;
-  for (auto& c : normalized) {
-    if (c == ',') {
-      c = '-';
-    }
-  }
   std::string tok;
-  auto flush = [&ints, &tok]() {
+  bool has_invalid_token = false;
+  auto flush = [&ints, &tok, &has_invalid_token]() {
     if (tok.empty()) {
       return;
+    }
+    for (char c : tok) {
+      if (!std::isdigit(static_cast<unsigned char>(c))) {
+        has_invalid_token = true;
+        tok.clear();
+        return;
+      }
     }
     try {
       int v = std::stoi(tok);
       if (v >= 0) {
         ints.push_back(v);
+      } else {
+        has_invalid_token = true;
       }
     } catch (...) {
+      // Out of int range (e.g. "99999999999") — a digits-only token the value cannot hold.
+      has_invalid_token = true;
     }
     tok.clear();
   };
-  for (char c : normalized) {
+  for (char c : seg) {
     if (c == '-') {
       flush();
     } else {
@@ -252,12 +269,16 @@ inline std::vector<int> ParseRaypathSegment(const std::string& seg) {
     }
   }
   flush();
+  if (has_invalid_token) {
+    return {};
+  }
   return ints;
 }
 
 // Parse multi-segment raypath text into a vector of int vectors, one per
-// segment. Tolerant: skips invalid tokens within each segment. Empty /
-// pure-whitespace segments are dropped from the result. Callers that need
+// segment. Drops any segment containing an invalid token (ParseRaypathSegment
+// returns the empty vector for it, and the empty-result skip below removes it),
+// along with empty / pure-whitespace segments. Callers that need
 // strict rejection of malformed input should run
 // ValidateRaypathTextMultiSegment first.
 inline std::vector<std::vector<int>> ParseRaypathTextMultiSegment(const std::string& text) {
@@ -765,6 +786,50 @@ inline std::string FormatSopExpansionPreview(const SumOfProducts& sop) {
 // (future) 333.3 serialization sites should use these instead of the compat
 // writers when the intent is a true SoP fan-out.
 // ---------------------------------------------------------------------------
+
+// Rewrite a summand row off the retired ',' raypath connector: inside a raypath token every ','
+// becomes '-', which is exactly the normalization ParseRaypathSegment used to do silently, so a
+// document written before the retirement loads with the same face path it had then.
+//
+// EE tokens (entry:/exit:/len:) are left alone. Their ',' is, and always was, OR-list syntax
+// (ValidateFaceNumberListText / GuiValidateFaceNumberListText) — a different language that happens
+// to reuse the character, which is why the token boundary, not the character position, decides.
+// Splitting with detail::SplitSummandTokens / detail::IsEeToken (the same pair ValidateSummandText
+// and ParseSummandText tokenize with) keeps "what the migration calls a token" from drifting away
+// from "what the validator calls a token".
+//
+// Idempotent, and a no-op returning the input verbatim when there is no ',' to rewrite — so it is
+// cheap and safe to run on every load regardless of the document's declared schema_version. That
+// is deliberate: the trigger is the text, not the version number, so a hand-edited file carrying a
+// wrong version still migrates correctly.
+inline std::string MigrateLegacyRaypathCommaConnector(const std::string& row_text) {
+  auto tokens = detail::SplitSummandTokens(row_text);
+  bool changed = false;
+  for (auto& tok : tokens) {
+    if (detail::IsEeToken(tok)) {
+      continue;
+    }
+    for (auto& c : tok) {
+      if (c == ',') {
+        c = '-';
+        changed = true;
+      }
+    }
+  }
+  if (!changed) {
+    return row_text;
+  }
+  std::string out;
+  bool first = true;
+  for (const auto& tok : tokens) {
+    if (!first) {
+      out += " & ";
+    }
+    out += tok;
+    first = false;
+  }
+  return out;
+}
 
 // Split RaypathParams.raypath_text on ';' into one OR-row per segment. Empty
 // input → empty SoP, which is "no filter" said in the type's own vocabulary and

--- a/src/gui/raypath_segments.hpp
+++ b/src/gui/raypath_segments.hpp
@@ -228,11 +228,18 @@ inline GuiValidationResult ValidateRaypathTextMultiSegment(const std::string& te
 // on '-' into "3" / "5,1" / "2", drops only the middle one, and returns {3, 2} — a plausible-
 // looking two-face path that no one asked for. A malformed segment has no path, not a shorter one.
 //
-// This accept set is deliberately the same as ValidateRaypathText's (config/raypath_validation.cpp,
-// ScanTokens + TokenAllDigits): the validator has always required every token to be all-digits, so
-// nothing it admits is dropped here. Keeping them equal is what stops "the validator says invalid,
-// the parser still draws a path" — see the cross-reference comment on TokenAllDigits; the API
-// boundary in AGENTS.md rules out sharing one implementation, so both sides move together by hand.
+// The all-digits judgement here is deliberately the same one ValidateRaypathText makes
+// (config/raypath_validation.cpp, ScanTokens + TokenAllDigits): the validator has always required
+// every token to be all-digits, so nothing it admits is dropped here. Keeping the two equal is
+// what closes the ','-triggered case of "the validator says invalid, the parser still draws a
+// path" — see the cross-reference comment on TokenAllDigits; the API boundary in AGENTS.md rules
+// out sharing one implementation, so both sides move together by hand.
+//
+// Only that case. The empty-token judgement is still split: "3--5" is kInvalid to the validator
+// (found_interior_empty) and {3, 5} to the parser, because an empty token returns from flush()
+// without setting the flag. That divergence predates this function's tightening and is untouched
+// by it — a different predicate on a different input class, left where it was rather than folded
+// in here.
 inline std::vector<int> ParseRaypathSegment(const std::string& seg) {
   std::vector<int> ints;
   std::string tok;

--- a/src/gui/raypath_segments.hpp
+++ b/src/gui/raypath_segments.hpp
@@ -809,6 +809,15 @@ inline std::string FormatSopExpansionPreview(const SumOfProducts& sop) {
 // cheap and safe to run on every load regardless of the document's declared schema_version. That
 // is deliberate: the trigger is the text, not the version number, so a hand-edited file carrying a
 // wrong version still migrates correctly.
+//
+// When it DOES rewrite, the row comes back re-joined from its tokens with a canonical " & ", not
+// patched character by character — so a row that also carried irregular '&' spacing ("a,b&c" or
+// "a,b   &   c") comes back canonically spaced. That is a declared part of the contract, not an
+// accident: the row is already being rewritten, the spacing carries no meaning (SplitSummandTokens
+// trims), and reconstructing from the tokens keeps one code path instead of a second, position-
+// tracking one. Rows with no ',' are untouched, which is the case that actually matters — see
+// MigrationIsAVerbatimNoOpWithoutCommas, and MigrationCanonicalizesRowSpacingWhenItRewrites for
+// the pinned behaviour of this paragraph.
 inline std::string MigrateLegacyRaypathCommaConnector(const std::string& row_text) {
   auto tokens = detail::SplitSummandTokens(row_text);
   bool changed = false;

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -1264,8 +1264,10 @@ typedef enum LUMICE_RaypathValidationState_ {
   LUMICE_RAYPATH_INVALID,     // Non-numeric tokens or illegal face numbers
 } LUMICE_RaypathValidationState;
 
-// Validate a raypath text string (dash- or comma-separated face indices) against
+// Validate a raypath text string (dash-separated face indices, e.g. "3-5") against
 // both syntax rules and face-number legality for the given crystal kind.
+// ',' is retired legacy syntax: a text containing one is LUMICE_RAYPATH_INVALID with a
+// dedicated out_msg naming '-' (join faces on one path) and ';' (separate paths).
 // Used by GUI for raypath filter input validation.
 // out_msg: human-readable error description (empty on kValid/kIncomplete).
 //          Caller provides buffer; recommended size = 256.

--- a/test/composition-correctness/gui/test_document_roundtrip_chain.cpp
+++ b/test/composition-correctness/gui/test_document_roundtrip_chain.cpp
@@ -784,5 +784,114 @@ TEST(DocumentRoundtripChain, FaceNumberValidityDependsOnCrystalKind) {
   }
 }
 
+// ---------------------------------------------------------------------------------------------
+// E5 — the retired ',' raypath connector, migrated on load.
+//
+// ',' used to be normalized to '-' by the parser, so a document could be saved with "3-5,1-2" in
+// it and meant the four-face path 3-5-1-2. Now that the validator rejects ',', such a document
+// would open into a state the editor refuses to commit — unless the load rewrites it. These cases
+// are about that rewrite happening on BOTH read paths and stopping exactly at the raypath token.
+//
+// The counter is drained before each load, not only read after: DeserializeGuiStateJson resets it
+// on entry, but a case that only read it afterwards would still pass if that reset were removed
+// and some earlier case had left a count behind.
+
+const char* const kCrystalJson = R"("crystal": {"type": "prism", "shape": {"height": 1.0}}, "proportion": 100.0)";
+
+std::string V3DocWithSummand(const std::string& summand) {
+  return std::string(R"({"schema_version": 3, "layers": [{"prob": 0.0, "entries": [{)") + kCrystalJson +
+         R"(, "filter": {"action": "filter_in", "summands": [")" + summand + R"("]}}]}]})";
+}
+
+std::string LegacyDocWithRaypathText(const std::string& raypath_text) {
+  return std::string(R"({"schema_version": 2, "layers": [{"prob": 0.0, "entries": [{)") + kCrystalJson +
+         R"(, "filter": {"type": "raypath", "action": "filter_in", "raypath_text": ")" + raypath_text + R"("}}]}]})";
+}
+
+const FilterConfig& OnlyFilter(const GuiState& s) {
+  EXPECT_EQ(s.filters.size(), 1u);
+  return s.filters.at(0);
+}
+
+TEST(DocumentRoundtripChain, LegacyCommaRaypathConnectorMigratesToDashOnLoadV3Summands) {
+  GuiState s;
+  TakeRaypathCommaMigratedCount();
+  ASSERT_TRUE(DeserializeGuiStateJson(V3DocWithSummand("3-5,1-2"), s));
+
+  const FilterConfig& f = OnlyFilter(s);
+  ASSERT_EQ(f.param.size(), 1u);
+  // The path the document meant is preserved; only its spelling changed.
+  EXPECT_EQ(f.param[0].text, std::string("3-5-1-2"));
+  EXPECT_EQ(TakeRaypathCommaMigratedCount(), 1);
+}
+
+TEST(DocumentRoundtripChain, LegacyCommaRaypathConnectorMigratesToDashOnLoadV1V2RaypathText) {
+  GuiState s;
+  TakeRaypathCommaMigratedCount();
+  ASSERT_TRUE(DeserializeGuiStateJson(LegacyDocWithRaypathText("3-5,1-2"), s));
+
+  // The legacy arm reaches the rewrite through FromLegacyRaypath rather than the summands loop.
+  // It is a separate call site, so it needs its own evidence — the v3 case above says nothing
+  // about it.
+  const FilterConfig& f = OnlyFilter(s);
+  ASSERT_EQ(f.param.size(), 1u);
+  EXPECT_EQ(f.param[0].text, std::string("3-5-1-2"));
+  EXPECT_EQ(TakeRaypathCommaMigratedCount(), 1);
+}
+
+TEST(DocumentRoundtripChain, LegacyCommaMigrationLeavesEntryExitFacelistCommaAlone) {
+  GuiState s;
+  TakeRaypathCommaMigratedCount();
+  ASSERT_TRUE(DeserializeGuiStateJson(V3DocWithSummand("entry:1,2 & 3-5,1-2"), s));
+
+  // The red line between the two meanings of ',' in one row: the EE facelist keeps its OR comma,
+  // the raypath token loses its connector comma. A migration that walked characters instead of
+  // tokens would turn "entry face 1 or 2" into "entry:1-2" and quietly change what the filter
+  // matches.
+  const FilterConfig& f = OnlyFilter(s);
+  ASSERT_EQ(f.param.size(), 1u);
+  EXPECT_EQ(f.param[0].text, std::string("entry:1,2 & 3-5-1-2"));
+  EXPECT_EQ(TakeRaypathCommaMigratedCount(), 1);
+}
+
+TEST(DocumentRoundtripChain, NoCommaDocumentIsNotTouchedByMigration) {
+  GuiState s;
+  TakeRaypathCommaMigratedCount();
+  ASSERT_TRUE(DeserializeGuiStateJson(V3DocWithSummand("3-5 & entry:1,2"), s));
+
+  // A document with no retired connector must come back byte for byte and must not be counted:
+  // the load is a no-op here, not a reformat that happens to agree.
+  const FilterConfig& f = OnlyFilter(s);
+  ASSERT_EQ(f.param.size(), 1u);
+  EXPECT_EQ(f.param[0].text, std::string("3-5 & entry:1,2"));
+  EXPECT_EQ(TakeRaypathCommaMigratedCount(), 0);
+}
+
+TEST(DocumentRoundtripChain, MigratedDocumentSurvivesTheNextRoundTrip) {
+  // The end of the story the migration promises: open an old document, save it, and the ',' is
+  // gone from the file for good. Without this, a load that rewrote only the in-memory state would
+  // still pass every case above and write the old spelling back out.
+  GuiState loaded;
+  ASSERT_TRUE(DeserializeGuiStateJson(V3DocWithSummand("3-5,1-2"), loaded));
+
+  const std::string resaved = SerializeGuiStateJson(loaded);
+  EXPECT_EQ(resaved.find("3-5,1-2"), std::string::npos) << "re-saved document still carries the retired ','";
+
+  GuiState reloaded;
+  TakeRaypathCommaMigratedCount();
+  ASSERT_TRUE(DeserializeGuiStateJson(resaved, reloaded));
+  ASSERT_EQ(OnlyFilter(reloaded).param.size(), 1u);
+  EXPECT_EQ(OnlyFilter(reloaded).param[0].text, std::string("3-5-1-2"));
+  EXPECT_EQ(TakeRaypathCommaMigratedCount(), 0) << "a re-saved document should need no second migration";
+}
+
+TEST(DocumentRoundtripChain, SchemaVersionIsFour) {
+  // The version the writer stamps is what dates a file's ',' for anyone who later has to decide
+  // what a ',' in it meant. Asserted as a literal, not as a read of the writer's own constant.
+  const nlohmann::json root = nlohmann::json::parse(SerializeGuiStateJson(MinimalDocument()));
+  ASSERT_TRUE(root.contains("schema_version"));
+  EXPECT_EQ(root["schema_version"].get<int>(), 4);
+}
+
 }  // namespace
 }  // namespace lumice::gui

--- a/test/composition-correctness/gui/test_document_roundtrip_chain.cpp
+++ b/test/composition-correctness/gui/test_document_roundtrip_chain.cpp
@@ -885,6 +885,20 @@ TEST(DocumentRoundtripChain, MigratedDocumentSurvivesTheNextRoundTrip) {
   EXPECT_EQ(TakeRaypathCommaMigratedCount(), 0) << "a re-saved document should need no second migration";
 }
 
+TEST(DocumentRoundtripChain, MigrationCountDoesNotLeakFromAPreviousLoad) {
+  // The count belongs to one load, and the load is what says so — not the caller's discipline in
+  // draining it. Two callers reach DeserializeGuiStateJson (LoadLmcFile and the user-defaults
+  // merge), and a count carried over from the first would make the second announce a migration
+  // that did not happen in it.
+  GuiState first;
+  TakeRaypathCommaMigratedCount();
+  ASSERT_TRUE(DeserializeGuiStateJson(V3DocWithSummand("3-5,1-2"), first));
+
+  GuiState second;
+  ASSERT_TRUE(DeserializeGuiStateJson(V3DocWithSummand("3-5"), second));
+  EXPECT_EQ(TakeRaypathCommaMigratedCount(), 0) << "the clean load inherited the previous load's count";
+}
+
 TEST(DocumentRoundtripChain, SchemaVersionIsFour) {
   // The version the writer stamps is what dates a file's ',' for anyone who later has to decide
   // what a ',' in it meant. Asserted as a literal, not as a read of the writer's own constant.

--- a/test/unit-correctness/core/test_filter.cpp
+++ b/test/unit-correctness/core/test_filter.cpp
@@ -143,12 +143,15 @@ TEST(ValidateRaypathTextTest, MultipleDashSeparated_IsValid) {
   EXPECT_EQ(ValidateRaypathText("3-1-5"), RaypathValidation::kValid);
 }
 
-TEST(ValidateRaypathTextTest, CommaSeparated_IsValid) {
-  EXPECT_EQ(ValidateRaypathText("3,1,5"), RaypathValidation::kValid);
+TEST(ValidateRaypathTextTest, CommaSeparated_IsInvalid) {
+  // ',' was retired as a path connector: it is no longer a separator, so "3,1,5" is a single
+  // token that is not all digits.
+  EXPECT_EQ(ValidateRaypathText("3,1,5"), RaypathValidation::kInvalid);
 }
 
-TEST(ValidateRaypathTextTest, MixedSeparators_IsValid) {
-  EXPECT_EQ(ValidateRaypathText("3-1,5"), RaypathValidation::kValid);
+TEST(ValidateRaypathTextTest, MixedSeparators_IsInvalid) {
+  // Same reason: the '-' does separate, but the "1,5" it yields is still not a number.
+  EXPECT_EQ(ValidateRaypathText("3-1,5"), RaypathValidation::kInvalid);
 }
 
 TEST(ValidateRaypathTextTest, Zero_IsValid) {
@@ -167,16 +170,18 @@ TEST(ValidateRaypathTextTest, SingleTrailingDash_IsIncomplete) {
   EXPECT_EQ(ValidateRaypathText("3-"), RaypathValidation::kIncomplete);
 }
 
-TEST(ValidateRaypathTextTest, TrailingComma_IsIncomplete) {
-  EXPECT_EQ(ValidateRaypathText("3,"), RaypathValidation::kIncomplete);
+TEST(ValidateRaypathTextTest, TrailingComma_IsInvalid) {
+  // Not kIncomplete any more: kIncomplete means "ends with a separator, user is still typing",
+  // and ',' is no longer a separator — "3," is one malformed token.
+  EXPECT_EQ(ValidateRaypathText("3,"), RaypathValidation::kInvalid);
 }
 
 TEST(ValidateRaypathTextTest, SingleDash_IsIncomplete) {
   EXPECT_EQ(ValidateRaypathText("-"), RaypathValidation::kIncomplete);
 }
 
-TEST(ValidateRaypathTextTest, SingleComma_IsIncomplete) {
-  EXPECT_EQ(ValidateRaypathText(","), RaypathValidation::kIncomplete);
+TEST(ValidateRaypathTextTest, SingleComma_IsInvalid) {
+  EXPECT_EQ(ValidateRaypathText(","), RaypathValidation::kInvalid);
 }
 
 TEST(ValidateRaypathTextTest, LeadingDashSingle_IsIncomplete) {
@@ -200,6 +205,8 @@ TEST(ValidateRaypathTextTest, ConsecutiveDashes_IsInvalid) {
 }
 
 TEST(ValidateRaypathTextTest, ConsecutiveCommas_IsInvalid) {
+  // Still kInvalid, but for a different reason than it used to be: not "interior empty token
+  // between two separators", just one non-digit token. The observable answer is unchanged.
   EXPECT_EQ(ValidateRaypathText("3,,5"), RaypathValidation::kInvalid);
 }
 
@@ -294,14 +301,15 @@ TEST(IsLegalFaceTest, Pyramid_Gaps_Illegal) {
 // Note: The single-argument ValidateRaypathText(text) is kept untouched and
 // remains syntax-only (so "0" and "51" still return kValid). The richer
 // semantics — global-union + kind-specific face-number checks — are confined
-// to the two-argument overload tested below. `-` and `,` are token separators
-// (no range semantics), so e.g. "3-1-5" is equivalent to "3,1,5".
+// to the two-argument overload tested below. `-` is the only token separator (no range
+// semantics); ',' used to be a second one and is now rejected by both overloads — what stayed
+// permissive in the single-argument overload is face-number legality, not the separator set.
 
 TEST(ValidateRaypathTextWithKindTest, Prism_BasicLegal) {
   EXPECT_EQ(ValidateRaypathText("1", CrystalKind::kPrism).state, RaypathValidation::kValid);
   EXPECT_EQ(ValidateRaypathText("2", CrystalKind::kPrism).state, RaypathValidation::kValid);
   EXPECT_EQ(ValidateRaypathText("3-8", CrystalKind::kPrism).state, RaypathValidation::kValid);
-  EXPECT_EQ(ValidateRaypathText("1,3-5", CrystalKind::kPrism).state, RaypathValidation::kValid);
+  EXPECT_EQ(ValidateRaypathText("1-3-5", CrystalKind::kPrism).state, RaypathValidation::kValid);
   EXPECT_EQ(ValidateRaypathText("8", CrystalKind::kPrism).state, RaypathValidation::kValid);  // boundary
 }
 
@@ -311,15 +319,36 @@ TEST(ValidateRaypathTextWithKindTest, Pyramid_BasicLegal) {
   EXPECT_EQ(ValidateRaypathText("3-8", CrystalKind::kPyramid).state, RaypathValidation::kValid);
   EXPECT_EQ(ValidateRaypathText("13-18", CrystalKind::kPyramid).state, RaypathValidation::kValid);
   EXPECT_EQ(ValidateRaypathText("23-28", CrystalKind::kPyramid).state, RaypathValidation::kValid);
-  EXPECT_EQ(ValidateRaypathText("1,3-5,13", CrystalKind::kPyramid).state, RaypathValidation::kValid);
+  EXPECT_EQ(ValidateRaypathText("1-3-5-13", CrystalKind::kPyramid).state, RaypathValidation::kValid);
   EXPECT_EQ(ValidateRaypathText("13", CrystalKind::kPyramid).state, RaypathValidation::kValid);  // boundary
 }
 
 TEST(ValidateRaypathTextWithKindTest, SyntaxInvalid_PropagatesInvalid) {
-  // "3,,5" is a syntax error (empty interior token) → kInvalid, "Invalid raypath".
-  auto r = ValidateRaypathText("3,,5", CrystalKind::kPrism);
+  // "3--5" is a syntax error (empty interior token) → kInvalid, generic "Invalid raypath".
+  // Deliberately comma-free: a text containing ',' now takes the dedicated message instead
+  // (see CommaConnector_IsInvalidWithDedicatedMessage), so this input is what still exercises
+  // the generic branch.
+  auto r = ValidateRaypathText("3--5", CrystalKind::kPrism);
   EXPECT_EQ(r.state, RaypathValidation::kInvalid);
   EXPECT_EQ(r.message, "Invalid raypath");
+}
+
+TEST(ValidateRaypathTextWithKindTest, CommaConnector_IsInvalidWithDedicatedMessage) {
+  // The flagship input: a user meaning "two paths" types "3-5,1-2". It used to normalize to the
+  // single four-face path 3-5-1-2 — legal on a prism, so green border, OK enabled, near-empty
+  // render, no diagnostic. Now it is rejected, and the message has to say what to type instead.
+  auto r = ValidateRaypathText("3-5,1-2", CrystalKind::kPrism);
+  EXPECT_EQ(r.state, RaypathValidation::kInvalid);
+  EXPECT_NE(r.message, "Invalid raypath");
+  // The information that makes this message worth having: it names both separators and what each
+  // one does. Asserted as content, not just as "some other string", so that collapsing the two
+  // branches back into one message cannot pass by accident.
+  EXPECT_NE(r.message.find("'-'"), std::string::npos);
+  EXPECT_NE(r.message.find("';'"), std::string::npos);
+  EXPECT_NE(r.message.find("','"), std::string::npos);
+
+  // The single-argument overload carries no message, but must agree on the state.
+  EXPECT_EQ(ValidateRaypathText("3-5,1-2"), RaypathValidation::kInvalid);
 }
 
 TEST(ValidateRaypathTextWithKindTest, SyntaxIncomplete_TakesPriorityOverFaceCheck) {
@@ -367,8 +396,8 @@ TEST(ValidateRaypathTextWithKindTest, TypeSpecificInvalid_OnPrism) {
 }
 
 TEST(ValidateRaypathTextWithKindTest, FirstInvalidTokenDeterminesMessage) {
-  // Sequence "9,13" on pyramid: 9 is outside-union → message references 9, not 13.
-  auto r = ValidateRaypathText("9,13", CrystalKind::kPyramid);
+  // Sequence "9-13" on pyramid: 9 is outside-union → message references 9, not 13.
+  auto r = ValidateRaypathText("9-13", CrystalKind::kPyramid);
   EXPECT_EQ(r.state, RaypathValidation::kInvalid);
   EXPECT_NE(r.message.find("9"), std::string::npos);
   EXPECT_NE(r.message.find("outside"), std::string::npos);
@@ -381,11 +410,14 @@ TEST(ValidateRaypathTextWithKindTest, SingleArg_Untouched) {
   EXPECT_EQ(ValidateRaypathText("0"), RaypathValidation::kValid);
   EXPECT_EQ(ValidateRaypathText("51"), RaypathValidation::kValid);
   EXPECT_EQ(ValidateRaypathText("13"), RaypathValidation::kValid);
-  EXPECT_EQ(ValidateRaypathText("9,13"), RaypathValidation::kValid);
+  EXPECT_EQ(ValidateRaypathText("9-13"), RaypathValidation::kValid);
+  // What stayed permissive is face-number legality, not syntax: the separator set tightened
+  // here too, so a ',' is rejected by this overload as well.
+  EXPECT_EQ(ValidateRaypathText("9,13"), RaypathValidation::kInvalid);
 }
 
 TEST(ValidateRaypathTextWithKindTest, KValidMessageIsEmpty) {
-  auto r = ValidateRaypathText("3-5,1", CrystalKind::kPrism);
+  auto r = ValidateRaypathText("3-5-1", CrystalKind::kPrism);
   EXPECT_EQ(r.state, RaypathValidation::kValid);
   EXPECT_TRUE(r.message.empty());
 }

--- a/test/unit-correctness/core/test_raypath_segments.cpp
+++ b/test/unit-correctness/core/test_raypath_segments.cpp
@@ -103,10 +103,11 @@ TEST(RaypathSegments, ValidateOneInvalidSegmentRejected) {
   EXPECT_EQ(r.state, LUMICE_RAYPATH_INVALID);
 }
 
-TEST(RaypathSegments, ValidateSegmentMixedSeparators) {
-  // Both '-' and ',' are accepted within a segment (legacy comma-as-dash).
+TEST(RaypathSegments, ValidateSegmentRejectsLegacyComma) {
+  // ',' inside a segment used to be accepted as a second spelling of '-'. It is retired: the
+  // "3,5" segment is now a syntax error, and one bad segment rejects the whole text.
   auto r = ValidateRaypathTextMultiSegment("3,5; 1-3", LUMICE_CRYSTAL_PRISM);
-  EXPECT_EQ(r.state, LUMICE_RAYPATH_VALID);
+  EXPECT_EQ(r.state, LUMICE_RAYPATH_INVALID);
 }
 
 // ---- ParseRaypathTextMultiSegment ----
@@ -140,11 +141,40 @@ TEST(RaypathSegments, ParseDropsEmptySegments) {
   EXPECT_EQ(v[1], (std::vector<int>{ 5 }));
 }
 
-TEST(RaypathSegments, ParseSegmentMixedSeparators) {
+TEST(RaypathSegments, ParseSegmentDropsLegacyCommaSegment) {
+  // The "3,5" segment yields no path at all, so only the well-formed segment survives. What it
+  // must NOT do is contribute a truncated {3}: std::stoi("3,5") returns 3 without throwing.
   auto v = ParseRaypathTextMultiSegment("3,5; 1-3");
-  ASSERT_EQ(v.size(), 2u);
-  EXPECT_EQ(v[0], (std::vector<int>{ 3, 5 }));
-  EXPECT_EQ(v[1], (std::vector<int>{ 1, 3 }));
+  ASSERT_EQ(v.size(), 1u);
+  EXPECT_EQ(v[0], (std::vector<int>{ 1, 3 }));
+}
+
+// ---- ParseRaypathSegment: whole-segment rejection (the retired ',' connector) ----
+
+TEST(RaypathSegments, ParseSegmentRejectsCommaConnectorEntirely) {
+  // The flagship input. A per-token rule would not be enough here: splitting "3-5,1-2" on '-'
+  // gives "3" / "5,1" / "2", and dropping only the malformed middle token returns {3, 2} — a
+  // plausible-looking two-face path nobody asked for. The segment, not the token, is what is
+  // invalidated.
+  auto v = ParseRaypathSegment("3-5,1-2");
+  EXPECT_TRUE(v.empty());
+  EXPECT_NE(v, (std::vector<int>{ 3, 2 }));
+}
+
+TEST(RaypathSegments, ParseSegmentRejectsSingleCommaToken) {
+  // "3,5" must not come back as {3} — std::stoi stops at the ',' and returns 3 without error,
+  // which is how removing the normalization alone would trade a four-face wrong answer for a
+  // one-face wrong answer.
+  auto v = ParseRaypathSegment("3,5");
+  EXPECT_TRUE(v.empty());
+  EXPECT_NE(v, (std::vector<int>{ 3 }));
+}
+
+TEST(RaypathSegments, ParseSegmentUnchangedForDashOnlyInput) {
+  // The other half of the tightening: well-formed input is untouched. Guards against the
+  // rejection being over-implemented into "anything unusual yields nothing".
+  EXPECT_EQ(ParseRaypathSegment("3-5-1-2"), (std::vector<int>{ 3, 5, 1, 2 }));
+  EXPECT_EQ(ParseRaypathSegment("3"), (std::vector<int>{ 3 }));
 }
 
 }  // namespace

--- a/test/unit-correctness/gui/test_color_window_logic.cpp
+++ b/test/unit-correctness/gui/test_color_window_logic.cpp
@@ -145,6 +145,9 @@ TEST_F(ColorWindow, ARefRejectsAnyTextThatIsMoreThanASingleAtom) {
     // face numbers, so the face-range checks pass and the rejection can only come from the
     // alternative count — otherwise this row would go green for the wrong reason.
     { "two alternatives in one factor", "1-3;5-7", false },
+    // The colour window and the filter edit modal share one validator, so retiring ',' as a path
+    // connector reaches this input box with no code of its own — this row is what says so.
+    { "legacy comma connector", "3,5", false },
   };
 
   for (const AtomCase& c : kCases) {
@@ -153,6 +156,13 @@ TEST_F(ColorWindow, ARefRejectsAnyTextThatIsMoreThanASingleAtom) {
     // A rejection the user cannot read is the same as a silent one.
     EXPECT_EQ(v.message.empty(), c.valid) << c.name;
   }
+
+  // ...and the ',' rejection specifically has to arrive here with the message that names the fix,
+  // not a generic one — the shared validator is only worth sharing if what it says survives the
+  // trip through this window's own wrapper.
+  const auto comma = gui::ValidateSingleAtomText("3,5");
+  EXPECT_NE(comma.message.find("'-'"), std::string::npos) << comma.message;
+  EXPECT_NE(comma.message.find("';'"), std::string::npos) << comma.message;
 }
 
 // ---- Per-ref symmetry ----

--- a/test/unit-correctness/gui/test_filter_sop_grammar.cpp
+++ b/test/unit-correctness/gui/test_filter_sop_grammar.cpp
@@ -571,7 +571,9 @@ TEST(FilterSopGrammar, ASemicolonSeparatesRaypathAlternativesButNeverStandsAlone
     { "1-3;3-5", LUMICE_RAYPATH_VALID },
     { "1-3;3-5 & entry:2", LUMICE_RAYPATH_VALID },
     { "entry:2 & 1-3;3-5", LUMICE_RAYPATH_VALID },
-    { "1,2;3-5 & entry:2", LUMICE_RAYPATH_VALID },           // ',' inside a segment + ';' separator
+    // Not a legal mixture any more: ',' is retired as a path connector, so the "1,2" segment is
+    // a syntax error even though the ';' around it is well-formed.
+    { "1,2;3-5 & entry:2", LUMICE_RAYPATH_INVALID },
     { "entry:2 & 1-3;3-5 & exit:4", LUMICE_RAYPATH_VALID },  // sandwiched between EE factors
     // Leading / trailing / consecutive ';' are an empty raypath segment. The last row covers
     // ';'+'&' adjacency, which must not slip through as a valid segment.
@@ -646,6 +648,67 @@ TEST(FilterSopPreview, TheRowPreviewExpandsSemicolonAlternativesAndLeavesEveryth
   SumOfProducts blank;
   blank.emplace_back(SummandText{ std::string{}, {} });
   EXPECT_EQ(FormatSopExpansionPreview(blank), "OR of 1 row(s):\n  *");
+}
+
+// ===========================================================================
+// MigrateLegacyRaypathCommaConnector — the load-time rewrite that keeps
+// documents written before the ',' retirement meaning what they meant then.
+//
+// It is tested here rather than next to file_io because it is a pure function
+// over one summand row, and because it tokenizes with the same
+// detail::SplitSummandTokens / detail::IsEeToken pair the grammar above uses —
+// which is the whole reason it can tell a raypath ',' from an EE facelist ','.
+// ===========================================================================
+
+TEST(FilterSopGrammar, MigrationRewritesRaypathCommaToDash) {
+  // The old parser normalized ',' to '-' silently; the migration does the same rewrite out loud,
+  // so the document keeps the four-face path it actually had.
+  EXPECT_EQ(MigrateLegacyRaypathCommaConnector("3-5,1-2"), "3-5-1-2");
+  EXPECT_EQ(MigrateLegacyRaypathCommaConnector("3,5"), "3-5");
+}
+
+TEST(FilterSopGrammar, MigrationLeavesEntryExitFacelistCommasAlone) {
+  // An EE facelist ',' is OR syntax and always was — a different language sharing one character.
+  // Rewriting it would turn "entry face 1 or 2" into a nonsense token.
+  EXPECT_EQ(MigrateLegacyRaypathCommaConnector("entry:1,2"), "entry:1,2");
+  EXPECT_EQ(MigrateLegacyRaypathCommaConnector("exit:1,2"), "exit:1,2");
+}
+
+TEST(FilterSopGrammar, MigrationSplitsTheTwoCommaMeaningsWithinOneRow) {
+  // The crossing case: both kinds of ',' in one row. Only the raypath token's is rewritten.
+  EXPECT_EQ(MigrateLegacyRaypathCommaConnector("entry:1,2 & 3-5,1-2"), "entry:1,2 & 3-5-1-2");
+  EXPECT_EQ(MigrateLegacyRaypathCommaConnector("3-5,1-2 & exit:1,2"), "3-5-1-2 & exit:1,2");
+}
+
+TEST(FilterSopGrammar, MigrationRewritesInsideEverySemicolonAlternative) {
+  // ';' alternatives live inside one raypath token, so a character-wise rewrite within the token
+  // already covers them — no second split needed.
+  EXPECT_EQ(MigrateLegacyRaypathCommaConnector("3,5;1-2"), "3-5;1-2");
+}
+
+TEST(FilterSopGrammar, MigrationIsAVerbatimNoOpWithoutCommas) {
+  // The common case is a document with no ',' at all, and it must come back byte for byte — not
+  // re-joined, re-spaced or trimmed. A migration that reformats every row on every load would
+  // make every load look like an edit.
+  const std::string kAlreadyCanonical = "3-5 & entry:1,2";
+  EXPECT_EQ(MigrateLegacyRaypathCommaConnector(kAlreadyCanonical), kAlreadyCanonical);
+  const std::string kOddSpacing = "3-5   &  len:2";
+  EXPECT_EQ(MigrateLegacyRaypathCommaConnector(kOddSpacing), kOddSpacing);
+  EXPECT_EQ(MigrateLegacyRaypathCommaConnector(""), "");
+}
+
+TEST(FilterSopGrammar, MigrationOutputPassesTheTightenedValidator) {
+  // The point of the rewrite is that what it produces is accepted by the validator that just
+  // stopped accepting the input. If these two ever disagree, an old document loads into a state
+  // the editor refuses to commit.
+  const std::string migrated = MigrateLegacyRaypathCommaConnector("entry:1,2 & 3-5,1-2");
+  EXPECT_EQ(ValidateSummandText(migrated, LUMICE_CRYSTAL_PRISM).state, LUMICE_RAYPATH_VALID);
+  EXPECT_EQ(ValidateSummandText("entry:1,2 & 3-5,1-2", LUMICE_CRYSTAL_PRISM).state, LUMICE_RAYPATH_INVALID);
+}
+
+TEST(FilterSopGrammar, MigrationIsIdempotent) {
+  const std::string once = MigrateLegacyRaypathCommaConnector("entry:1,2 & 3,5;1-2");
+  EXPECT_EQ(MigrateLegacyRaypathCommaConnector(once), once);
 }
 
 }  // namespace

--- a/test/unit-correctness/gui/test_filter_sop_grammar.cpp
+++ b/test/unit-correctness/gui/test_filter_sop_grammar.cpp
@@ -686,6 +686,17 @@ TEST(FilterSopGrammar, MigrationRewritesInsideEverySemicolonAlternative) {
   EXPECT_EQ(MigrateLegacyRaypathCommaConnector("3,5;1-2"), "3-5;1-2");
 }
 
+TEST(FilterSopGrammar, MigrationCanonicalizesRowSpacingWhenItRewrites) {
+  // The other half of the no-op case above, and the one that was an unstated implementation
+  // detail until it was pinned here: once a row IS being rewritten, it comes back re-joined from
+  // its tokens with a canonical " & " — irregular '&' spacing in the same row is normalized along
+  // with the comma. This is contract, not accident (see the note on the function): the row is
+  // already changing, '&' spacing carries no meaning, and rebuilding from tokens avoids a second
+  // position-tracking code path. Only rows that carry no ',' at all are byte-for-byte preserved.
+  EXPECT_EQ(MigrateLegacyRaypathCommaConnector("3-5,1-2&entry:1,2"), "3-5-1-2 & entry:1,2");
+  EXPECT_EQ(MigrateLegacyRaypathCommaConnector("3-5,1-2   &  len:2"), "3-5-1-2 & len:2");
+}
+
 TEST(FilterSopGrammar, MigrationIsAVerbatimNoOpWithoutCommas) {
   // The common case is a document with no ',' at all, and it must come back byte for byte — not
   // re-joined, re-spaced or trimmed. A migration that reformats every row on every load would


### PR DESCRIPTION
## 背景

`,` 曾是 raypath 的**原始**分隔符，`d48bdc52`（2026-04-01）用 `-` 取代它，`,` 只作为读旧 `.lmc` 的兼容分支留下。从那天起它在用户文档里就是隐形的——`doc/gui-guide.md` 的 Raypath 行只列 `3-5`/`1-3`，编辑框静态提示和 ⓘ 语法 tooltip 都没提过它。

问题不是「不报错」，而是**同一个字符在同一个输入框里有两个相反的含义**：

- `entry:1,2` —— `,` = OR（已文档化）
- `3-5,1-2` —— `,` = 连接（从未文档化）

用户按直觉写 `3-5,1-2` 想表达「两条光路」，实际被归一化成 `3-5-1-2`，得到一条 4 面路径。而 1/2/3/5 在棱柱上都是合法面号 ⇒ **校验通过、边框绿、OK 可点、跑出来近乎空图，全程零诊断**。

## 改动

- **校验器收紧**：`IsSeparator` 去掉 `,`；含逗号的非法 raypath 文本走专门消息而非通用 `"Invalid raypath"`，同时点名两个正确写法——`-` 连接同一光路上的面，`;` 分隔不同光路。
- **解析器整段作废**：`ParseRaypathSegment` 从「逐 token 跳过」改为 **segment 作用域整体作废**。这一条不是形式主义——朴素改法下 `3-5,1-2` 会按 `-` 切成 `3` / `5,1` / `2`，只丢中间那个，返回 `{3, 2}`：一条看起来合理、没人要过的两面路径（round-1 评审预测并红态复现）。现在返回空。
- **加载期迁移**：新增 `MigrateLegacyRaypathCommaConnector`，raypath token 内 `,`→`-`，**不触碰** `entry:`/`exit:` facelist 逗号；覆盖 v3 `summands` 与 v1/v2 `raypath_text` 两条读路径，命中时每文档一次 `GUI_LOG_WARNING`。存量文档照常打开，下次保存即规范化。
- **`schema_version` 3→4**：该字段是软信号而非加载闸（真正的闸是二进制 `kLmcVersion` 头），loader 对 v1/v2/v3 一视同仁 ⇒ bump 零成本，且把「v≤3 的逗号 = 老的连接语义」冻结成历史事实。
- **删死代码**：`ParseRaypathText`（`file_io.cpp`/`file_io.hpp`）零调用点，连同随之无用的 `#include <sstream>` 一并删除。
- **文档与注释同步**：`doc/gui-guide.md` 明确写出「`,` 不是路径连接符」；`lumice.h` / `raypath_validation.hpp` / `gui_state.hpp` 里 "dash- or comma-separated" 的陈述全部改到与新行为一致。

## 不在范围内

**逗号复活为「分隔不同光路」（`;` 的同义词）** —— 已与 owner 讨论并裁定不在本 PR 做。理由链、已核实的机制事实（`SplitSummandTokens` 只按 `&` 切 ⇒ 无 tokenizer 歧义、分配律可继承）、真实成本与重新评估条件，均记入 backlog。要点：先退役 ⇒ 期间没人能存下新逗号 ⇒ 日后若真加别名，「这个逗号是什么时候写的」没有存量答案要兼容。

## 测试

翻转 13 条既有承认逗号的用例，新增 21 条判据（拒绝 / 迁移 / EE facelist 边界 / 两个界面）。**每条新判据均做过红态自证**——六类反向改动逐一验证转红，含一次探针未红 → 补判据「迁移计数不跨 load 残留」的诚实记录。

`./scripts/test.sh quick` 在 rebase 后的基线上重跑：`RESULT: PASS`（ctest 7/7、fast-e2e 86 passed/1 skipped、gui-correctness 320/320）。

## 已知边界（有意保留，非遗漏）

- 校验器选择「逗号专门消息 vs 通用消息」的判据是「原文本是否含 `,`」，不是「逗号是否本次 kInvalid 的真正触发原因」。`3--5,` 会显示逗号消息而掩盖双横杠这个真实错误——两步修复而非一步，且逗号在该串里确实也是错的。存档以防将来有人依赖「消息 = 真实触发原因」这个不成立的假设。
- 数字合法性判据在校验器（`src/config/`）与解析器（`src/gui/`）两侧各有一份手写实现，接受集必须保持一致。API 边界（`src/gui/` 禁 include `config/`）排除了共享实现，两侧以互相指名的注释维持，**无机制强制**。已回写 backlog。
- 一条既有的校验器/解析器分歧未收口：`3--5` 对校验器是 kInvalid、对解析器是 `{3,5}`。不同谓词、不同输入类，不在本任务根因内（a07），现已就地记录而非潜伏。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ViBZSwqKK9pdkvBWiXGofZ
