### PR TITLE
fix(gui): 修 kLensTypeJsonNames 越界读（用户可达崩溃）

### DIFF
--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -68,7 +68,17 @@ static float MillerToAlpha(int i1, int i4) {
   return std::atan(kSqrt3_2 * i4 / i1 / kIceCrystalC) * kRadToDeg;
 }
 
-// Lens type JSON names (shared by Core config and GuiState JSON)
+// Lens type JSON names (shared by Core config and GuiState JSON), indexed by the GUI
+// RenderConfig::lens_type value and mirroring core's own wire vocabulary verbatim (see
+// config/render_config.hpp's NLOHMANN_JSON_SERIALIZE_ENUM for LensParam::LensType) — one word means
+// one lens on both sides of the boundary, so a document this file writes is a document the CLI
+// reads.
+//
+// The static_assert is the load-bearing part, not decoration: this table is indexed by an enum
+// value whose range is kLensTypeCount, so a table shorter than that count is an out-of-bounds read
+// on the writer's hottest path (every .lmc save, every Settings panel open, every personal-defaults
+// save), not a missing feature. It once was, and the three lens types added last reached the combo
+// without reaching this array.
 static const char* kLensTypeJsonNames[] = { "linear",
                                             "fisheye_equal_area",
                                             "fisheye_equidistant",
@@ -76,7 +86,12 @@ static const char* kLensTypeJsonNames[] = { "linear",
                                             "dual_fisheye_equal_area",
                                             "dual_fisheye_equidistant",
                                             "dual_fisheye_stereographic",
-                                            "rectangular" };
+                                            "rectangular",
+                                            "fisheye_orthographic",
+                                            "dual_fisheye_orthographic",
+                                            "globe" };
+static_assert(sizeof(kLensTypeJsonNames) / sizeof(kLensTypeJsonNames[0]) == kLensTypeCount,
+              "kLensTypeJsonNames must match kLensTypeCount");
 
 static const char* kVisibleJsonNames[] = { "upper", "lower", "full" };
 static_assert(sizeof(kVisibleJsonNames) / sizeof(kVisibleJsonNames[0]) == kVisibleCount,
@@ -86,6 +101,8 @@ static_assert(sizeof(kVisibleJsonNames) / sizeof(kVisibleJsonNames[0]) == kVisib
 // rather than the raw int on BOTH the .lmc and the CLI-JSON path, so one word means one thing
 // everywhere and a reader never has to ask which integer this file's 1 was.
 static const char* kEvModeJsonNames[] = { "relative", "absolute" };
+static_assert(sizeof(kEvModeJsonNames) / sizeof(kEvModeJsonNames[0]) == kEvModeCount,
+              "kEvModeJsonNames must match kEvModeCount");
 static const char* kAspectPresetJsonNames[] = { "free", "16:9", "3:2", "4:3", "1:1", "2:1", "match_background" };
 static_assert(sizeof(kAspectPresetJsonNames) / sizeof(kAspectPresetJsonNames[0]) == kAspectPresetCount,
               "kAspectPresetJsonNames must match kAspectPresetCount");
@@ -897,11 +914,25 @@ static void ParseCrystalIntoMap(const json& jc, std::map<int, CrystalConfig>& cr
   }
 }
 
+// kLensTypeCount is the loop bound rather than sizeof(kLensTypeJsonNames)/sizeof(...) on purpose:
+// the static_assert beside that table makes the two the same number at compile time, and spelling
+// the external count keeps this reader in the shape its two sibling tables already use
+// (kVisibleJsonNames / kAspectPresetJsonNames). The count was never the defect — the table was
+// short, and a self-referential bound would have hidden that by silently walking eight entries
+// while the writer walked eleven.
+//
+// Unknown text falls back to linear, which is also the missing-key answer, and says so out loud.
+// The notice is the point: a document written by a build where the short table read out of bounds
+// carries whatever bytes happened to sit past the array, and that string is unpredictable by
+// construction, so no key-driven migration can recognise it. What CAN be done is refuse to lose the
+// setting silently — the fallback stays, the silence does not.
 static int LensTypeFromString(const std::string& s) {
   for (int i = 0; i < kLensTypeCount; i++) {
     if (s == kLensTypeJsonNames[i])
       return i;
   }
+  GUI_LOG_WARNING("[FileIO] Unrecognized renderer.lens_type \"{}\"; loading as linear.", s);
+  SetImportComplexFilterWarning("renderer.lens_type states an unrecognized value \"" + s + "\"; loaded as linear.");
   return 0;  // default: linear
 }
 

--- a/test/composition-correctness/gui/test_document_roundtrip_chain.cpp
+++ b/test/composition-correctness/gui/test_document_roundtrip_chain.cpp
@@ -979,4 +979,56 @@ TEST(DocumentRoundtripChain, EvModeIsSpelledOnDiskTheWayCoreSpellsIt) {
   }
 }
 
+// Every lens type must be spelled on disk the way core spells it, and read back to the same value.
+//
+// All eleven, not just the three that were once missing from the writer's name table: the table is
+// indexed by the enum value, so a wrong entry anywhere shifts a lens onto a neighbour's name, and a
+// case that only probed the newest entries would read that as green. The spellings are asserted as
+// literals rather than read out of the writer's own constant — a case that reads the table it is
+// checking cannot see the table being wrong, only being inconsistent with itself. They are core's
+// wire vocabulary (config/render_config.hpp's NLOHMANN_JSON_SERIALIZE_ENUM for LensParam::LensType),
+// which is the same word list the CLI writes and reads, so the two layers cannot drift apart.
+TEST(DocumentRoundtripChain, LensTypeIsSpelledOnDiskTheWayCoreSpellsIt) {
+  struct Row {
+    int value;
+    const char* spelling;
+  };
+  constexpr Row kRows[] = {
+    Row{ 0, "linear" },
+    Row{ 1, "fisheye_equal_area" },
+    Row{ 2, "fisheye_equidistant" },
+    Row{ 3, "fisheye_stereographic" },
+    Row{ 4, "dual_fisheye_equal_area" },
+    Row{ 5, "dual_fisheye_equidistant" },
+    Row{ 6, "dual_fisheye_stereographic" },
+    Row{ 7, "rectangular" },
+    Row{ 8, "fisheye_orthographic" },
+    Row{ 9, "dual_fisheye_orthographic" },
+    Row{ 10, "globe" },
+  };
+  static_assert(sizeof(kRows) / sizeof(kRows[0]) == kLensTypeCount,
+                "this case must probe every lens type, not a prefix of them");
+
+  for (const Row& row : kRows) {
+    GuiState doc = MinimalDocument();
+    doc.renderer.lens_type = row.value;
+    const auto written = nlohmann::json::parse(SerializeGuiStateJson(doc));
+    EXPECT_EQ(written["renderer"]["lens_type"].get<std::string>(), row.spelling) << "value: " << row.value;
+
+    auto on_disk = nlohmann::json::parse(SerializeGuiStateJson(MinimalDocument()));
+    on_disk["renderer"]["lens_type"] = row.spelling;
+    GuiState read_back = MinimalDocument();
+    // Seed something this row cannot legitimately produce, so a reader that ignores the key is
+    // visible on every row instead of only on the rows whose value is not the default.
+    read_back.renderer.lens_type = (row.value + 1) % kLensTypeCount;
+    if (!DeserializeGuiStateJson(on_disk.dump(), read_back)) {
+      // Non-fatal per row: one unreadable spelling must not take the other ten rows' reports with
+      // it — which spellings fail is the whole diagnostic here.
+      ADD_FAILURE() << row.spelling << ": the reader rejected a document carrying this spelling";
+      continue;
+    }
+    EXPECT_EQ(read_back.renderer.lens_type, row.value) << row.spelling;
+  }
+}
+
 }  // namespace lumice::gui

--- a/test/composition-correctness/gui/test_document_roundtrip_chain.cpp
+++ b/test/composition-correctness/gui/test_document_roundtrip_chain.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 
+#include "gui/app.hpp"
 #include "gui/file_io.hpp"
 #include "gui/gui_state.hpp"
 #include "gui/raypath_segments.hpp"
@@ -1029,6 +1030,37 @@ TEST(DocumentRoundtripChain, LensTypeIsSpelledOnDiskTheWayCoreSpellsIt) {
     }
     EXPECT_EQ(read_back.renderer.lens_type, row.value) << row.spelling;
   }
+
+  // A lens_type this build cannot recognise still loads — as linear, and loudly. A document written
+  // by a build whose name table was short carries whatever bytes sat past the array, so the string
+  // itself is unpredictable and no migration can key off it; what the reader owes the user is a
+  // visible degradation rather than a silent one. Missing key keeps the old contract: same
+  // destination, no notice, because nothing was lost.
+  for (const char* variant : { "", "not_a_real_lens" }) {
+    auto on_disk = nlohmann::json::parse(SerializeGuiStateJson(MinimalDocument()));
+    if (variant[0] == '\0') {
+      on_disk["renderer"].erase("lens_type");
+    } else {
+      on_disk["renderer"]["lens_type"] = variant;
+    }
+    GuiState read_back = MinimalDocument();
+    read_back.renderer.lens_type = kLensTypeGlobe;  // seed non-default so a no-op read is visible
+    ClearImportComplexFilterWarning();
+    const char* label = variant[0] == '\0' ? "<absent>" : variant;
+    if (!DeserializeGuiStateJson(on_disk.dump(), read_back)) {
+      ADD_FAILURE() << label << ": an unrecognised lens_type must load, not fail the whole document";
+      continue;
+    }
+    EXPECT_EQ(read_back.renderer.lens_type, 0) << "variant: " << label;
+    const std::string notice = PeekImportComplexFilterWarning();
+    if (variant[0] == '\0') {
+      EXPECT_EQ(notice, "") << "an absent key lost nothing and must not warn";
+    } else {
+      EXPECT_NE(notice.find(variant), std::string::npos)
+          << "the notice must name the value it could not read, got: " << notice;
+    }
+  }
+  ClearImportComplexFilterWarning();
 }
 
 }  // namespace lumice::gui

--- a/test/composition-correctness/gui/test_user_defaults_chain.cpp
+++ b/test/composition-correctness/gui/test_user_defaults_chain.cpp
@@ -361,5 +361,42 @@ TEST_F(UserDefaultsChain, RevertingEveryDefaultLeavesOnlyTheStampAndStillReadsAs
       << "the panel still shows the reverted key as saved, so the user can never clear it";
 }
 
+// AC5 path 3 — saving a personal default goes through the same serializer the other two paths do,
+// so every lens type has to reach disk under its own name and come back as itself.
+//
+// The round trip is the assertion, not the write: a lens type that lands on a neighbour's spelling
+// writes a perfectly well-formed file and reads back as a DIFFERENT lens, which is the silent half
+// of this defect — the loud half (the writer walking off the end of its name table) only shows up
+// on builds where that read happens to fault.
+TEST_F(UserDefaultsChain, EveryLensTypeSurvivesTheUserDefaultsRoundTrip) {
+  constexpr const char* kLensKey = "renderer.lens_type";
+
+  for (int value = 0; value < kLensTypeCount; ++value) {
+    const std::filesystem::path& dir = UseFreshConfigDir(("lens_type_" + std::to_string(value)).c_str());
+
+    GuiState current;
+    current.renderer.lens_type = value;
+
+    nlohmann::json doc = ReadActiveOverlayDoc();
+    const std::vector<DefaultDiffRow> rows = BuildDefaultDiffRows(current, doc);
+    // Non-fatal per value: a failure on one lens type must not take the other ten readings with it,
+    // and "which values fail" is the diagnostic that separates a short table from a wrong entry.
+    if (FindRow(rows, kLensKey) == nullptr) {
+      ADD_FAILURE() << "value " << value << ": the panel produced no " << kLensKey << " row to adopt";
+      continue;
+    }
+    if (!ApplyCheckedRowsToDoc(doc, rows, { kLensKey }, current) || !WriteActiveOverlayDoc(doc)) {
+      ADD_FAILURE() << "value " << value << ": adopting the lens type never reached disk";
+      continue;
+    }
+
+    ResetUserDefaultsChannels();
+    const GuiState after = MakeNewDocumentState(dir);
+    EXPECT_EQ(after.renderer.lens_type, value)
+        << "a new document started from a personal default that is not the one adopted";
+    EXPECT_EQ(TakeUserDefaultsDowngradeCount(), 0) << "value " << value << ": nothing about this value is wrong";
+  }
+}
+
 }  // namespace
 }  // namespace lumice::gui

--- a/test/composition-correctness/gui/test_user_defaults_chain.cpp
+++ b/test/composition-correctness/gui/test_user_defaults_chain.cpp
@@ -370,6 +370,27 @@ TEST_F(UserDefaultsChain, RevertingEveryDefaultLeavesOnlyTheStampAndStillReadsAs
 // on builds where that read happens to fault.
 TEST_F(UserDefaultsChain, EveryLensTypeSurvivesTheUserDefaultsRoundTrip) {
   constexpr const char* kLensKey = "renderer.lens_type";
+  // Core's wire vocabulary, as literals. The round trip alone would NOT catch a wrong entry in the
+  // writer's table: write and read walk the same table, so a misspelled name is written, read back,
+  // and lands on its own index again — perfectly self-consistent and perfectly wrong for anyone
+  // else reading the file. Measured, not assumed: with entry 8 deliberately misspelled, the round
+  // trip half of this case stayed green while the two literal-spelling cases went red. The
+  // on-disk assertion below is what makes this path see it.
+  constexpr const char* kSpellings[] = {
+    "linear",
+    "fisheye_equal_area",
+    "fisheye_equidistant",
+    "fisheye_stereographic",
+    "dual_fisheye_equal_area",
+    "dual_fisheye_equidistant",
+    "dual_fisheye_stereographic",
+    "rectangular",
+    "fisheye_orthographic",
+    "dual_fisheye_orthographic",
+    "globe",
+  };
+  static_assert(sizeof(kSpellings) / sizeof(kSpellings[0]) == kLensTypeCount,
+                "this case must probe every lens type, not a prefix of them");
 
   for (int value = 0; value < kLensTypeCount; ++value) {
     const std::filesystem::path& dir = UseFreshConfigDir(("lens_type_" + std::to_string(value)).c_str());
@@ -389,6 +410,14 @@ TEST_F(UserDefaultsChain, EveryLensTypeSurvivesTheUserDefaultsRoundTrip) {
       ADD_FAILURE() << "value " << value << ": adopting the lens type never reached disk";
       continue;
     }
+
+    std::ifstream in(dir / kUserDefaultsFileName);
+    if (!in.is_open()) {
+      ADD_FAILURE() << "value " << value << ": no personal-defaults file was written";
+      continue;
+    }
+    const nlohmann::json on_disk = nlohmann::json::parse(in);
+    EXPECT_EQ(on_disk["renderer"]["lens_type"].get<std::string>(), kSpellings[value]) << "value " << value;
 
     ResetUserDefaultsChannels();
     const GuiState after = MakeNewDocumentState(dir);

--- a/test/unit-correctness/gui/test_defaults_diff.cpp
+++ b/test/unit-correctness/gui/test_defaults_diff.cpp
@@ -283,6 +283,53 @@ TEST_F(DefaultsDiff, ac4_array_edit_produces_exactly_one_row) {
 //     for its "differs from factory" filter: that comparison would report "same as factory" for
 //     the one row the user definitely customised
 // ================================================================================
+// Opening the Settings panel serializes the CURRENT state, so every lens type the combo can reach
+// has to survive that walk — including the three highest enum values, which for a time indexed past
+// the end of the writer's name table and took the process down before any row was built.
+//
+// All eleven are probed rather than only those three: the table is indexed by the enum value, so a
+// wrong entry anywhere lands a lens on its neighbour's name, and this path reports that as a
+// perfectly healthy row.
+TEST_F(DefaultsDiff, ac5_every_lens_type_survives_the_settings_panel_diff_walk) {
+  FreshUserConfig("diff_lens_types");
+
+  struct Row {
+    int value;
+    const char* spelling;
+  };
+  constexpr Row kRows[] = {
+    Row{ gui::kLensTypeLinear, "linear" },
+    Row{ gui::kLensTypeFisheyeEqualArea, "fisheye_equal_area" },
+    Row{ gui::kLensTypeFisheyeEquidist, "fisheye_equidistant" },
+    Row{ gui::kLensTypeFisheyeStereographic, "fisheye_stereographic" },
+    Row{ gui::kLensTypeDualFisheyeEqualArea, "dual_fisheye_equal_area" },
+    Row{ gui::kLensTypeDualFisheyeEquidist, "dual_fisheye_equidistant" },
+    Row{ gui::kLensTypeDualFisheyeStereographic, "dual_fisheye_stereographic" },
+    Row{ gui::kLensTypeRectangular, "rectangular" },
+    Row{ gui::kLensTypeFisheyeOrthographic, "fisheye_orthographic" },
+    Row{ gui::kLensTypeDualFisheyeOrthographic, "dual_fisheye_orthographic" },
+    Row{ gui::kLensTypeGlobe, "globe" },
+  };
+  static_assert(sizeof(kRows) / sizeof(kRows[0]) == gui::kLensTypeCount,
+                "this case must probe every lens type, not a prefix of them");
+
+  for (const Row& row : kRows) {
+    gui::GuiState state = gui::InitDefaultState();
+    state.renderer.lens_type = row.value;
+
+    const auto rows = gui::BuildDefaultDiffRows(state);
+    const gui::DefaultDiffRow* lens = FindRow(rows, "renderer.lens_type");
+    // Non-fatal per row: a missing row on one lens type must not hide the other ten readings, which
+    // together are what says whether the table is short or merely wrong somewhere.
+    if (lens == nullptr) {
+      ADD_FAILURE() << row.spelling << ": the diff walk produced no renderer.lens_type row";
+      continue;
+    }
+    EXPECT_EQ(lens->current_value.get<std::string>(), row.spelling) << "value: " << row.value;
+    EXPECT_EQ(lens->factory_value.get<std::string>(), "linear") << "value: " << row.value;
+  }
+}
+
 TEST_F(DefaultsDiff, ac5_effective_default_layers_the_saved_override_over_an_unmoving_factory_value) {
   const auto& dir = FreshUserConfig("diff_ac5");
 


### PR DESCRIPTION
## 问题

`src/gui/file_io.cpp` 的 `kLensTypeJsonNames[]` 只有 8 个元素，而 `kLensTypeCount == 11`，且该数组**缺 `static_assert`**（同文件相邻的 `kVisibleJsonNames` / `kAspectPresetJsonNames` 都有）。

**这是一个用户可达的崩溃，不是潜伏的越界读**：实测对全 11 个 lens 值走 `SerializeGuiStateJson` → `DeserializeGuiStateJson` 往返，idx 0–7 正常，**idx 8（Fisheye Orthographic）SIGSEGV**。三条触发路径全部用户可达——保存 `.lmc` / 打开 Settings 面板 / 保存用户默认值——前置条件只有「在 Lens Type 下拉里选中后三种镜头之一」，而 combo 列全 11 项。

因为是 UB，别的构建上的表现可能不是崩溃，而是**读到邻接字符串并写进文件**，再经 `LensTypeFromString` 回落 `0` ⇒ **静默丢掉用户的镜头设置**。修复覆盖了两种表现。

## 改动

- `kLensTypeJsonNames[]` 补齐 `fisheye_orthographic` / `dual_fisheye_orthographic` / `globe`，拼写与 core 的 `NLOHMANN_JSON_SERIALIZE_ENUM(LensParam::LensType, ...)` 逐字一致（跨层同一套 wire 词汇）
- 补 `static_assert`，形态照抄同文件相邻两个数组
- `LensTypeFromString` 未匹配拼写时回落 `linear` 并发一条 **可见 notice**（把静默降级变成可见降级）；存量文档里可能已被写入的垃圾串内容不可预测，无法写出可识别的迁移规则，故不做键控迁移
- 三条触发路径各补一条机械断言，均用**字面量拼写表**而非读被测方自己的常量表

## 验证

- AC0 红态先行：全 11 值往返断言在改动前跑红（idx 8 崩溃），改动后转绿
- 实施中经错拼负向对照发现路径③ 原写法「写读同表」自洽但检出力为零，已改为盘上字面量断言
- `./scripts/test.sh quick` RESULT: PASS；四道工程闸 + `format.sh --check` 全绿
- code review APPROVE（0 Critical / 0 Major）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hzhUWaC4pkG3xyUzEQ3qG