### PR TITLE
给 user_defaults.json 盖上独立的 schema 版本戳（只记录，不设闸，不迁移）

### DIFF
--- a/doc/gui-state-governance.md
+++ b/doc/gui-state-governance.md
@@ -175,3 +175,20 @@
 ⚠️ "没有 `kView` 顶层字段"本身不等于"没有视图性的设置"，因为档位登记在**顶层字段**这一粒度上（`renderer` 整体登记为 `kStructSoft`，`gui_state_tiers.hpp`），一个顶层字段内部的成员不会单独出现在那份七项清单里。但对 `renderer` 这一项，答案现在是明确的：快照存的是 `RenderConfigResimFields renderer_resim` 而**不是**整份 `RenderConfig`，镜头 / fov / elevation / azimuth / roll / visible / front 与 `exposure_offset` 结构性地不在快照里，Revert 不覆盖它们。「Revert 应当覆盖哪些字段」这个语义问题已有答案且只有一个真源——`RenderConfigResimFields`，见 §3 偏离 F。
 
 默认值层复用的是 `ConfigSnapshot` 背后"两份状态结构化 diff、按需派生效果"的**模式**，但不能复用其 struct：两者覆盖的字段集合不同，把默认值的 diff 引擎强行套进 `ConfigSnapshot` 会连带改动 Revert 语义。
+
+### 8.9 覆盖文件的版本戳：只记录，不迁移，不设闸
+
+覆盖文件带一个根级 `defaults_schema_version`（整数，当前 1），由**唯一写入方** `WriteUserDefaultsFile`（`user_defaults.cpp`）在写盘那一刻盖上——不是 diff 行、不由面板决定、调用方自带的值会被覆盖。所以"哪条路径写的文件"这个问题不存在：`src/` 下经 `WriteActiveOverlayDoc` 的那唯一一条生产路径必然带戳，这条单点约束本身由 `scripts/check_policies.py` 的 `user-defaults-single-write-path` 机械守着。
+
+**它记录，但不裁决。** 加载路径上没有任何分支读它做决定：戳缺失 → 静默按正常文件加载（这是版本戳出现之前的所有存量文件，给它们记一条降级警告等于让每个老用户升级后白吃一条提示，与 §8.6 I3 想留痕的那类真实失效不是一回事）；戳的形态非法（字符串 / 负数 / 0 / 小数 / null）→ 等同缺失，但记一条 notice，因为文件对自己说了一句不可能为真的话；戳比当前构建**新** → 记一条 notice，**其余键照常全部生效**。
+
+最后这条是本节与 `.lmc` 策略的分水岭，也是这个设计最容易被"顺手加固"改错的地方。`.lmc` 的 `kLmcVersion` 是硬闸——一份读不全的整份文档不该假装能忠实显示，那是对的。覆盖文件的结构恰好相反：它是一袋各自独立、每个都已有"不存在即取工厂值"回退的提示（§8.4），因为其中一个键来自未来就拒掉整袋，比"忽略不认识的键、其余照常工作"这个**它今天已有的行为**更差。真实场景就摆在这里：用户从 release 页下载多个版本来回切换，跑一次新版再退回旧版，一道闸会让旧版拒掉他全部个人默认值。⇒ **任何情况下都不得因为版本号而拒绝或降级加载整份覆盖文件。**
+
+那它现在有什么用？现在没有，将来才有——而这正是它必须先写进存量文件的原因。本仓库既有的迁移触发器全是**数据形态**而不是版本号（如 `MigrateLegacyRaypathCommaConnector` 每次 load 无条件按文本判别，`raypath_segments.hpp`），键存在性与值形态能覆盖绝大多数变更。它们覆盖不了的恰好是一格：键名没变、值没变、**语义**变了。`presets.axis.*` 存的是裸 zenith std，含义依赖 `ClassifyAxisPreset` 的阈值常量——那两个常量哪天挪动，存量文件里的值就会静默映射到另一个预设，任何形态判别都看不出来。判别位必须在那次变更**之前**就在文件里，所以它今天先写，等有人需要时再读。
+
+⚠️ **与 `kGuiStateSchemaVersion`（`file_io.hpp`，`.lmc` / GuiState payload 的版本）是两个独立计数器，故意不对齐，不得假设二者同步、也不得为了"看起来整齐"把其中一个重新编号。** 两者的键空间**重叠但不相等**：`presets.*` 是覆盖文件独有，`layers` 是 `.lmc` 独有且被覆盖文件整个排除（`kDiffEngineExcludedRootKeys`）——`.lmc` 至今 v1→v4 四次变更全部发生在 `layers` 底下，即覆盖文件的键空间零变更历史。共用一个计数器意味着任何一侧的语义变更都推高另一侧从未变过的数，制造"版本号涨了但其实什么都没变"的噪音。反过来，当一个**两边都能承载**的字段（`layers` 之外的某个 GuiState 序列化键）语义变了，两个计数器都要评估。这条告诫在两处常量旁各写了一遍——只写一处等于没写，改另一处的人看不见。
+
+两条与文件形态相关的连带约束：
+
+- **`schema_version` 与 `defaults_schema_version` 是两个键，不是一个。** 前者是 `SerializeGuiStateJson` 的输出里本来就有的根键（因此被 `kDiffEngineExcludedRootKeys` 排除在 diff 行之外），后者是覆盖文件自己的。同名复用会让同一份合并文档里一个键承载两种含义，打开文件的人无从区分。另外，`ApplyUserDefaultsOverlay` 的 merge 是 `merge_patch`，磁盘文档里任何与工厂文档同名的根键都会覆盖合并结果里的那个（值为 `null` 时更是直接**删除**该键）——所以 `BuildMergedOverlayDocument` 在 merge 之后无条件把 `schema_version` 回写成当前构建值：喂给反序列化器的那份文档描述的是**它自己**，不是它读过的文件。今天无害（反序列化器不读它），它咬人的那天正是版本号开始被用上的那天。
+- **"只含一个版本戳"必须继续读作"没有个人默认值"。** 用户把所有默认值都改回出厂值后，文件从 `{}` 变成只剩这一个键。任何回答"这个用户有没有个人默认值"的判断都不得因此翻面——今天这样的判断只有 `ApplyUserDefaultsOverlay` 的早退一处，它按键名忽略版本戳。

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -2579,7 +2579,10 @@ std::string SerializeGuiStateJson(const GuiState& state) {
   // load is rewritten to '-' (see MigrateLegacyRaypathCommaConnector). Loader is tolerant of
   // older forms (v=1/v=2/v=3 all still migrate correctly), so this is a soft signal, not a
   // load gate — the binary kLmcVersion header is the actual gate (see §2.7).
-  root["schema_version"] = 4;
+  //
+  // The constant carries the coupling note with the overlay's own independent counter; read it
+  // (file_io.hpp) before bumping this.
+  root["schema_version"] = kGuiStateSchemaVersion;
 
   return root.dump(2);
 }

--- a/src/gui/file_io.hpp
+++ b/src/gui/file_io.hpp
@@ -120,6 +120,21 @@ SopExpansionSummary SummarizeSopExpansion(const FilterConfig& f);
 // Deserialize Core JSON string to GuiState, returns true on success
 bool DeserializeFromJson(const std::string& json_str, GuiState& state);
 
+// Format version of the GuiState JSON payload written by SerializeGuiStateJson (the `.lmc`
+// document body). A soft provenance signal, not a load gate: DeserializeGuiStateJson never reads
+// it, and every migration in this file triggers on the DATA's shape instead. The actual gate for
+// `.lmc` is the binary kLmcVersion header.
+//
+// ⚠️ Coupling with the personal-defaults store, which has a SECOND, INDEPENDENT counter:
+// kUserDefaultsOverlaySchemaVersion in user_defaults.hpp. The two are deliberately NOT aligned
+// and must not be assumed to move together — this one tracks the `.lmc` payload (every bump so
+// far happened under `layers`, which the overlay excludes wholesale), the other tracks the
+// overlay's own key space (GuiState's serialized keys minus `layers`, plus `presets.*`). Those
+// key spaces OVERLAP but are not equal. So when the SEMANTICS of a field visible to both change
+// (a serialized GuiState key that is not under `layers`), evaluate BOTH counters — bumping only
+// this one leaves the overlay unable to tell its own generations apart.
+inline constexpr int kGuiStateSchemaVersion = 4;
+
 // Serialize GuiState to full JSON (for .lmc file, preserves all frontend params)
 std::string SerializeGuiStateJson(const GuiState& state);
 

--- a/src/gui/user_defaults.cpp
+++ b/src/gui/user_defaults.cpp
@@ -118,6 +118,65 @@ void ResetIneligibleScalarFields(GuiState& state) {
   state.use_gpu_backend = factory.use_gpu_backend;
 }
 
+// "Does this document say anything the user chose?" — the provenance stamp does not count.
+//
+// The stamp is written by WriteUserDefaultsFile on every save, so a user who reverts every
+// personal default back to factory ends up with a file holding exactly one key instead of the
+// `{}` that meant "nothing saved" before. Anything answering "are there personal defaults?" with
+// a plain emptiness test would flip its answer over a field the user never set and cannot see.
+// Only one such test exists today (ApplyUserDefaultsOverlay's early return, below); this states
+// the rule where the next one will find it, instead of leaving it to be re-derived.
+bool IsOverlayDocEffectivelyEmpty(const nlohmann::json& doc) {
+  if (!doc.is_object()) {
+    return true;
+  }
+  for (const auto& item : doc.items()) {
+    if (item.key() != kUserDefaultsOverlaySchemaVersionKey) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Classify the overlay's provenance stamp and report anything worth telling the user about. It
+// returns nothing and gates nothing: the caller proceeds identically whatever this finds, which
+// is the mechanical form of "record, never refuse" (see kUserDefaultsOverlaySchemaVersion).
+//
+//   absent          — every file written before the stamp existed. Silent, NOT a degradation:
+//                     that is the same reason ReadOverlayJsonIfPresent short-circuits a missing
+//                     file rather than counting it, and folding it in would hand every existing
+//                     user a warning the first time they upgraded.
+//   malformed       — string / null / negative / fractional. Treated as absent, but noticed: the
+//                     file says something about itself that cannot be true, and the legal domain
+//                     is positive integers only (0 was never written by any build, the counter
+//                     starts at 1).
+//   newer than this build — noticed, and that is ALL. The other keys are applied in full; see
+//                     AC5 in the issue and the header note for why refusing them would be worse
+//                     than the pre-stamp behavior it replaces.
+//   at or below this build — the ordinary case (a file this build or an older one wrote). Silent:
+//                     reading an older file is the design's daily job, not an anomaly.
+void CheckUserDefaultsSchemaVersionStamp(const nlohmann::json& doc) {
+  const auto stamp = doc.find(kUserDefaultsOverlaySchemaVersionKey);
+  if (stamp == doc.end()) {
+    return;
+  }
+
+  if (!stamp->is_number_integer() || stamp->get<long long>() <= 0) {
+    NoteUserDefaultsDowngrade(std::string("'") + kUserDefaultsOverlaySchemaVersionKey +
+                              "' is not a positive integer (" + stamp->dump() +
+                              "); treating the file as unstamped and loading it anyway");
+    return;
+  }
+
+  const long long version = stamp->get<long long>();
+  if (version > kUserDefaultsOverlaySchemaVersion) {
+    NoteUserDefaultsDowngrade("personal defaults were written by a newer version of Lumice (format " +
+                              std::to_string(version) + ", this build understands " +
+                              std::to_string(kUserDefaultsOverlaySchemaVersion) +
+                              "); settings it does not recognize are ignored");
+  }
+}
+
 }  // namespace
 
 int TakeUserDefaultsDowngradeCount() {
@@ -214,21 +273,43 @@ nlohmann::json ReadOverlayJsonIfPresent(const std::filesystem::path& dir) {
   }
 }
 
+// Layer the sparse override onto a full factory document rather than handing the fragment
+// straight to the deserializer. Both routes end at the same values (the deserializer is
+// already "missing key = factory value"), but this one keeps the deserializer's own
+// "no renderer key found" diagnostic honest: it is meant to flag a malformed .lmc, and it
+// would otherwise fire on every startup for a user whose defaults touch no renderer setting.
+nlohmann::json BuildMergedOverlayDocument(const nlohmann::json& doc) {
+  nlohmann::json merged = nlohmann::json::parse(SerializeGuiStateJson(GuiState{}));
+  merged.merge_patch(doc);
+
+  // Unconditional, after the merge and before anyone reads the result: whatever the overlay said
+  // about `schema_version` describes the file it came from, never the document being assembled
+  // here. merge_patch has already either overwritten this build's value with the file's, or —
+  // for a `null` — deleted the key; one assignment repairs both. See the header for why this
+  // cannot be observed through the resulting GuiState, and therefore why this function is
+  // separately visible at all.
+  merged["schema_version"] = kGuiStateSchemaVersion;
+  return merged;
+}
+
 void ApplyUserDefaultsOverlay(GuiState& state, const nlohmann::json& doc) {
-  if (!doc.is_object() || doc.empty()) {
+  if (!doc.is_object()) {
     return;
   }
 
-  // Layer the sparse override onto a full factory document rather than handing the fragment
-  // straight to the deserializer. Both routes end at the same values (the deserializer is
-  // already "missing key = factory value"), but this one keeps the deserializer's own
-  // "no renderer key found" diagnostic honest: it is meant to flag a malformed .lmc, and it
-  // would otherwise fire on every startup for a user whose defaults touch no renderer setting.
+  // Before the emptiness check, not after: a document whose ONLY key is a malformed stamp is
+  // still a file making a false claim about itself, and the user is owed the notice even though
+  // there is nothing left to apply.
+  CheckUserDefaultsSchemaVersionStamp(doc);
+
+  if (IsOverlayDocEffectivelyEmpty(doc)) {
+    return;
+  }
+
   nlohmann::json merged;
   GuiState overlaid;
   try {
-    merged = nlohmann::json::parse(SerializeGuiStateJson(GuiState{}));
-    merged.merge_patch(doc);
+    merged = BuildMergedOverlayDocument(doc);
     if (!DeserializeGuiStateJson(merged.dump(), overlaid)) {
       ++g_downgrade_count;
       GUI_LOG_WARNING("[GUI] User defaults: override document could not be applied; using factory defaults");
@@ -481,7 +562,20 @@ bool WriteUserDefaultsFile(const std::filesystem::path& dir, const nlohmann::jso
     GUI_LOG_WARNING("[GUI] User defaults: cannot write '{}'; nothing was saved", PathToU8(file));
     return false;
   }
-  out << doc.dump(2) << '\n';
+
+  // Stamp here, in the single write owner, so every writer is stamped without knowing it exists —
+  // and so no caller can choose otherwise. Overwriting any stamp the caller supplied is the point:
+  // "this file was written by this build" has no legitimate caller-chosen value. A test that needs
+  // a file claiming something else writes it raw, outside this owner (WriteRawOverlay).
+  //
+  // A non-object `doc` is left exactly as given. The only thing that hands one over is a test
+  // staging a deliberately malformed file; stamping it would turn it into a well-formed-but-odd
+  // file and quietly retire the case.
+  nlohmann::json stamped = doc;
+  if (stamped.is_object()) {
+    stamped[kUserDefaultsOverlaySchemaVersionKey] = kUserDefaultsOverlaySchemaVersion;
+  }
+  out << stamped.dump(2) << '\n';
   out.flush();
   if (!out.good()) {
     GUI_LOG_WARNING("[GUI] User defaults: write to '{}' failed; the file may be incomplete", PathToU8(file));

--- a/src/gui/user_defaults.cpp
+++ b/src/gui/user_defaults.cpp
@@ -155,25 +155,42 @@ bool IsOverlayDocEffectivelyEmpty(const nlohmann::json& doc) {
 //                     than the pre-stamp behavior it replaces.
 //   at or below this build — the ordinary case (a file this build or an older one wrote). Silent:
 //                     reading an older file is the design's daily job, not an anomaly.
-void CheckUserDefaultsSchemaVersionStamp(const nlohmann::json& doc) {
+void ReportSchemaVersionStampIssues(const nlohmann::json& doc) {
   const auto stamp = doc.find(kUserDefaultsOverlaySchemaVersionKey);
   if (stamp == doc.end()) {
     return;
   }
 
-  if (!stamp->is_number_integer() || stamp->get<long long>() <= 0) {
-    NoteUserDefaultsDowngrade(std::string("'") + kUserDefaultsOverlaySchemaVersionKey +
-                              "' is not a positive integer (" + stamp->dump() +
-                              "); treating the file as unstamped and loading it anyway");
-    return;
-  }
+  // The classification below reads a value from a document that need not have come from a
+  // text file this build's own parser validated. `dump()` (used to render the malformed-shape
+  // notice) independently re-validates UTF-8 and throws (nlohmann::json type_error 316) on a
+  // string built in-memory from raw invalid bytes — e.g. `nlohmann::json{}["k"] =
+  // std::string("\xC0\x80")`, which bypasses json::parse()'s own strict UTF-8 checking (that
+  // checking is why a hand-edited FILE containing such a string, like an unpaired UTF-16
+  // surrogate escape `\uD800`, never reaches here at all: parse() rejects it upstream in
+  // ReadOverlayJsonIfPresent, well before this doc exists). This exception would otherwise
+  // escape this function and, since it runs before ApplyUserDefaultsOverlay's own try/catch
+  // (see the call site), abort loading the ENTIRE overlay — turning "an oddly-shaped version
+  // stamp" into exactly the kind of hard failure B3/AC5/AC6 rule out. A malformed stamp must
+  // never do worse than being ignored-and-reported.
+  try {
+    if (!stamp->is_number_integer() || stamp->get<long long>() <= 0) {
+      NoteUserDefaultsDowngrade(std::string("'") + kUserDefaultsOverlaySchemaVersionKey +
+                                "' is not a positive integer (" + stamp->dump() +
+                                "); treating the file as unstamped and loading it anyway");
+      return;
+    }
 
-  const long long version = stamp->get<long long>();
-  if (version > kUserDefaultsOverlaySchemaVersion) {
-    NoteUserDefaultsDowngrade("personal defaults were written by a newer version of Lumice (format " +
-                              std::to_string(version) + ", this build understands " +
-                              std::to_string(kUserDefaultsOverlaySchemaVersion) +
-                              "); settings it does not recognize are ignored");
+    const long long version = stamp->get<long long>();
+    if (version > kUserDefaultsOverlaySchemaVersion) {
+      NoteUserDefaultsDowngrade("personal defaults were written by a newer version of Lumice (format " +
+                                std::to_string(version) + ", this build understands " +
+                                std::to_string(kUserDefaultsOverlaySchemaVersion) +
+                                "); settings it does not recognize are ignored");
+    }
+  } catch (const std::exception&) {
+    NoteUserDefaultsDowngrade(std::string("'") + kUserDefaultsOverlaySchemaVersionKey +
+                              "' could not be interpreted; treating the file as unstamped and loading it anyway");
   }
 }
 
@@ -273,6 +290,8 @@ nlohmann::json ReadOverlayJsonIfPresent(const std::filesystem::path& dir) {
   }
 }
 
+namespace detail {
+
 // Layer the sparse override onto a full factory document rather than handing the fragment
 // straight to the deserializer. Both routes end at the same values (the deserializer is
 // already "missing key = factory value"), but this one keeps the deserializer's own
@@ -292,6 +311,8 @@ nlohmann::json BuildMergedOverlayDocument(const nlohmann::json& doc) {
   return merged;
 }
 
+}  // namespace detail
+
 void ApplyUserDefaultsOverlay(GuiState& state, const nlohmann::json& doc) {
   if (!doc.is_object()) {
     return;
@@ -300,7 +321,7 @@ void ApplyUserDefaultsOverlay(GuiState& state, const nlohmann::json& doc) {
   // Before the emptiness check, not after: a document whose ONLY key is a malformed stamp is
   // still a file making a false claim about itself, and the user is owed the notice even though
   // there is nothing left to apply.
-  CheckUserDefaultsSchemaVersionStamp(doc);
+  ReportSchemaVersionStampIssues(doc);
 
   if (IsOverlayDocEffectivelyEmpty(doc)) {
     return;
@@ -309,7 +330,7 @@ void ApplyUserDefaultsOverlay(GuiState& state, const nlohmann::json& doc) {
   nlohmann::json merged;
   GuiState overlaid;
   try {
-    merged = BuildMergedOverlayDocument(doc);
+    merged = detail::BuildMergedOverlayDocument(doc);
     if (!DeserializeGuiStateJson(merged.dump(), overlaid)) {
       ++g_downgrade_count;
       GUI_LOG_WARNING("[GUI] User defaults: override document could not be applied; using factory defaults");

--- a/src/gui/user_defaults.cpp
+++ b/src/gui/user_defaults.cpp
@@ -183,10 +183,19 @@ void ReportSchemaVersionStampIssues(const nlohmann::json& doc) {
 
     const long long version = stamp->get<long long>();
     if (version > kUserDefaultsOverlaySchemaVersion) {
+      // COPY CONSTRAINT, same one DescribeAxisPresetClamp above is written under: the sentence
+      // must not assert something the user cannot check and that may well be false. A higher
+      // stamp says only which build wrote the file — it does NOT imply the file holds any key
+      // this build fails to recognize, and the common case is that it holds none (the stamp
+      // rises on every format generation, whether or not the user's own settings changed shape).
+      // "settings it does not recognize are ignored" told every such user their settings had
+      // been dropped, on a load where nothing was. State what always holds: known keys applied,
+      // unknown ones (if any) skipped.
       NoteUserDefaultsDowngrade("personal defaults were written by a newer version of Lumice (format " +
                                 std::to_string(version) + ", this build understands " +
                                 std::to_string(kUserDefaultsOverlaySchemaVersion) +
-                                "); settings it does not recognize are ignored");
+                                "); every setting this build recognizes was applied as usual, and any it does "
+                                "not recognize were skipped");
     }
   } catch (const std::exception&) {
     NoteUserDefaultsDowngrade(std::string("'") + kUserDefaultsOverlaySchemaVersionKey +

--- a/src/gui/user_defaults.hpp
+++ b/src/gui/user_defaults.hpp
@@ -254,6 +254,34 @@ inline UserConfigSource ResolveUserConfigSource(UserConfigArgPresence presence, 
 
 inline constexpr const char* kUserDefaultsFileName = "user_defaults.json";
 
+// Provenance stamp for the override file: which generation of this program's key space wrote it.
+// Stamped by WriteUserDefaultsFile (the single write owner), so every writer gets it without
+// knowing it exists.
+//
+// It RECORDS, it does not gate and it does not migrate. Nothing in the load path branches on it:
+// a file from a newer build still has every one of its other keys applied, because an overlay is
+// a bag of independent hints that each already fall back to the factory value when absent, so
+// rejecting the bag over one key from the future is strictly worse than today's "ignore the keys
+// you don't know". (That is the opposite of the `.lmc` policy, where a document read only in part
+// must not be displayed as if it were whole.) The one thing a stamp mismatch produces is a notice
+// through NoteUserDefaultsDowngrade.
+//
+// Its point is future-facing: a key whose NAME and VALUE stay the same while its MEANING moves is
+// invisible to the key-existence/value-shape probing every migration in this codebase actually
+// uses. `presets.axis.*` stores a bare zenith-std whose meaning depends on ClassifyAxisPreset's
+// threshold constants — move those and a stored value silently maps to a different preset. The
+// discriminator has to be in the stored files BEFORE that change, which is why it is written now
+// while nothing reads it.
+//
+// ⚠️ Coupling with kGuiStateSchemaVersion (file_io.hpp) — the `.lmc`/GuiState payload version.
+// TWO INDEPENDENT COUNTERS, deliberately NOT aligned; do not assume they move together, and do
+// not renumber one to match the other. They answer different questions over overlapping but
+// unequal key spaces (`presets.*` is overlay-only; `layers` is `.lmc`-only and is excluded from
+// the overlay wholesale). A semantic change to a field BOTH can carry must be evaluated against
+// both counters.
+inline constexpr const char* kUserDefaultsOverlaySchemaVersionKey = "defaults_schema_version";
+inline constexpr int kUserDefaultsOverlaySchemaVersion = 1;
+
 // Pure OS config-directory computation — no environment reads, no filesystem IO, so all three
 // are testable on any host regardless of which platform it actually is. An absent OR EMPTY
 // input string counts as "unset" (the XDG spec says so explicitly, and an empty %APPDATA% /
@@ -448,6 +476,29 @@ void ResetUserAxisPresetOverrides();
 // the caller's business (the defaults panel decides which keys the user adopted); this only
 // owns "given a document, put it on disk". Returns false + GUI_LOG_WARNING on failure.
 bool WriteUserDefaultsFile(const std::filesystem::path& dir, const nlohmann::json& doc);
+
+// Layer a sparse override document over the factory document and hand back the merged JSON, one
+// step short of deserializing it. Pure: no IO, no globals.
+//
+// ⛔ Intended callers: ApplyUserDefaultsOverlay's own body, and gui_unit_test. Production code must
+// NOT call this to assemble an overlay of its own — ApplyUserDefaultsOverlay orchestrates a fixed
+// sequence around it (classify the stamp, then the effectively-empty early return, THEN merge),
+// and reaching straight for the merge step skips the first two.
+//
+// It exists as a separate, header-visible function only because the invariant below is otherwise
+// untestable. DeserializeGuiStateJson does not read `schema_version` at all, so a polluted value
+// in the merged document produces NO observable difference in the resulting GuiState — a black-box
+// test through ApplyUserDefaultsOverlay stays green with the protection deleted. Testing it
+// requires looking at the merged document itself, before it is consumed.
+//
+// The invariant: the `schema_version` in the returned document is ALWAYS this build's
+// kGuiStateSchemaVersion, whatever the disk file said. A hand-edited overlay may carry a root
+// `schema_version` of its own (nothing stops a user adding one; the diff engine merely never
+// writes it), and merge_patch would then overwrite the factory value with it — or, for a JSON
+// `null`, delete the key outright. Harmless today because nothing downstream reads it; it is
+// precisely the thing that starts biting on the day something does, which is the day a version
+// number exists to serve.
+nlohmann::json BuildMergedOverlayDocument(const nlohmann::json& doc);
 
 // Number of override-file degradations since the last call, then resets — same shape as
 // TakeShapeDistDowngradeCount(), so the load-time notice can be surfaced through the same

--- a/src/gui/user_defaults.hpp
+++ b/src/gui/user_defaults.hpp
@@ -477,13 +477,18 @@ void ResetUserAxisPresetOverrides();
 // owns "given a document, put it on disk". Returns false + GUI_LOG_WARNING on failure.
 bool WriteUserDefaultsFile(const std::filesystem::path& dir, const nlohmann::json& doc);
 
+namespace detail {
+
 // Layer a sparse override document over the factory document and hand back the merged JSON, one
 // step short of deserializing it. Pure: no IO, no globals.
 //
-// ⛔ Intended callers: ApplyUserDefaultsOverlay's own body, and gui_unit_test. Production code must
-// NOT call this to assemble an overlay of its own — ApplyUserDefaultsOverlay orchestrates a fixed
-// sequence around it (classify the stamp, then the effectively-empty early return, THEN merge),
-// and reaching straight for the merge step skips the first two.
+// Exposed in detail:: for unit testing; not part of the stable public surface. Intended callers:
+// ApplyUserDefaultsOverlay's own body, and gui_unit_test. Production code must NOT call this to
+// assemble an overlay of its own — ApplyUserDefaultsOverlay orchestrates a fixed sequence around
+// it (classify the stamp, then the effectively-empty early return, THEN merge), and reaching
+// straight for the merge step skips the first two. The detail:: namespace makes that boundary
+// structural rather than comment-only: it keeps the function out of lumice::gui's public surface
+// (and IDE autocomplete there) while still leaving it reachable for gui_unit_test.
 //
 // It exists as a separate, header-visible function only because the invariant below is otherwise
 // untestable. DeserializeGuiStateJson does not read `schema_version` at all, so a polluted value
@@ -499,6 +504,8 @@ bool WriteUserDefaultsFile(const std::filesystem::path& dir, const nlohmann::jso
 // precisely the thing that starts biting on the day something does, which is the day a version
 // number exists to serve.
 nlohmann::json BuildMergedOverlayDocument(const nlohmann::json& doc);
+
+}  // namespace detail
 
 // Number of override-file degradations since the last call, then resets — same shape as
 // TakeShapeDistDowngradeCount(), so the load-time notice can be surfaced through the same

--- a/test/composition-correctness/gui/test_user_defaults_chain.cpp
+++ b/test/composition-correctness/gui/test_user_defaults_chain.cpp
@@ -17,6 +17,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <filesystem>
+#include <fstream>
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <string>
@@ -275,6 +276,89 @@ TEST_F(UserDefaultsChain, OverridePresenceIsNotTheSameQuestionAsTheResultingDist
   AdoptAxisPresetZenithStdOverrideInMemory(AxisPreset::kColumn, std::nullopt);
   EXPECT_FALSE(GetUserAxisPresetZenithStdOverride(AxisPreset::kColumn).has_value())
       << "reverting to the factory value must remove the override, not store the factory number";
+}
+
+// ---------------------------------------------------------------------------------------------
+// The override file's provenance stamp, across the write path the panel actually uses.
+//
+// The unit-level half of these claims (the stamp is applied, malformed ones are reported, a
+// stamp-only document loads as nothing) lives in gui_unit_test against WriteUserDefaultsFile
+// directly. What only shows up here is whether the two units still agree once the panel's route
+// runs end to end — WriteActiveOverlayDoc resolving the directory, the store stamping the write,
+// the diff engine walking what came back.
+
+// The stamp has to arrive through the route the panel takes, not only when the store is called
+// directly. defaults_panel commits through WriteActiveOverlayDoc; if the stamping had been put at
+// a call site rather than in the store, THIS is the case that would notice, because it is the only
+// one that never mentions WriteUserDefaultsFile.
+TEST_F(UserDefaultsChain, TheSchemaStampArrivesThroughThePanelsOwnWritePath) {
+  const std::filesystem::path& dir = UseFreshConfigDir("stamp_via_panel_path");
+
+  ASSERT_TRUE(WriteActiveOverlayDoc(nlohmann::json{ { kProbeKey, 0.625f } }));
+
+  std::ifstream in(dir / kUserDefaultsFileName);
+  ASSERT_TRUE(in.is_open()) << "the write reported success but produced no file";
+  const nlohmann::json on_disk = nlohmann::json::parse(in);
+  ASSERT_TRUE(on_disk.contains(kUserDefaultsOverlaySchemaVersionKey))
+      << "the panel's write path reached disk unstamped: " << on_disk.dump();
+  EXPECT_EQ(on_disk[kUserDefaultsOverlaySchemaVersionKey].get<int>(), kUserDefaultsOverlaySchemaVersion);
+  EXPECT_EQ(on_disk[kProbeKey].get<float>(), 0.625f) << "and it must still carry what was being saved";
+}
+
+// Reverting every personal default used to leave `{}` on disk and now leaves a file holding one
+// key the user never set and cannot see. Everything downstream that answers "does this user have
+// personal defaults?" has to keep answering no.
+//
+// Run as a round trip rather than as an assertion about IsOverlayDocEffectivelyEmpty because the
+// regression this guards against is a disagreement BETWEEN units: the writer adding a key and a
+// reader still testing plain emptiness. Each unit is self-consistent in that state; only the
+// composition is wrong.
+TEST_F(UserDefaultsChain, RevertingEveryDefaultLeavesOnlyTheStampAndStillReadsAsNoPersonalDefaults) {
+  const std::filesystem::path& dir = UseFreshConfigDir("stamp_revert_all");
+
+  GuiState current;
+  current.bg_alpha = 0.375f;  // deliberately not the factory value, so the row asks to be adopted
+
+  // Save one personal default the way the panel does, then confirm it really is on disk — the
+  // revert below would otherwise be reverting nothing and the case would pass vacuously.
+  nlohmann::json doc = ReadActiveOverlayDoc();
+  std::vector<DefaultDiffRow> rows = BuildDefaultDiffRows(current, doc);
+  ASSERT_NE(FindRow(rows, kProbeKey), nullptr);
+  ASSERT_TRUE(ApplyCheckedRowsToDoc(doc, rows, { kProbeKey }, current));
+  ASSERT_TRUE(WriteActiveOverlayDoc(doc));
+  // ASSERT on the pointer before dereferencing it: a missing row here is a nullptr deref that
+  // aborts this single-process binary and takes every case after it down too.
+  const std::vector<DefaultDiffRow> saved_rows = BuildDefaultDiffRows(current, ReadActiveOverlayDoc());
+  const DefaultDiffRow* saved = FindRow(saved_rows, kProbeKey);
+  ASSERT_NE(saved, nullptr);
+  ASSERT_TRUE(saved->has_saved_override)
+      << "the precondition never landed, so this case would prove nothing about reverting it";
+
+  // Now the "reset all my defaults" gesture: every row present, none checked.
+  nlohmann::json reverted = ReadActiveOverlayDoc();
+  const std::vector<DefaultDiffRow> all_rows = BuildDefaultDiffRows(current, reverted);
+  ASSERT_TRUE(ApplyCheckedRowsToDoc(reverted, all_rows, {}, current));
+  ASSERT_TRUE(WriteActiveOverlayDoc(reverted));
+
+  std::ifstream in(dir / kUserDefaultsFileName);
+  ASSERT_TRUE(in.is_open());
+  const nlohmann::json on_disk = nlohmann::json::parse(in);
+  ASSERT_TRUE(on_disk.is_object());
+  EXPECT_EQ(on_disk.size(), static_cast<size_t>(1))
+      << "after reverting everything the file must hold the stamp and nothing else: " << on_disk.dump();
+  EXPECT_TRUE(on_disk.contains(kUserDefaultsOverlaySchemaVersionKey)) << on_disk.dump();
+
+  // The claim that matters: that file means "no personal defaults", exactly as `{}` did.
+  ResetUserDefaultsChannels();
+  const GuiState after = MakeNewDocumentState(dir);
+  EXPECT_EQ(SerializeGuiStateJson(after), SerializeGuiStateJson(MakeNewDocumentState(FreshOverlayDir("stamp_none"))))
+      << "a stamp-only file produced a different document than an empty directory";
+  EXPECT_EQ(TakeUserDefaultsDowngradeCount(), 0) << "and it is not a degradation — nothing about it is wrong";
+  const std::vector<DefaultDiffRow> reverted_rows = BuildDefaultDiffRows(current, ReadActiveOverlayDoc());
+  const DefaultDiffRow* reverted_row = FindRow(reverted_rows, kProbeKey);
+  ASSERT_NE(reverted_row, nullptr);
+  EXPECT_FALSE(reverted_row->has_saved_override)
+      << "the panel still shows the reverted key as saved, so the user can never clear it";
 }
 
 }  // namespace

--- a/test/unit-correctness/gui/test_user_defaults.cpp
+++ b/test/unit-correctness/gui/test_user_defaults.cpp
@@ -1038,3 +1038,168 @@ TEST_F(UserDefaults, bg_degrade_is_wired_into_every_document_path) {
   }
   EXPECT_EQ(raw_loads, 3);  // 1 definition + LoadBackgroundWithDegrade + DoLoadBackground
 }
+
+// ================================================================================
+// The override file's own provenance stamp (`defaults_schema_version`)
+// ================================================================================
+// Prefix these `schema_version_` rather than continuing the `ac2_`/`ac3_` numbering above: those
+// belong to an older effort's own acceptance list, and reusing the numerals would read as the
+// same list continuing.
+//
+// The stamp RECORDS which generation of the key space wrote a file. It never gates: no branch
+// below rejects, discards or downgrades anything on account of it. The cases are grouped around
+// that claim — every one that reports something also asserts the rest of the document still
+// arrived.
+
+// The stamp comes from the write owner, so no writer has to know it exists and none can opt out.
+// The non-object half guards the deliberate "write a malformed file" staging other cases in this
+// suite rely on: stamping that would make it well-formed and quietly retire them.
+TEST_F(UserDefaults, schema_version_write_owner_stamps_every_document) {
+  const auto dir = FreshOverlayDir("stamp_write_owner");
+
+  ASSERT_TRUE(gui::WriteUserDefaultsFile(dir, json{ { "bg_alpha", 0.25f } }));
+  const json stamped = ReadOverlayDoc(dir);
+  ASSERT_TRUE(stamped.contains(gui::kUserDefaultsOverlaySchemaVersionKey))
+      << "a document written through the owner reached disk without a stamp";
+  EXPECT_EQ(stamped[gui::kUserDefaultsOverlaySchemaVersionKey].get<int>(), gui::kUserDefaultsOverlaySchemaVersion);
+  EXPECT_EQ(stamped["bg_alpha"].get<float>(), 0.25f) << "stamping must not disturb what the caller wrote";
+
+  // A caller-supplied stamp is overwritten, not honored: "which build wrote this file" is not a
+  // value any caller gets to choose. (A test that needs a file claiming otherwise writes it raw.)
+  ASSERT_TRUE(gui::WriteUserDefaultsFile(dir, json{ { gui::kUserDefaultsOverlaySchemaVersionKey, 4242 } }));
+  EXPECT_EQ(ReadOverlayDoc(dir)[gui::kUserDefaultsOverlaySchemaVersionKey].get<int>(),
+            gui::kUserDefaultsOverlaySchemaVersion);
+
+  ASSERT_TRUE(gui::WriteUserDefaultsFile(dir, json::array({ 1, 2, 3 })));
+  std::ifstream in(dir / gui::kUserDefaultsFileName);
+  const json non_object = json::parse(in);
+  EXPECT_TRUE(non_object.is_array()) << "a non-object document must land exactly as handed over";
+}
+
+// AC3 — the merged document handed to the deserializer always carries THIS build's
+// kGuiStateSchemaVersion, whatever the file on disk said.
+//
+// Asserted on the merged JSON rather than on the resulting GuiState because there is no assertion
+// available on the GuiState: DeserializeGuiStateJson does not read `schema_version` at all, so a
+// polluted value produces no observable difference downstream and an end-to-end check stays green
+// with the protection deleted. That is the whole reason BuildMergedOverlayDocument is reachable
+// from here.
+//
+// `null` gets its own row because merge_patch treats it as "delete this key", so the failure it
+// would cause is an ABSENT `schema_version`, not a wrong one — a different defect from the same
+// unprotected line.
+TEST_F(UserDefaults, schema_version_stale_root_key_is_stripped_before_deserialize) {
+  const json kPolluted[] = {
+    json{ { "schema_version", 1 }, { "bg_alpha", 0.5f } },        // an older build's value
+    json{ { "schema_version", 999 }, { "bg_alpha", 0.5f } },      // a value from the future
+    json{ { "schema_version", nullptr }, { "bg_alpha", 0.5f } },  // merge_patch would DELETE the key
+    json{ { "bg_alpha", 0.5f } },                                 // the ordinary file: nothing to repair
+  };
+
+  for (const json& doc : kPolluted) {
+    const json merged = gui::BuildMergedOverlayDocument(doc);
+    // Non-fatal + `continue` rather than ASSERT: this loop's rows are independent defects, and a
+    // fatal report on the first would hide whether the others also regressed.
+    if (!merged.contains("schema_version")) {
+      ADD_FAILURE() << "the merged document lost `schema_version` entirely: " << doc.dump();
+      continue;
+    }
+    EXPECT_EQ(merged["schema_version"].get<int>(), gui::kGuiStateSchemaVersion) << doc.dump();
+    EXPECT_EQ(merged["bg_alpha"].get<float>(), 0.5f)
+        << "repairing the version must not cost the overlay its actual content: " << doc.dump();
+  }
+}
+
+// AC4 — every file written before the stamp existed. Silent, and specifically NOT counted as a
+// degradation: otherwise every existing user collects a warning the first time they upgrade, for
+// a file that is in no way wrong.
+TEST_F(UserDefaults, schema_version_missing_key_is_silent) {
+  const auto dir = FreshOverlayDir("stamp_missing");
+  WriteRawOverlay(dir, R"({"bg_alpha": 0.4})");
+
+  const gui::GuiState state = gui::MakeNewDocumentState(dir);
+  EXPECT_EQ(state.bg_alpha, 0.4f) << "an unstamped file is an ordinary file and must load in full";
+  EXPECT_EQ(gui::TakeUserDefaultsDowngradeCount(), 0);
+  EXPECT_TRUE(gui::TakeUserDefaultsDowngradeNotices().empty());
+}
+
+// AC5 — a file from a newer build is REPORTED and then applied in full. Both halves are the point:
+// the notice alone would be satisfied by an implementation that also discarded the document, and
+// discarding it is exactly what this design refuses to do (an overlay is a bag of independent
+// hints, so dropping all of them over one key from the future is worse than ignoring that key).
+TEST_F(UserDefaults, schema_version_newer_than_build_reports_but_still_applies_other_keys) {
+  const auto dir = FreshOverlayDir("stamp_newer");
+  WriteRawOverlay(dir, R"({"defaults_schema_version": 9999, "bg_alpha": 0.77, "aspect_portrait": true})");
+
+  const gui::GuiState state = gui::MakeNewDocumentState(dir);
+  EXPECT_EQ(gui::TakeUserDefaultsDowngradeCount(), 1) << "a file from the future must say so exactly once";
+  EXPECT_EQ(gui::TakeUserDefaultsDowngradeNotices().size(), static_cast<size_t>(1))
+      << "and the user must be able to read WHICH degradation it was, not just that there was one";
+  EXPECT_EQ(state.bg_alpha, 0.77f) << "the notice must not have cost the overlay its content";
+  EXPECT_TRUE(state.aspect_portrait);
+}
+
+// AC6 — a stamp that cannot mean anything is treated as no stamp, noticed, and costs the file
+// nothing. The legal domain is positive integers: a negative or fractional generation counter has
+// no reading, and 0 was never written by any build (the counter starts at 1).
+//
+// `1e9` is spelled as a JSON float on purpose — it is a perfectly plausible hand-edit that is
+// numerically enormous AND fractionally typed, so an implementation testing only `is_number()`
+// would take it as a version from the future and report the wrong thing.
+TEST_F(UserDefaults, schema_version_malformed_shape_is_ignored_and_reported) {
+  struct MalformedCase {
+    const char* name;
+    const char* raw;
+  };
+  const MalformedCase kCases[] = {
+    { "a string", R"({"defaults_schema_version": "1", "bg_alpha": 0.31})" },
+    { "a negative integer", R"({"defaults_schema_version": -1, "bg_alpha": 0.31})" },
+    { "zero", R"({"defaults_schema_version": 0, "bg_alpha": 0.31})" },
+    { "a fraction", R"({"defaults_schema_version": 1.5, "bg_alpha": 0.31})" },
+    { "a large float", R"({"defaults_schema_version": 1e9, "bg_alpha": 0.31})" },
+    { "null", R"({"defaults_schema_version": null, "bg_alpha": 0.31})" },
+    { "an object", R"({"defaults_schema_version": {"v": 1}, "bg_alpha": 0.31})" },
+  };
+
+  for (const MalformedCase& c : kCases) {
+    ResetUserDefaultsChannels();
+    const auto dir = FreshOverlayDir("stamp_malformed");
+    WriteRawOverlay(dir, c.raw);
+
+    const gui::GuiState state = gui::MakeNewDocumentState(dir);
+    EXPECT_EQ(gui::TakeUserDefaultsDowngradeCount(), 1) << c.name;
+    EXPECT_EQ(gui::TakeUserDefaultsDowngradeNotices().size(), static_cast<size_t>(1)) << c.name;
+    EXPECT_EQ(state.bg_alpha, 0.31f) << "a stamp nobody can read must not cost the file its keys: " << c.name;
+  }
+}
+
+// A malformed stamp with NOTHING beside it. The two predicates disagree about this document on
+// purpose — IsOverlayDocEffectivelyEmpty keys off the NAME (so this is "empty" and the merge is
+// skipped), while the stamp check keys off the VALUE (so this is a false claim worth reporting) —
+// and the notice only survives because the classification runs BEFORE the early return. Swap the
+// two lines and this is the only case that notices.
+TEST_F(UserDefaults, schema_version_malformed_stamp_alone_is_still_reported) {
+  const auto dir = FreshOverlayDir("stamp_malformed_alone");
+  WriteRawOverlay(dir, R"({"defaults_schema_version": "nonsense"})");
+
+  const gui::GuiState state = gui::MakeNewDocumentState(dir);
+  EXPECT_EQ(gui::TakeUserDefaultsDowngradeCount(), 1)
+      << "nothing was left to apply, but the file still says something untrue about itself";
+  EXPECT_TRUE(SerializesIdentically(state, gui::MakeNewDocumentState(FreshOverlayDir("stamp_alone_factory"))));
+}
+
+// AC7 — the stamp must not answer "does this user have personal defaults?".
+//
+// Before the stamp, a user who reverted every default was left with `{}`. Now they are left with a
+// file holding exactly one key they never set and cannot see, and any emptiness test that counted
+// it would flip its answer on that alone.
+TEST_F(UserDefaults, schema_version_stamp_only_document_is_effectively_empty) {
+  const auto dir = FreshOverlayDir("stamp_only");
+  WriteRawOverlay(dir, R"({"defaults_schema_version": 1})");
+  const gui::GuiState stamped_only = gui::MakeNewDocumentState(dir);
+  EXPECT_EQ(gui::TakeUserDefaultsDowngradeCount(), 0) << "a well-formed stamp of this build's own is not news";
+
+  const gui::GuiState truly_empty = gui::MakeNewDocumentState(FreshOverlayDir("stamp_only_empty"));
+  EXPECT_TRUE(SerializesIdentically(stamped_only, truly_empty))
+      << "a document carrying only the stamp must produce the same state as one carrying nothing";
+}

--- a/test/unit-correctness/gui/test_user_defaults.cpp
+++ b/test/unit-correctness/gui/test_user_defaults.cpp
@@ -1097,7 +1097,7 @@ TEST_F(UserDefaults, schema_version_stale_root_key_is_stripped_before_deserializ
   };
 
   for (const json& doc : kPolluted) {
-    const json merged = gui::BuildMergedOverlayDocument(doc);
+    const json merged = gui::detail::BuildMergedOverlayDocument(doc);
     // Non-fatal + `continue` rather than ASSERT: this loop's rows are independent defects, and a
     // fatal report on the first would hide whether the others also regressed.
     if (!merged.contains("schema_version")) {
@@ -1186,6 +1186,46 @@ TEST_F(UserDefaults, schema_version_malformed_stamp_alone_is_still_reported) {
   EXPECT_EQ(gui::TakeUserDefaultsDowngradeCount(), 1)
       << "nothing was left to apply, but the file still says something untrue about itself";
   EXPECT_TRUE(SerializesIdentically(state, gui::MakeNewDocumentState(FreshOverlayDir("stamp_alone_factory"))));
+}
+
+// code-review round 1's Major: nlohmann::json's `dump()` throws (type_error 316) on a string
+// holding a raw invalid UTF-8 byte sequence, and the malformed-shape branch calls `dump()` to
+// render the stamp into its notice text. That call used to run before ApplyUserDefaultsOverlay's
+// own try/catch, so — for a document whose stamp value carries that kind of poison — the
+// exception would escape uncaught and abort loading the ENTIRE overlay, turning "an odd version
+// stamp" into a hard crash on GUI startup / New / Open, exactly what B3/AC5/AC6 rule out.
+//
+// This is NOT reachable through a file on disk: nlohmann::json::parse() validates UTF-8 strictly
+// by default and already rejects malformed byte sequences (including an unpaired UTF-16 surrogate
+// escape like `\ud800`) at parse time, and that rejection is caught by ReadOverlayJsonIfPresent's
+// existing try/catch — so a hand-edited file with such a stamp never reaches this code at all
+// (verified: json::parse(R"({"v":"\ud800"})") throws parse_error.101 in this build's nlohmann_json
+// version). The poison value can only appear via an in-memory nlohmann::json constructed directly
+// from a raw std::string, which bypasses parse()'s validation — dump() re-validates independently
+// and is where it actually throws. Exercised here by calling ApplyUserDefaultsOverlay directly
+// with such a document, skipping the disk round trip that would otherwise mask the scenario.
+//
+// The poisoned value is reported, not stripped, so it survives into BuildMergedOverlayDocument's
+// own merge_patch/dump() further down — the pre-existing try/catch there (not new in this fix)
+// catches that second throw and discards the whole overlay, same as any other field-level type
+// error. So the outcome here is coarser than an ordinary malformed stamp (which never poisons
+// that later dump()): two notices instead of one, and bg_alpha falls back to the factory value
+// instead of surviving. What this test actually pins is narrower and is exactly what the review
+// asked for — no uncaught exception, i.e. loading never aborts outright.
+TEST_F(UserDefaults, schema_version_unprintable_stamp_does_not_throw) {
+  ResetUserDefaultsChannels();
+  json doc;
+  doc["defaults_schema_version"] = std::string("\xC0\x80");  // invalid UTF-8 (overlong encoding)
+  doc["bg_alpha"] = 0.42f;
+
+  gui::GuiState state{};
+  EXPECT_NO_THROW(gui::ApplyUserDefaultsOverlay(state, doc));
+  EXPECT_GE(gui::TakeUserDefaultsDowngradeCount(), 1)
+      << "a stamp nobody can read must still be reported, not silently swallowed";
+  EXPECT_EQ(state.bg_alpha, gui::GuiState{}.bg_alpha)
+      << "the poisoned value survives into the later merge/dump step and takes the whole overlay "
+         "down with it (pre-existing fallback: factory defaults) — this test only pins that "
+         "nothing throws uncaught, see the comment above";
 }
 
 // AC7 — the stamp must not answer "does this user have personal defaults?".


### PR DESCRIPTION
## 背景

个人默认值文件 `user_defaults.json` 至今没有任何版本标识。它的路径不含版本号（`%APPDATA%\Lumice\` / `~/Library/Application Support/Lumice/` / `$XDG_CONFIG_HOME/lumice/`），所以从 release 页下载的**所有版本共用同一份文件**——这是设计意图（升级不必重调设置），但也意味着将来某个键的**语义**变化时，没有任何判别位能区分"这份文件是哪一代写的"。

值得先说清楚的是，绝大多数跨版本不兼容形态**本来就已经被覆盖**：overlay 是稀疏 diff，缺键取出厂值、未知键静默忽略，所以"新版加键/删键/改名"这三类的判别器就是键本身。版本号唯一不可替代的是**键名与值都不变、含义变了**那一格——判别信息不在数据里，只能预先记下来。

所以本 PR 不是防御闸，是一次**成本接近零、不引入任何失败路径的 provenance 记录**：只写不读、不拒绝任何东西。

## 改了什么

- **新增独立键 `defaults_schema_version`**，不复用 `.lmc` payload 的 `schema_version`。两个键空间重合但不相等（`presets.*` 是 overlay 独有，`layers` 是 `.lmc` 独有且被 overlay 整个排除），共用一个计数器会让"为 `presets.*` 改动 bump 一次"连带使老版本拒绝其实没问题的 `.lmc`。两个常量旁各写一份耦合注释，双向可见。
- **写入侧单点盖章**：`WriteUserDefaultsFile` 是唯一写入 owner（既有的 `check_policies.py` `user-defaults-single-write-path` 规则守着），所有写入方无差别获得，无需知道它存在。
- **读取侧只分类、不设闸**：缺失（所有存量文件）静默通过、不计降级；形态非法降级为缺失并记 notice；高于当前构建记 notice 但**其余键照常全部生效**。任何情况下都不因版本号拒绝加载整份 overlay——这是刻意与 `.lmc` 相反的策略：`.lmc` 是整份文档，读不全就不该假装能忠实显示；overlay 是一袋各自独立、每个都已有出厂值回退的提示，因为一个键来自未来就拒掉整袋，比今天的行为更差。
- **修一个既有地雷**：`ApplyUserDefaultsOverlay` 用 `merge_patch` 把 overlay 铺到工厂文档上，而工厂文档带 `schema_version`。一份手工写了该键的 overlay 会覆盖读取方自己的版本号（写 `null` 则直接删键）。现在 merge 后无条件回写当前值，一次赋值两路都修。今天无害（反序列化器不读它），但正是"有了版本号之后"第一个会咬人的东西。

## 明确不做

不写迁移机制、不写版本键控分支、不加门禁、不动 `.lmc` 的 `kLmcVersion` 及其硬闸。现在没有东西要迁移，为尚未发生的需求猜形状是纯负债。

## 测试

按仓库判据分层：单个单元的纯逻辑进 `gui_unit_test`（`test/unit-correctness/gui/`），写→读往返进 `composition_correctness_test`，**未进 `gui_test`**（无渲染帧、无 `ImGuiTestContext`）。

其中一条不变量**黑盒不可观测**——`DeserializeGuiStateJson` 根本不读 `schema_version`，删掉保护后黑盒测试照样绿。为此 `BuildMergedOverlayDocument` 单独暴露到 `detail::` 命名空间，让测试能检查合并后的文档本体；这是该函数存在的唯一理由，注释里写明了。

## Review

两轮。round 1 抓到一条真 Major：拼 notice 文案的 `dump()` 对含未配对 UTF-16 代理项的字符串抛 `type_error(316)`，而 `json::parse()` 对 `\uD800` 这类孤立代理转义并不拒绝——于是一份手工构造的 overlay 会在进 `try` 块之前抛出未捕获异常，直接终止 GUI 启动 / New / Open。这恰好是本 PR 明令排除的那类退化（版本戳把整个应用打崩，比它替代的行为更差）。已修并补红态用例。round 2 APPROVE。

末尾另有一个 commit 修 round 2 的 Minor：版本偏高分支的文案无条件宣称"有设置因不认识而被忽略"，但触发条件只是"文件由更新的构建写成"，并不蕴含真有不认识的键——常见情形是一个都没有。同文件 `DescribeAxisPresetClamp` 上方已有同款 COPY CONSTRAINT（不得断言用户无法核实且可能为假的事），此处补同款注释。

🤖 Generated with [Claude Code](https://claude.com/claude-code)