### PR TITLE
feat(core): 单镜头鱼眼定义域按 lens 放宽到 θ≤180，与 GUI 对齐

### DIFF
--- a/src/core/lens_proj_build.hpp
+++ b/src/core/lens_proj_build.hpp
@@ -183,12 +183,14 @@ inline MaskDir CameraDirToWorld(const Rotation& rot, const projection::Dir3& c) 
 // after projecting (screen handedness: right = +az), so the projected coordinates that produced
 // the pixel are (-u, v) and the inverse consumes them in that order.
 //
-// The fisheye inverses reject r > 1, and r = 1 is the EQUATOR for r_scale = 1 — the same
-// theta <= 90 deg region the forward's `cz <= 0` cull leaves renderable. That makes this test
-// exactly "could a ray have landed here", which is what the mask is for. Note it is NOT the
-// same region the GUI shader's `fisheyeInverse` accepts: its guard is the asin domain
-// (theta <= 180 deg), a radius sqrt(2)x larger for equal-area. See
-// test_visible_mask_gui_parity.cpp, which pins that difference rather than papering over it.
+// Each fisheye inverse rejects beyond its own rim radius, and that rim is the same theta the
+// forward's per-type cull stops at (projection.cpp's kFisheyeStereographicMaxR and the
+// kFisheyeAntipodeMinCz / kFisheyeStereographicMinCz notes in projection_shared.h). That makes
+// this test exactly "could a ray have landed here", which is what the mask is for. It is also the
+// same region the GUI shader's `fisheyeInverse` accepts — equal-area and equidistant now run to
+// theta = 180 deg on both sides, orthographic stops at the equator on both sides, and
+// stereographic's core-only numerical cap sits far off any real frame. test_visible_mask_gui_parity.cpp
+// asserts that agreement pixel by pixel; before 474.1 it pinned a divergence there instead.
 inline MaskDir SingleLensPixelToWorld(LensParam::LensType type, const Rotation& rot, float u, float v) {
   projection::Dir3 c{ 0, 0, 0, false };
   switch (type) {

--- a/src/core/lens_proj_build.hpp
+++ b/src/core/lens_proj_build.hpp
@@ -185,7 +185,7 @@ inline MaskDir CameraDirToWorld(const Rotation& rot, const projection::Dir3& c) 
 //
 // Each fisheye inverse rejects beyond its own rim radius, and that rim is the same theta the
 // forward's per-type cull stops at (projection.cpp's kFisheyeStereographicMaxR and the
-// kFisheyeAntipodeMinCz / kFisheyeStereographicMinCz notes in projection_shared.h). That makes
+// the three kFisheye*MinCz notes in projection_shared.h). That makes
 // this test exactly "could a ray have landed here", which is what the mask is for. It is also the
 // same region the GUI shader's `fisheyeInverse` accepts — equal-area and equidistant now run to
 // theta = 180 deg on both sides, orthographic stops at the equator on both sides, and

--- a/src/core/projection.cpp
+++ b/src/core/projection.cpp
@@ -58,13 +58,32 @@ ProjXY FisheyeOrthographicForward(float dx, float dy, float dz, float r_scale) {
 
 
 // =============== Fisheye inverse projections (pure math) ===============
-// Domain check: r > 1 in the r_scale-normalized space = beyond coverage boundary.
+// Domain check: r beyond the type's coverage boundary is rejected. The boundary is that type's
+// radius at the largest theta the RENDER path will produce, so "the inverse accepts this pixel"
+// and "a ray could have landed on this pixel" stay the same statement — which is what makes
+// lens_proj_build.hpp's render-domain mask exact rather than approximate. See the per-type cull
+// in projection_shared.h::ProjectExitToPixel and its kFisheyeAntipodeMinCz /
+// kFisheyeStereographicMinCz notes; the values below are the mirror image of those two floors.
+//
+// The dual-fisheye path shares these same functions and is NOT affected by the wider bounds:
+// lens_proj_build.hpp::DualFisheyePixelToWorld feeds them coordinates PixelToDualFisheye has
+// already clipped to r <= 1, so it never reaches the region that opened up.
+//
 // When r_scale < 1, inverse may return z < 0 (past-equator direction) — this is correct.
+
+// Largest r each type's inverse accepts at r_scale = 1, i.e. that type's radius at its rim:
+//   equal-area     sqrt(2) sin(theta/2)  at theta = 180 deg -> sqrt(2)   (r^2 <= 2)
+//   equidistant    theta / (pi/2)        at theta = 180 deg -> 2
+//   stereographic  tan(theta/2)          at acos(kFisheyeStereographicMinCz) = 179.5 deg
+// Derived from the shared cull floor rather than restating 179.5 deg, so a change to that floor
+// moves both sides at once. Orthographic keeps r <= r_scale (theta <= 90 deg) — it is the one
+// type whose forward is not injective past the equator.
+const float kFisheyeStereographicMaxR = std::tan(0.5f * std::acos(lm_proj::kFisheyeStereographicMinCz));
 
 // Equal-area inverse: direct Cartesian formula (1 sqrt, no trig).
 Dir3 FisheyeEqualAreaInverse(float x, float y, float r_scale) {
   float r2 = x * x + y * y;
-  if (r2 > 1.0f) {
+  if (r2 > 2.0f) {
     return { 0, 0, 0, false };
   }
   float inv_s = 1.0f / r_scale;
@@ -78,7 +97,7 @@ Dir3 FisheyeEqualAreaInverse(float x, float y, float r_scale) {
 // Equidistant inverse: theta = r / r_scale * pi/2.
 Dir3 FisheyeEquidistantInverse(float x, float y, float r_scale) {
   float r = std::sqrt(x * x + y * y);
-  if (r > 1.0f) {
+  if (r > 2.0f) {
     return { 0, 0, 0, false };
   }
   if (r < 1e-10f) {
@@ -94,7 +113,7 @@ Dir3 FisheyeEquidistantInverse(float x, float y, float r_scale) {
 // Stereographic inverse: theta = 2 * atan(r / r_scale).
 Dir3 FisheyeStereographicInverse(float x, float y, float r_scale) {
   float r = std::sqrt(x * x + y * y);
-  if (r > 1.0f) {
+  if (r > kFisheyeStereographicMaxR) {
     return { 0, 0, 0, false };
   }
   if (r < 1e-10f) {

--- a/src/core/projection.cpp
+++ b/src/core/projection.cpp
@@ -62,8 +62,8 @@ ProjXY FisheyeOrthographicForward(float dx, float dy, float dz, float r_scale) {
 // radius at the largest theta the RENDER path will produce, so "the inverse accepts this pixel"
 // and "a ray could have landed on this pixel" stay the same statement — which is what makes
 // lens_proj_build.hpp's render-domain mask exact rather than approximate. See the per-type cull
-// in projection_shared.h::ProjectExitToPixel and its kFisheyeAntipodeMinCz /
-// kFisheyeStereographicMinCz notes; the values below are the mirror image of those two floors.
+// in projection_shared.h::ProjectExitToPixel and its three kFisheye*MinCz notes; the values below
+// are the mirror image of those floors.
 //
 // The dual-fisheye path shares these same functions and is NOT affected by the wider bounds:
 // lens_proj_build.hpp::DualFisheyePixelToWorld feeds them coordinates PixelToDualFisheye has
@@ -72,18 +72,31 @@ ProjXY FisheyeOrthographicForward(float dx, float dy, float dz, float r_scale) {
 // When r_scale < 1, inverse may return z < 0 (past-equator direction) — this is correct.
 
 // Largest r each type's inverse accepts at r_scale = 1, i.e. that type's radius at its rim:
-//   equal-area     sqrt(2) sin(theta/2)  at theta = 180 deg -> sqrt(2)   (r^2 <= 2)
+//   equal-area     sqrt(2) sin(theta/2)  at theta = 180 deg -> sqrt(2)   (compared as r^2 <= 2)
 //   equidistant    theta / (pi/2)        at theta = 180 deg -> 2
 //   stereographic  tan(theta/2)          at acos(kFisheyeStereographicMinCz) = 179.5 deg
-// Derived from the shared cull floor rather than restating 179.5 deg, so a change to that floor
-// moves both sides at once. Orthographic keeps r <= r_scale (theta <= 90 deg) — it is the one
-// type whose forward is not injective past the equator.
-const float kFisheyeStereographicMaxR = std::tan(0.5f * std::acos(lm_proj::kFisheyeStereographicMinCz));
+// The stereographic bound is derived from the shared cull floor rather than restating 179.5 deg,
+// so a change to that floor moves both sides at once. Orthographic keeps r <= r_scale
+// (theta <= 90 deg) — it is the one type whose forward is not injective past the equator.
+//
+// kRimSlack is the allowance for the fact that a rim is not a crisp number in float. The forward's
+// radius is a function of cz, cz reaches it with a few ulps of error, and the largest radius the
+// render path can ACTUALLY produce therefore sits a little above the analytic rim. Without the
+// slack the inverse rejects a pixel a ray has just landed on, and the render-domain mask built
+// from this inverse (lens_proj_build.hpp) paints background over it — a defect that only appears
+// in the outermost ring, which is precisely the region 474.1 opened up. It can be this small only
+// because the cull floors bound that error rather than letting it grow; kFisheyeEqualAreaMinCz is
+// the one chosen for this reason specifically. 1e-5 of a rim is under a thousandth of a pixel at
+// any resolution these lenses render at.
+constexpr float kRimSlack = 1.0f + 1e-5f;
+constexpr float kFisheyeEqualAreaMaxR2 = 2.0f * kRimSlack * kRimSlack;
+constexpr float kFisheyeEquidistantMaxR = 2.0f * kRimSlack;
+const float kFisheyeStereographicMaxR = std::tan(0.5f * std::acos(lm_proj::kFisheyeStereographicMinCz)) * kRimSlack;
 
 // Equal-area inverse: direct Cartesian formula (1 sqrt, no trig).
 Dir3 FisheyeEqualAreaInverse(float x, float y, float r_scale) {
   float r2 = x * x + y * y;
-  if (r2 > 2.0f) {
+  if (r2 > kFisheyeEqualAreaMaxR2) {
     return { 0, 0, 0, false };
   }
   float inv_s = 1.0f / r_scale;
@@ -97,7 +110,7 @@ Dir3 FisheyeEqualAreaInverse(float x, float y, float r_scale) {
 // Equidistant inverse: theta = r / r_scale * pi/2.
 Dir3 FisheyeEquidistantInverse(float x, float y, float r_scale) {
   float r = std::sqrt(x * x + y * y);
-  if (r > 2.0f) {
+  if (r > kFisheyeEquidistantMaxR) {
     return { 0, 0, 0, false };
   }
   if (r < 1e-10f) {
@@ -130,7 +143,10 @@ Dir3 FisheyeStereographicInverse(float x, float y, float r_scale) {
 // and dz = cos(theta) = sqrt(1 - (r/r_scale)^2).
 Dir3 FisheyeOrthographicInverse(float x, float y, float r_scale) {
   float r2 = x * x + y * y;
-  float rs2 = r_scale * r_scale;
+  // kRimSlack applies here too, and for the same reason, even though this type's rim did not move
+  // in 474.1: r = sin(theta) reaches r_scale at the equator, which is exactly where its cull sits,
+  // so a ray culled at cz > 0 can still land a few ulps outside r_scale.
+  float rs2 = r_scale * r_scale * kRimSlack * kRimSlack;
   if (r2 > rs2) {
     return { 0, 0, 0, false };
   }

--- a/src/core/shared/projection_shared.h
+++ b/src/core/shared/projection_shared.h
@@ -63,7 +63,7 @@ LM_FN ProjXY FisheyeStereographicForward(float dx, float dy, float dz, float r_s
     // reachable here at the north pole only: the single-lens path culls at kFisheyeStereographicMinCz
     // (rho >= 8.7e-3 past it) and the dual-fisheye path feeds |dz| <= 1 from one hemisphere at a
     // time, so neither can arrive at the antipode. Left as-is deliberately — see the note on
-    // kFisheyeAntipodeMinCz for the type that does need the distinction.
+    // kFisheyeEquidistantMinCz for the type that does need the distinction.
     return { 0.0f, 0.0f, true };
   }
   float theta = LM_ACOS(LM_CLAMP(dz, -1.0f, 1.0f));
@@ -168,33 +168,44 @@ LM_CONSTANT float kGlobeCameraD = 4.0f;
 // visibility judgements — visibility is `p.visible_range`, and bounds culling belongs to the
 // caller. They are the points past which each type's forward formula stops describing the sky it
 // was handed. Before 474.1 the whole family shared one `cz <= 0` cull, i.e. core rendered only
-// theta <= 90 deg while the GUI preview re-projected out to 180 deg; these two constants are what
-// that cull became once it was taken per type.
+// theta <= 90 deg while the GUI preview re-projected out to 180 deg; these three constants are
+// what that one cull became once it was taken per type. (Orthographic is the fourth, and it keeps
+// `cz <= 0` — see its branch.)
 //
-// kFisheyeAntipodeMinCz — equal-area and equidistant stay finite and monotone all the way to
-//   theta = 180 deg, so their RADIUS needs no bound. Their AZIMUTH does: at the exact antipode of
-//   the camera axis rho = 0 and every azimuth is equally correct, so no single pixel is. In float
-//   that breakdown starts before the antipode itself — FisheyeEqualAreaForward clamps dz at
-//   -1 + 1e-6 to keep 1/sqrt(1+dz) finite, and inside that clamp the radius it returns decays
-//   toward 0 instead of converging to its rim value. -1 + 1e-6 is therefore exactly where the
-//   clamp stops being a no-op, and rejecting there states outright what the clamp was quietly
-//   getting wrong. It also keeps this path clear of FisheyeEquidistantForward's own `rho < 1e-10`
-//   guard (rho >= 1.4e-3 at this floor), which is why that guard is left alone: it is shared with
-//   the dual-fisheye path, where the pole is a legitimate input and (0,0) is the right answer.
-//   The floor sits at theta = 179.919 deg. The inverse's rim (theta = 180 deg) is 4e-7 image radii
-//   further out for equal-area and 0.05 px further out for equidistant on a 120 px short edge, so
-//   the region core renders and the region lens_proj_build.hpp's mask accepts still coincide
-//   everywhere a pixel can tell them apart.
+// Each floor is set by ITS type's numerics, and they differ by three orders of magnitude for that
+// reason. What they have in common is the shape of the failure: every type recovers the azimuth by
+// dividing by rho = sin(theta), which collapses at the antipode of the lens axis, where every
+// azimuth is equally correct and no single pixel is.
 //
-// kFisheyeStereographicMinCz — r = tan(theta/2) diverges at theta = 180 deg, so this type needs a
-//   bound on the radius itself and not just on the azimuth. The value is cos(179.5 deg): the half
-//   angle of the 359 deg fov ceiling `render_config.cpp::MaxFov` already imposes on this lens, so
-//   the per-ray floor and the config-level ceiling describe one boundary rather than two. It puts
-//   the rim at r = tan(89.75 deg) = 229.18 image radii — past any frame at any usable resolution,
-//   which is why the GUI preview (whose stereographic inverse has no guard at all) and core still
-//   agree pixel for pixel. projection.cpp::FisheyeStereographicInverse derives its own r bound
-//   from THIS constant rather than restating the angle, so the two cannot drift.
-LM_CONSTANT float kFisheyeAntipodeMinCz = -1.0f + 1e-6f;
+// kFisheyeEqualAreaMinCz — r = rho / sqrt(1 + cz) equals sqrt(1 - cz) analytically, so the RADIUS
+//   is bounded (sqrt(2) at the antipode) and needs no cull of its own. Its accuracy is not: cz
+//   arrives with a few ulps of error and dividing by sqrt(1 + cz) amplifies that by 1/(2(1 + cz)),
+//   so the computed radius drifts ABOVE the analytic rim as the antipode is approached — past the
+//   point where projection.cpp's inverse still accepts it, which is exactly the state that makes
+//   the render-domain mask paint background over a lit pixel. The floor is where that stops: with
+//   1 + cz >= 1e-3 the relative error stays under 1e-4, while sqrt(2 - 1e-3) already sits 2.5e-4
+//   below sqrt(2), so the drift cannot reach the rim. It is also, not coincidentally, well clear of
+//   FisheyeEqualAreaForward's own dz clamp at -1 + 1e-6, inside which the returned radius decays
+//   toward 0 instead of converging to the rim. theta = 177.4 deg; the 2.5e-4 of rim radius given up
+//   is 0.02 px on a 60 px lens scale.
+//
+// kFisheyeEquidistantMinCz — r = acos(cz)/(pi/2) is well conditioned in the radius all the way in
+//   (acos absorbs the error into theta, where 4e-5 rad costs 3e-5 of a rim radius of 2), so this
+//   type can be culled two decades closer to the antipode than equal-area. -1 + 1e-6 is where
+//   FisheyeEquidistantForward's own `rho < 1e-10` guard becomes unreachable (rho >= 1.4e-3 here),
+//   which is why that guard is left alone: it is shared with the dual-fisheye path, where the pole
+//   is a legitimate input and (0,0) is the right answer. theta = 179.92 deg.
+//
+// kFisheyeStereographicMinCz — r = tan(theta/2) DIVERGES at the antipode, so this is the one type
+//   whose radius itself has to be bounded. The value is cos(179.5 deg): the half angle of the
+//   359 deg fov ceiling `render_config.cpp::MaxFov` already imposes on this lens, so the per-ray
+//   floor and the config-level ceiling describe one boundary rather than two. It puts the rim at
+//   r = tan(89.75 deg), about 229 image radii — past any frame at any usable resolution, which is
+//   why the GUI preview (whose stereographic inverse has no guard at all) and core still agree
+//   pixel for pixel. projection.cpp::FisheyeStereographicInverse derives its own r bound from THIS
+//   constant rather than restating the angle, so the two cannot drift.
+LM_CONSTANT float kFisheyeEqualAreaMinCz = -1.0f + 1e-3f;
+LM_CONSTANT float kFisheyeEquidistantMinCz = -1.0f + 1e-6f;
 LM_CONSTANT float kFisheyeStereographicMinCz = -0.99996192f;
 
 // Apply the transpose of a row-major 3x3 matrix (equivalent to Rotation::ApplyInverse
@@ -257,7 +268,7 @@ LM_FN ProjResult ProjectExitToPixel(LM_THREAD const ProjParams& p, float wx, flo
     } else if (t == kProjFisheyeOrthographic) {
       // The one member of the family that must keep a hemisphere cull: r = sin(theta) aliases past
       // the equator (sin 120 deg == sin 60 deg), so two distinct rays would land on one pixel.
-      // Structurally not widenable — see kFisheyeAntipodeMinCz above for the ones that were.
+      // Structurally not widenable — see the three MinCz constants above for the ones that were.
       if (cz <= 0.0f) {
         return r;
       }
@@ -267,15 +278,16 @@ LM_FN ProjResult ProjectExitToPixel(LM_THREAD const ProjParams& p, float wx, flo
         return r;
       }
       xy = FisheyeStereographicForward(cx, cy, cz, 1.0f);
-    } else {
-      if (cz < kFisheyeAntipodeMinCz) {
+    } else if (t == kProjFisheyeEqualArea) {
+      if (cz < kFisheyeEqualAreaMinCz) {
         return r;
       }
-      if (t == kProjFisheyeEqualArea) {
-        xy = FisheyeEqualAreaForward(cx, cy, cz, 1.0f);
-      } else {  // kProjFisheyeEquidistant
-        xy = FisheyeEquidistantForward(cx, cy, cz, 1.0f);
+      xy = FisheyeEqualAreaForward(cx, cy, cz, 1.0f);
+    } else {  // kProjFisheyeEquidistant
+      if (cz < kFisheyeEquidistantMinCz) {
+        return r;
       }
+      xy = FisheyeEquidistantForward(cx, cy, cz, 1.0f);
     }
     if (!xy.valid) {
       return r;

--- a/src/core/shared/projection_shared.h
+++ b/src/core/shared/projection_shared.h
@@ -59,6 +59,11 @@ LM_FN ProjXY FisheyeEquidistantForward(float dx, float dy, float dz, float r_sca
 LM_FN ProjXY FisheyeStereographicForward(float dx, float dy, float dz, float r_scale) {
   float rho = LM_SQRT(dx * dx + dy * dy);
   if (rho < 1e-10f) {
+    // rho -> 0 happens at BOTH poles, and (0,0) is the right answer at only one of them. It is
+    // reachable here at the north pole only: the single-lens path culls at kFisheyeStereographicMinCz
+    // (rho >= 8.7e-3 past it) and the dual-fisheye path feeds |dz| <= 1 from one hemisphere at a
+    // time, so neither can arrive at the antipode. Left as-is deliberately — see the note on
+    // kFisheyeAntipodeMinCz for the type that does need the distinction.
     return { 0.0f, 0.0f, true };
   }
   float theta = LM_ACOS(LM_CLAMP(dz, -1.0f, 1.0f));
@@ -159,6 +164,39 @@ LM_CONSTANT int kProjGlobe = 10;
 //   mask in lens_proj_build.hpp).
 LM_CONSTANT float kGlobeCameraD = 4.0f;
 
+// Per-type numerical floors on `cz` for the SINGLE-lens fisheye cull below. These are not
+// visibility judgements — visibility is `p.visible_range`, and bounds culling belongs to the
+// caller. They are the points past which each type's forward formula stops describing the sky it
+// was handed. Before 474.1 the whole family shared one `cz <= 0` cull, i.e. core rendered only
+// theta <= 90 deg while the GUI preview re-projected out to 180 deg; these two constants are what
+// that cull became once it was taken per type.
+//
+// kFisheyeAntipodeMinCz — equal-area and equidistant stay finite and monotone all the way to
+//   theta = 180 deg, so their RADIUS needs no bound. Their AZIMUTH does: at the exact antipode of
+//   the camera axis rho = 0 and every azimuth is equally correct, so no single pixel is. In float
+//   that breakdown starts before the antipode itself — FisheyeEqualAreaForward clamps dz at
+//   -1 + 1e-6 to keep 1/sqrt(1+dz) finite, and inside that clamp the radius it returns decays
+//   toward 0 instead of converging to its rim value. -1 + 1e-6 is therefore exactly where the
+//   clamp stops being a no-op, and rejecting there states outright what the clamp was quietly
+//   getting wrong. It also keeps this path clear of FisheyeEquidistantForward's own `rho < 1e-10`
+//   guard (rho >= 1.4e-3 at this floor), which is why that guard is left alone: it is shared with
+//   the dual-fisheye path, where the pole is a legitimate input and (0,0) is the right answer.
+//   The floor sits at theta = 179.919 deg. The inverse's rim (theta = 180 deg) is 4e-7 image radii
+//   further out for equal-area and 0.05 px further out for equidistant on a 120 px short edge, so
+//   the region core renders and the region lens_proj_build.hpp's mask accepts still coincide
+//   everywhere a pixel can tell them apart.
+//
+// kFisheyeStereographicMinCz — r = tan(theta/2) diverges at theta = 180 deg, so this type needs a
+//   bound on the radius itself and not just on the azimuth. The value is cos(179.5 deg): the half
+//   angle of the 359 deg fov ceiling `render_config.cpp::MaxFov` already imposes on this lens, so
+//   the per-ray floor and the config-level ceiling describe one boundary rather than two. It puts
+//   the rim at r = tan(89.75 deg) = 229.18 image radii — past any frame at any usable resolution,
+//   which is why the GUI preview (whose stereographic inverse has no guard at all) and core still
+//   agree pixel for pixel. projection.cpp::FisheyeStereographicInverse derives its own r bound
+//   from THIS constant rather than restating the angle, so the two cannot drift.
+LM_CONSTANT float kFisheyeAntipodeMinCz = -1.0f + 1e-6f;
+LM_CONSTANT float kFisheyeStereographicMinCz = -0.99996192f;
+
 // Apply the transpose of a row-major 3x3 matrix (equivalent to Rotation::ApplyInverse
 // in src/core/geo3d.cpp:79). Splits out of the switch so both fisheye and linear
 // single-lens branches share one implementation.
@@ -216,19 +254,27 @@ LM_FN ProjResult ProjectExitToPixel(LM_THREAD const ProjParams& p, float wx, flo
     ProjXY xy = { 0.0f, 0.0f, false };
     if (t == kProjLinear) {
       xy = LinearForward(cx, cy, cz);
-    } else {
-      // Fisheye 4 types: additional cz<=0 rejection (past-horizon).
+    } else if (t == kProjFisheyeOrthographic) {
+      // The one member of the family that must keep a hemisphere cull: r = sin(theta) aliases past
+      // the equator (sin 120 deg == sin 60 deg), so two distinct rays would land on one pixel.
+      // Structurally not widenable — see kFisheyeAntipodeMinCz above for the ones that were.
       if (cz <= 0.0f) {
+        return r;
+      }
+      xy = FisheyeOrthographicForward(cx, cy, cz, 1.0f);
+    } else if (t == kProjFisheyeStereographic) {
+      if (cz < kFisheyeStereographicMinCz) {
+        return r;
+      }
+      xy = FisheyeStereographicForward(cx, cy, cz, 1.0f);
+    } else {
+      if (cz < kFisheyeAntipodeMinCz) {
         return r;
       }
       if (t == kProjFisheyeEqualArea) {
         xy = FisheyeEqualAreaForward(cx, cy, cz, 1.0f);
-      } else if (t == kProjFisheyeEquidistant) {
+      } else {  // kProjFisheyeEquidistant
         xy = FisheyeEquidistantForward(cx, cy, cz, 1.0f);
-      } else if (t == kProjFisheyeStereographic) {
-        xy = FisheyeStereographicForward(cx, cy, cz, 1.0f);
-      } else {  // kProjFisheyeOrthographic
-        xy = FisheyeOrthographicForward(cx, cy, cz, 1.0f);
       }
     }
     if (!xy.valid) {

--- a/test/e2e-correctness/test_background_domain_mask.py
+++ b/test/e2e-correctness/test_background_domain_mask.py
@@ -8,12 +8,18 @@ so they must stay black rather than being painted the sky background — otherwi
 fisheye render is a solid rectangle of background with an invisible circle inside it, and
 the lens boundary the GUI draws has no counterpart in the CLI image.
 
-The config renders a 180 deg equal-area fisheye at 400x300 pointing at the zenith, so the
-image circle has radius `min(400, 300) / 2 = 150` px centred on the frame; the frame
-corners sit at ~246 px from the centre, i.e. well outside it (r = 1.64 in image-circle
-units, not a boundary coin flip). Pointing at the zenith with `visible: upper` makes the
-image circle and the visible hemisphere the same set, so this pin isolates the *domain*
-half of the mask from the *visibility* half.
+The config renders a 180 deg equal-area fisheye at 400x300 pointing at the zenith. Radius
+normalises by `min(400, 300) / 2 = 150` px, and the lens images out to its rim at
+r = sqrt(2), so the imaged disc has radius 212.1 px centred on the frame; the frame corners
+sit at ~246 px from the centre, i.e. outside it (r = 1.64 against a rim of 1.414, not a
+boundary coin flip). Pointing at the zenith with `visible: upper` makes the imaged disc and
+the visible hemisphere the same set, so this pin isolates the *domain* half of the mask from
+the *visibility* half.
+
+The 150 px in that first sentence used to be the whole story: before 474.1 core stopped at
+the equator (r = 1) for every single-lens fisheye. Widening the cull per lens type moved the
+disc out to r = sqrt(2) without moving this fixture's verdict, because its corner probes were
+already outside the wider disc too.
 
 Both halves are asserted, and the second is what keeps the first honest: the corners must
 be black AND the pixels inside the circle must still carry the authored background, so a
@@ -36,9 +42,10 @@ CONFIG = (
 )
 
 WIDTH, HEIGHT = 400, 300
-# Image-circle radius in pixels: an equal-area fisheye at fov=180 maps theta=90 deg onto
-# r = short_edge / 2 (see ComputeScaleAz0's kFisheyeEqualArea branch).
-IMAGE_RADIUS = min(WIDTH, HEIGHT) / 2.0
+# Imaged-disc radius in pixels: an equal-area fisheye at fov=180 maps theta=90 deg onto
+# r = short_edge / 2 (see ComputeScaleAz0's kFisheyeEqualArea branch) and reaches its rim,
+# theta=180 deg, at sqrt(2) times that.
+IMAGE_RADIUS = min(WIDTH, HEIGHT) / 2.0 * 2 ** 0.5  # 212.13 px
 
 # Pixels sampled well outside the image circle (distance from centre, in units of
 # IMAGE_RADIUS, in parentheses).

--- a/test/e2e-correctness/test_background_visible_hemisphere.py
+++ b/test/e2e-correctness/test_background_visible_hemisphere.py
@@ -18,13 +18,16 @@ frame into three regions that are all present in one image:
 
 Geometry, all of it derived rather than observed. `ComputeScaleAz0`'s equal-area branch gives
 scale = (short_edge / 2) / (sqrt(2) * sin(fov/4)), which at fov=180 on a 400x300 canvas is exactly
-150 -- so the core mask's own domain guard (`FisheyeEqualAreaInverse` rejects normalised r > 1)
-puts the image circle at 150 px, and the frame corners at 250 px are outside it. Region A is
-sampled beyond 170 px and region B/C inside 140 px, both with margin, so no probe sits on the
-boundary. The 150..212 px annulus where the GUI shader's own guard disagrees with the core mask
-(the domain divergence pinned in test_preview_background.cpp) is likewise never sampled -- this
-file compares the CLI against arithmetic, not against the GUI, but staying clear of that band
-keeps the numbers here readable next to the ones there.
+150. The core mask's domain guard (`FisheyeEqualAreaInverse`) rejects normalised r beyond the
+lens's rim, and for equal-area that rim is sqrt(2) -- theta = 180 deg -- so the imaged disc reaches
+212.1 px and the frame corners at 250 px are outside it. Region A is sampled beyond 230 px and
+region B/C inside 140 px, both with margin, so no probe sits on the boundary.
+
+That rim used to be 150 px, not 212.1: core stopped at the equator for every single-lens fisheye
+while the GUI preview kept inverting out to theta = 180 deg, and the 150..212 px annulus was a
+pinned CLI/GUI divergence. 474.1 closed it by taking the cull per lens type, which moved region A's
+inner bound from 170 px to 230 px -- the numbers here are the visible consequence of that change,
+not a relaxation of the assertion.
 
 Two renders come out of ONE run, differing only in `visible`, so region B has a paired positive
 control from the same rays: it must be background under `full` and black under `upper`. Without
@@ -60,13 +63,16 @@ CONFIG = (
 
 WIDTH, HEIGHT = 400, 300
 CX, CY = WIDTH / 2.0, HEIGHT / 2.0
-# Equal-area fisheye at fov=180: the core mask's inverse rejects normalised r > 1, and the scale
-# that normalises it is short_edge / 2 (see the module docstring's derivation).
-IMAGE_RADIUS = min(WIDTH, HEIGHT) / 2.0
+# Equal-area fisheye at fov=180: the scale that normalises radius is short_edge / 2, and the core
+# mask's inverse accepts out to the lens's rim, r = sqrt(2) (theta = 180 deg). See the module
+# docstring's derivation, including what this number was before 474.1 and why it moved.
+IMAGE_RADIUS = min(WIDTH, HEIGHT) / 2.0 * 2 ** 0.5  # 212.13 px
 
-# Region bounds, in pixels. The two radii straddle IMAGE_RADIUS with ~20 px of margin either way,
-# and the horizon rows are 15 px clear of CY, so nothing here is a boundary coin flip.
-OUTSIDE_RADIUS = 170.0
+# Region bounds, in pixels. The two radii straddle IMAGE_RADIUS with margin either way (18 px
+# outside, 72 px inside; the outer one is bounded by the 250 px frame corner, and region A still
+# holds 1740 pixels), and the horizon rows are 15 px clear of CY, so nothing here is a boundary
+# coin flip.
+OUTSIDE_RADIUS = 230.0
 INSIDE_RADIUS = 140.0
 BELOW_FIRST_ROW = 165
 ABOVE_LAST_ROW = 135

--- a/test/golden-analytic/core/test_projection.cpp
+++ b/test/golden-analytic/core/test_projection.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cmath>
+#include <cstring>
 #include <random>
 #include <vector>
 
@@ -24,6 +26,32 @@ constexpr float kEpsPolar = 5e-6f;  // Relaxed for polar-path projections (atan2
 void ExpectUnitVector(const Dir3& d) {
   float len = std::sqrt(d.x * d.x + d.y * d.y + d.z * d.z);
   EXPECT_NEAR(len, 1.0f, kEps);
+}
+
+// The single-lens fisheye render domain runs to theta = 180 deg (474.1), but a round trip through
+// it is not uniformly conditioned: every type recovers the AZIMUTH by dividing by rho = sin(theta),
+// which collapses at the antipode. Equal-area shows it most directly — the inverse recovers
+// z = 1 - r^2 with r^2 -> 2, so the subtraction keeps an absolute error of ~2e-7 while the factor
+// sqrt(1 + z) it feeds shrinks to 1e-3, and the relative error in the recovered x/y grows as
+// 1 / sqrt(1 + z). The round-trip tests below therefore run the well-conditioned bulk of the
+// domain at kEps and hand the last 26 deg to SingleFisheyeRimRoundTrip, which states the looser
+// tolerance the float arithmetic actually allows rather than pretending the whole domain is equal.
+constexpr float kRoundTripMinDz = -0.9f;  // theta <= 154 deg
+
+// Equal-area's past-equator tolerance. Its inverse recovers z as 1 - r^2 with r^2 running to 2, so
+// the absolute error in z stays flat while the factor sqrt(1 + z) it feeds shrinks — a few units in
+// the last place at the equator become a few 1e-6 by theta = 154 deg. The equator-and-up half of
+// the domain, which this test already covered before 474.1, keeps kEps: the half that was added is
+// the half that is less well conditioned, and saying so per-sample is more useful than relaxing the
+// whole test. (Same spirit as kEpsPolar above.) Equidistant and stereographic need no equivalent —
+// they recover z through cos() of a well-conditioned angle.
+constexpr float kEpsPastEquator = 5e-6f;
+
+// Angle between two unit vectors, in radians — the tolerance that means the same thing for every
+// projection type, unlike a per-component epsilon.
+float AngleBetween(const Dir3& a, float bx, float by, float bz) {
+  const float dot = std::max(-1.0f, std::min(1.0f, a.x * bx + a.y * by + a.z * bz));
+  return std::acos(dot);
 }
 
 // =============== Type A: Linear ===============
@@ -83,9 +111,12 @@ TEST(Projection, FisheyeEqualAreaForwardEquator) {
 }
 
 TEST(Projection, FisheyeEqualAreaRoundTrip) {
-  // Full-sphere round-trip: caller flips z for lower hemisphere
+  // Direct round trip over the whole widened domain — no hemisphere flip. Before 474.1 this test
+  // projected |dz| and flipped the sign afterwards, which only ever exercised theta <= 90 deg; the
+  // past-equator half of the domain the render path now writes to went untested here.
   std::mt19937 rng(45);
   std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+  size_t past_equator = 0;
   for (int i = 0; i < 2000; i++) {
     float dx = dist(rng), dy = dist(rng), dz = dist(rng);
     float len = std::sqrt(dx * dx + dy * dy + dz * dz);
@@ -94,19 +125,27 @@ TEST(Projection, FisheyeEqualAreaRoundTrip) {
     dx /= len;
     dy /= len;
     dz /= len;
+    if (dz < kRoundTripMinDz) {
+      continue;  // see kRoundTripMinDz — the rim is SingleFisheyeRimRoundTrip's job
+    }
+    if (dz < 0.0f) {
+      ++past_equator;
+    }
 
-    bool is_upper = (dz >= 0);
-    float z_hemi = is_upper ? dz : -dz;
-    auto fwd = FisheyeEqualAreaForward(dx, dy, z_hemi);
+    auto fwd = FisheyeEqualAreaForward(dx, dy, dz);
     auto inv = FisheyeEqualAreaInverse(fwd.x, fwd.y);
-    ASSERT_TRUE(inv.valid);
+    if (!inv.valid) {
+      ADD_FAILURE() << "the inverse rejected a direction the render path projects; dz = " << dz;
+      continue;
+    }
     ExpectUnitVector(inv);
-    // inv.z is in z_hemi space; flip back for lower hemisphere
-    float recovered_z = is_upper ? inv.z : -inv.z;
-    EXPECT_NEAR(inv.x, dx, kEps);
-    EXPECT_NEAR(inv.y, dy, kEps);
-    EXPECT_NEAR(recovered_z, dz, kEps);
+    const float tol = (dz >= 0.0f) ? kEps : kEpsPastEquator;
+    EXPECT_NEAR(inv.x, dx, tol) << "dz = " << dz;
+    EXPECT_NEAR(inv.y, dy, tol) << "dz = " << dz;
+    EXPECT_NEAR(inv.z, dz, tol) << "dz = " << dz;
   }
+  EXPECT_GT(past_equator, 100u) << "the sample must actually reach past the equator, or this test "
+                                   "still only covers the pre-474.1 domain";
 }
 
 TEST(Projection, FisheyeEqualAreaEqualAreaProperty) {
@@ -143,9 +182,17 @@ TEST(Projection, FisheyeEqualAreaEqualAreaProperty) {
   EXPECT_LT(chi2, 21.67f) << "Equal-area property violated: chi2=" << chi2;
 }
 
-TEST(Projection, FisheyeEqualAreaInverseBeyondDomain) {
+TEST(Projection, FisheyeEqualAreaInverseInsideTheWidenedDomain) {
+  // r = 1.1 used to be rejected: the domain stopped at r = 1, the equator. It is now inside, and
+  // what it recovers is the point of 474.1 — a direction BELOW the horizon of the lens axis.
+  // r = sqrt(2) sin(theta/2)  =>  theta = 2 asin(1.1 / sqrt(2)) = 101.1 deg.
   auto r = FisheyeEqualAreaInverse(1.1f, 0);
-  EXPECT_FALSE(r.valid);
+  ASSERT_TRUE(r.valid);
+  ExpectUnitVector(r);
+  EXPECT_LT(r.z, 0.0f) << "r > 1 is the past-equator region; a positive z would mean the widening "
+                          "moved the radius mapping instead of extending it";
+  EXPECT_NEAR(std::acos(r.z) * math::kRadToDegree, 2.0f * std::asin(1.1f / std::sqrt(2.0f)) * math::kRadToDegree,
+              1e-3f);
 }
 
 // =============== Fisheye Equidistant ===============
@@ -158,8 +205,11 @@ TEST(Projection, FisheyeEquidistantEquatorNorm) {
 }
 
 TEST(Projection, FisheyeEquidistantRoundTrip) {
+  // Direct round trip over the widened domain — see FisheyeEqualAreaRoundTrip for why the
+  // hemisphere flip is gone.
   std::mt19937 rng(47);
   std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+  size_t past_equator = 0;
   for (int i = 0; i < 2000; i++) {
     float dx = dist(rng), dy = dist(rng), dz = dist(rng);
     float len = std::sqrt(dx * dx + dy * dy + dz * dz);
@@ -168,18 +218,25 @@ TEST(Projection, FisheyeEquidistantRoundTrip) {
     dx /= len;
     dy /= len;
     dz /= len;
+    if (dz < kRoundTripMinDz) {
+      continue;
+    }
+    if (dz < 0.0f) {
+      ++past_equator;
+    }
 
-    bool is_upper = (dz >= 0);
-    float z_hemi = is_upper ? dz : -dz;
-    auto fwd = FisheyeEquidistantForward(dx, dy, z_hemi);
+    auto fwd = FisheyeEquidistantForward(dx, dy, dz);
     auto inv = FisheyeEquidistantInverse(fwd.x, fwd.y);
-    ASSERT_TRUE(inv.valid);
+    if (!inv.valid) {
+      ADD_FAILURE() << "the inverse rejected a direction the render path projects; dz = " << dz;
+      continue;
+    }
     ExpectUnitVector(inv);
-    float recovered_z = is_upper ? inv.z : -inv.z;
     EXPECT_NEAR(inv.x, dx, kEps);
     EXPECT_NEAR(inv.y, dy, kEps);
-    EXPECT_NEAR(recovered_z, dz, kEps);
+    EXPECT_NEAR(inv.z, dz, kEps);
   }
+  EXPECT_GT(past_equator, 100u) << "the sample must actually reach past the equator";
 }
 
 // =============== Fisheye Stereographic ===============
@@ -191,8 +248,12 @@ TEST(Projection, FisheyeStereographicEquatorNorm) {
 }
 
 TEST(Projection, FisheyeStereographicRoundTrip) {
+  // Direct round trip over the widened domain — see FisheyeEqualAreaRoundTrip. r = tan(theta/2)
+  // is the one type whose radius diverges rather than converging to a rim, so its far end belongs
+  // to SingleFisheyeRimRoundTrip for a second reason on top of the shared azimuth conditioning.
   std::mt19937 rng(48);
   std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+  size_t past_equator = 0;
   for (int i = 0; i < 2000; i++) {
     float dx = dist(rng), dy = dist(rng), dz = dist(rng);
     float len = std::sqrt(dx * dx + dy * dy + dz * dz);
@@ -201,18 +262,25 @@ TEST(Projection, FisheyeStereographicRoundTrip) {
     dx /= len;
     dy /= len;
     dz /= len;
+    if (dz < kRoundTripMinDz) {
+      continue;
+    }
+    if (dz < 0.0f) {
+      ++past_equator;
+    }
 
-    bool is_upper = (dz >= 0);
-    float z_hemi = is_upper ? dz : -dz;
-    auto fwd = FisheyeStereographicForward(dx, dy, z_hemi);
+    auto fwd = FisheyeStereographicForward(dx, dy, dz);
     auto inv = FisheyeStereographicInverse(fwd.x, fwd.y);
-    ASSERT_TRUE(inv.valid);
+    if (!inv.valid) {
+      ADD_FAILURE() << "the inverse rejected a direction the render path projects; dz = " << dz;
+      continue;
+    }
     ExpectUnitVector(inv);
-    float recovered_z = is_upper ? inv.z : -inv.z;
     EXPECT_NEAR(inv.x, dx, kEps);
     EXPECT_NEAR(inv.y, dy, kEps);
-    EXPECT_NEAR(recovered_z, dz, kEps);
+    EXPECT_NEAR(inv.z, dz, kEps);
   }
+  EXPECT_GT(past_equator, 100u) << "the sample must actually reach past the equator";
 }
 
 // =============== Rectangular ===============
@@ -298,23 +366,203 @@ TEST(Projection, DualFisheyeLayoutOutsideCircles) {
 
 // =============== Boundary cases ===============
 
-TEST(Projection, InverseBeyondDomainEA) {
-  auto r = FisheyeEqualAreaInverse(1.5f, 0);
-  EXPECT_FALSE(r.valid);
+// The rim radius of each single-fisheye inverse at r_scale = 1, i.e. the value of that type's
+// radius formula at the largest theta the render path produces. Restated here from the formulas
+// rather than read out of projection.cpp, so a change to either side has to be argued for twice.
+float RimRadius(LensParam::LensType t) {
+  switch (t) {
+    case LensParam::kFisheyeEqualArea:
+      return std::sqrt(2.0f);  // sqrt(2) sin(theta/2) at theta = 180 deg
+    case LensParam::kFisheyeEquidistant:
+      return 2.0f;  // theta / (pi/2) at theta = 180 deg
+    case LensParam::kFisheyeStereographic:
+      // tan(theta/2) at the numerical cull floor, which is the half angle of this lens's fov
+      // ceiling — pinned against MaxFov by StereographicCullFloorIsTheFovCeilingHalfAngle below.
+      return std::tan(0.5f * std::acos(lm_proj::kFisheyeStereographicMinCz));
+    default:  // kFisheyeOrthographic — sin(theta) is not injective past the equator
+      return 1.0f;
+  }
 }
 
-TEST(Projection, InverseBeyondDomainED) {
-  auto r = FisheyeEquidistantInverse(1.5f, 0);
-  EXPECT_FALSE(r.valid);
+Dir3 InverseFor(LensParam::LensType t, float x, float y) {
+  switch (t) {
+    case LensParam::kFisheyeEqualArea:
+      return FisheyeEqualAreaInverse(x, y, 1.0f);
+    case LensParam::kFisheyeEquidistant:
+      return FisheyeEquidistantInverse(x, y, 1.0f);
+    case LensParam::kFisheyeStereographic:
+      return FisheyeStereographicInverse(x, y, 1.0f);
+    default:
+      return FisheyeOrthographicInverse(x, y, 1.0f);
+  }
 }
 
-TEST(Projection, InverseBeyondDomainST) {
-  auto r = FisheyeStereographicInverse(1.5f, 0);
-  EXPECT_FALSE(r.valid);
+ProjXY ForwardFor(LensParam::LensType t, float dx, float dy, float dz) {
+  switch (t) {
+    case LensParam::kFisheyeEqualArea:
+      return FisheyeEqualAreaForward(dx, dy, dz, 1.0f);
+    case LensParam::kFisheyeEquidistant:
+      return FisheyeEquidistantForward(dx, dy, dz, 1.0f);
+    case LensParam::kFisheyeStereographic:
+      return FisheyeStereographicForward(dx, dy, dz, 1.0f);
+    default:
+      return FisheyeOrthographicForward(dx, dy, dz, 1.0f);
+  }
+}
+
+// The cull floor ProjectExitToPixel applies to each single-lens fisheye. Restated from the
+// constants in projection_shared.h; SingleFisheyeCullAndInverseDomainAgree checks this restatement
+// against the real ProjectExitToPixel rather than trusting it.
+float CullFloorCz(LensParam::LensType t) {
+  switch (t) {
+    case LensParam::kFisheyeEqualArea:
+      return lm_proj::kFisheyeEqualAreaMinCz;
+    case LensParam::kFisheyeEquidistant:
+      return lm_proj::kFisheyeEquidistantMinCz;
+    case LensParam::kFisheyeStereographic:
+      return lm_proj::kFisheyeStereographicMinCz;
+    default:
+      return 0.0f;  // orthographic — strict: its branch rejects cz <= 0
+  }
+}
+
+const LensParam::LensType kSingleFisheyeTypes[] = { LensParam::kFisheyeEqualArea, LensParam::kFisheyeEquidistant,
+                                                    LensParam::kFisheyeStereographic, LensParam::kFisheyeOrthographic };
+
+TEST(Projection, InverseRejectsBeyondTheRim) {
+  // r = 1.5 used to be the "beyond domain" probe for all three widened types. It is now INSIDE two
+  // of the three domains, so a fixed radius cannot serve them any more — each type is probed
+  // against its own rim.
+  for (LensParam::LensType t : kSingleFisheyeTypes) {
+    const float rim = RimRadius(t);
+    EXPECT_TRUE(InverseFor(t, rim * 0.999f, 0.0f).valid) << "type " << static_cast<int>(t) << ": just inside the rim";
+    EXPECT_FALSE(InverseFor(t, rim * 1.001f, 0.0f).valid) << "type " << static_cast<int>(t) << ": just outside the rim";
+    // And far outside, so a rim that silently grew would still be caught.
+    EXPECT_FALSE(InverseFor(t, rim * 4.0f, 0.0f).valid) << "type " << static_cast<int>(t) << ": far outside the rim";
+  }
+}
+
+TEST(Projection, InverseAtTheRimRecoversTheAntipode) {
+  // The rim is not an arbitrary cut-off: it is where theta reaches its maximum. For the two types
+  // that run to 180 deg the recovered direction there must be the antipode of the lens axis.
+  const Dir3 ea = FisheyeEqualAreaInverse(std::sqrt(2.0f), 0.0f, 1.0f);
+  ASSERT_TRUE(ea.valid);
+  EXPECT_NEAR(ea.z, -1.0f, 1e-5f);
+  const Dir3 ed = FisheyeEquidistantInverse(2.0f, 0.0f, 1.0f);
+  ASSERT_TRUE(ed.valid);
+  EXPECT_NEAR(ed.z, -1.0f, 1e-5f);
+}
+
+TEST(Projection, StereographicCullFloorIsTheFovCeilingHalfAngle) {
+  // AC3's closed-form reason, as a mechanical assertion rather than a comment: the per-ray cull
+  // floor is not an independently chosen number, it is the half angle of the fov ceiling
+  // render_config.cpp already imposes on this lens. If MaxFov changes and the constant does not
+  // (or the other way round), this is what says so.
+  const float theta_max_deg = std::acos(lm_proj::kFisheyeStereographicMinCz) * math::kRadToDegree;
+  EXPECT_NEAR(theta_max_deg, lumice::MaxFov(LensParam::kFisheyeStereographic) / 2.0f, 1e-3f);
+  // ... and the radius that half angle implies is far outside any frame, which is why widening
+  // stereographic needs no product decision about where to stop.
+  EXPECT_GT(RimRadius(LensParam::kFisheyeStereographic), 200.0f);
+}
+
+TEST(Projection, SingleFisheyeCullAndInverseDomainAgree) {
+  // AC2, mechanically: "a ray could have landed on this pixel" and "the inverse accepts this
+  // pixel" must be the same statement, because lens_proj_build.hpp's render-domain mask is built
+  // from the second and describes the first. Driven through the real ProjectExitToPixel (identity
+  // rotation, visible = full, so the only cull left is the per-type cz floor under test) rather
+  // than through a restatement of its branch structure.
+  lm_proj::ProjParams p{};
+  p.img_w = 1024;
+  p.img_h = 1024;
+  p.visible_range = 2;  // kFull
+  p.scale = 1.0f;
+  p.r_scale = 1.0f;
+  const float kIdentity[9] = { 1, 0, 0, 0, 1, 0, 0, 0, 1 };
+  std::memcpy(p.rot, kIdentity, sizeof(kIdentity));
+
+  for (LensParam::LensType t : kSingleFisheyeTypes) {
+    p.proj_type = static_cast<int>(t);
+    const float floor_cz = CullFloorCz(t);
+    const float rim = RimRadius(t);
+    size_t rendered = 0;
+    size_t culled = 0;
+    // 20001 steps of theta, plus four azimuths so the check is not confined to one meridian.
+    for (int i = 0; i <= 20000; ++i) {
+      const float theta = static_cast<float>(i) / 20000.0f * math::kPi;
+      for (float az : { 0.0f, 0.7f, 2.4f, 5.1f }) {
+        const float cz = std::cos(theta);
+        const float cx = std::sin(theta) * std::cos(az);
+        const float cy = std::sin(theta) * std::sin(az);
+        // ProjectExitToPixel computes c = R^T * (-w); with R = I that is w = -c.
+        const auto res = lm_proj::ProjectExitToPixel(p, -cx, -cy, -cz);
+        const bool inside_floor = (t == LensParam::kFisheyeOrthographic) ? (cz > floor_cz) : (cz >= floor_cz);
+        if (!inside_floor) {
+          if (res.count != 0) {
+            ADD_FAILURE() << "type " << static_cast<int>(t) << ": theta = " << theta
+                          << " is past the cull floor but produced a hit";
+          }
+          ++culled;
+          continue;
+        }
+        if (res.count != 1) {
+          ADD_FAILURE() << "type " << static_cast<int>(t) << ": theta = " << theta
+                        << " is inside the cull floor but was rejected";
+          continue;
+        }
+        ++rendered;
+        const ProjXY fwd = ForwardFor(t, cx, cy, cz);
+        const float r = std::sqrt(fwd.x * fwd.x + fwd.y * fwd.y);
+        EXPECT_TRUE(InverseFor(t, fwd.x, fwd.y).valid)
+            << "type " << static_cast<int>(t) << ": theta = " << theta << " renders at r = " << r
+            << " but the inverse (rim " << rim << ") rejects it — the mask would call this pixel empty";
+      }
+    }
+    EXPECT_GT(rendered, 0u) << "type " << static_cast<int>(t);
+    EXPECT_GT(culled, 0u) << "type " << static_cast<int>(t)
+                          << ": every type must still cull SOMETHING, or the "
+                             "floor under test is not being exercised";
+    // The other direction: the inverse must not accept a meaningfully larger disc than the forward
+    // can reach, or the mask promises sky no ray can paint. Evaluated AT the floor rather than off
+    // the sweep above, whose theta step is coarser than the last decade each floor sits in.
+    // 1e-3 of the rim is well under a pixel at any resolution these lenses are used at.
+    const float rho_floor = std::sqrt(std::max(0.0f, 1.0f - floor_cz * floor_cz));
+    const ProjXY at_floor = ForwardFor(t, rho_floor, 0.0f, floor_cz);
+    const float r_floor = std::sqrt(at_floor.x * at_floor.x + at_floor.y * at_floor.y);
+    EXPECT_NEAR(r_floor, rim, rim * 1e-3f) << "type " << static_cast<int>(t);
+  }
+}
+
+TEST(Projection, SingleFisheyeRimRoundTrip) {
+  // The last 14 deg the *RoundTrip tests hand over (see kRoundTripMinDz). Two separate claims, and
+  // they degrade differently: the RADIUS stays accurate all the way to the floor, while the
+  // AZIMUTH does not, because every inverse recovers it by dividing by rho = sin(theta).
+  for (LensParam::LensType t :
+       { LensParam::kFisheyeEqualArea, LensParam::kFisheyeEquidistant, LensParam::kFisheyeStereographic }) {
+    const float floor_cz = CullFloorCz(t);
+    for (int i = 0; i <= 200; ++i) {
+      const float cz = kRoundTripMinDz + (floor_cz - kRoundTripMinDz) * static_cast<float>(i) / 200.0f;
+      const float rho = std::sqrt(std::max(0.0f, 1.0f - cz * cz));
+      const float az = 0.9f;
+      const float cx = rho * std::cos(az);
+      const float cy = rho * std::sin(az);
+      const ProjXY fwd = ForwardFor(t, cx, cy, cz);
+      const Dir3 inv = InverseFor(t, fwd.x, fwd.y);
+      if (!inv.valid) {
+        ADD_FAILURE() << "type " << static_cast<int>(t) << ": the inverse rejected the rim; cz = " << cz;
+        continue;
+      }
+      ExpectUnitVector(inv);
+      // Radius: well conditioned, and the half of the round trip the render domain depends on.
+      EXPECT_NEAR(inv.z, cz, 1e-4f) << "type " << static_cast<int>(t) << " cz = " << cz;
+      // Direction: 1e-3 rad = 0.06 deg. At this distance from the antipode a whole degree of
+      // azimuth spans well under a pixel of arc, so this is tighter than anything observable.
+      EXPECT_LT(AngleBetween(inv, cx, cy, cz), 1e-3f) << "type " << static_cast<int>(t) << " cz = " << cz;
+    }
+  }
 }
 
 TEST(Projection, FisheyeForwardAtPoles) {
-  // All three: pole -> center (0,0)
+  // North pole -> centre (0,0) for all three: theta = 0, and every azimuth agrees there.
   auto ea = FisheyeEqualAreaForward(0, 0, 1);
   EXPECT_NEAR(ea.x, 0, kEps);
   EXPECT_NEAR(ea.y, 0, kEps);
@@ -326,6 +574,36 @@ TEST(Projection, FisheyeForwardAtPoles) {
   auto st = FisheyeStereographicForward(0, 0, 1);
   EXPECT_NEAR(st.x, 0, kEps);
   EXPECT_NEAR(st.y, 0, kEps);
+}
+
+TEST(Projection, ForwardAtTheAntipodeIsCulledRatherThanCollapsedToTheCentre) {
+  // The south pole is the one direction where these *Forward functions still answer wrongly, and
+  // deliberately so: rho = 0 there, every azimuth is equally correct, and both equal-area (via its
+  // dz clamp) and equidistant (via its rho guard) return (0,0) — the CENTRE, which is where
+  // theta = 0 belongs, not theta = 180 deg. Widening the domain is what made that reachable, and
+  // the fix is the cull floor rather than a change to the shared functions, because those same
+  // functions serve the dual-fisheye path where rho = 0 really is the pole and (0,0) really is the
+  // right answer. This test pins both halves: the functions still collapse, and the render path
+  // never lets a ray get there.
+  const auto ea = FisheyeEqualAreaForward(0, 0, -1);
+  EXPECT_NEAR(std::sqrt(ea.x * ea.x + ea.y * ea.y), 0.0f, kEps) << "the collapse is still there";
+  const auto ed = FisheyeEquidistantForward(0, 0, -1);
+  EXPECT_NEAR(std::sqrt(ed.x * ed.x + ed.y * ed.y), 0.0f, kEps) << "the collapse is still there";
+
+  lm_proj::ProjParams p{};
+  p.img_w = 256;
+  p.img_h = 256;
+  p.visible_range = 2;  // kFull
+  p.scale = 1.0f;
+  p.r_scale = 1.0f;
+  const float kIdentity[9] = { 1, 0, 0, 0, 1, 0, 0, 0, 1 };
+  std::memcpy(p.rot, kIdentity, sizeof(kIdentity));
+  for (LensParam::LensType t : kSingleFisheyeTypes) {
+    p.proj_type = static_cast<int>(t);
+    // c = (0,0,-1) is the antipode of the lens axis; w = -c.
+    EXPECT_EQ(lm_proj::ProjectExitToPixel(p, 0.0f, 0.0f, 1.0f).count, 0)
+        << "type " << static_cast<int>(t) << ": the antipode must be culled, not painted at the centre";
+  }
 }
 
 // =============== r_scale round-trip (overlap support) ===============

--- a/test/golden-analytic/core/test_visible_mask.cpp
+++ b/test/golden-analytic/core/test_visible_mask.cpp
@@ -230,26 +230,35 @@ TEST(VisibleMask, RectangularLeavesPolarCapsOnATallerCanvas) {
 }
 
 TEST(VisibleMask, SingleFisheyeMasksOutsideTheImageCircle) {
-  // For each single-lens fisheye the mask's domain edge is the EQUATOR (theta = 90 deg), which is
-  // where the r <= 1 inverse domain sits and equally where the forward's `cz <= 0` cull sits. Its
-  // pixel radius follows from each type's `scale` in ComputeScaleAz0 and the r = 1 boundary.
+  // Each single-lens fisheye's mask edge is its RIM — the radius its inverse stops accepting,
+  // which is that type's radius formula at the largest theta the forward's per-type cull leaves
+  // renderable (the three kFisheye*MinCz constants in projection_shared.h). Before
+  // 474.1 all four shared one edge, the equator at r = 1; three of them now run further, and only
+  // orthographic still stops there because sin(theta) aliases past it.
+  //
+  // `fov` is chosen per type so the rim lands INSIDE the frame — otherwise the case would assert
+  // nothing (`off` would be 0). It is the rim that moved, so the fov that exposes it moved too:
+  // at fov = 180 equidistant's rim is at 2 * scale = 150 px, past this frame's 125 px half
+  // diagonal, and stereographic's is three orders of magnitude further out.
   struct Case {
     LensParam::LensType type;
     float fov;
+    float rim_r;  // rim radius in normalized (r_scale = 1) coordinates
     const char* name;
   };
   const Case cases[] = {
-    { LensParam::kFisheyeEqualArea, 180.0f, "equal_area" },
-    { LensParam::kFisheyeEquidistant, 180.0f, "equidistant" },
-    { LensParam::kFisheyeStereographic, 180.0f, "stereographic" },
-    { LensParam::kFisheyeOrthographic, 180.0f, "orthographic" },
+    { LensParam::kFisheyeEqualArea, 180.0f, std::sqrt(2.0f), "equal_area" },
+    { LensParam::kFisheyeEquidistant, 240.0f, 2.0f, "equidistant" },
+    { LensParam::kFisheyeStereographic, 359.0f, std::tan(0.5f * std::acos(lm_proj::kFisheyeStereographicMinCz)),
+      "stereographic" },
+    { LensParam::kFisheyeOrthographic, 180.0f, 1.0f, "orthographic" },
   };
   for (const Case& c : cases) {
     const RenderConfig cfg = MakeCfg(c.type, c.fov, 200, 150);
     const float short_pix = 150.0f;
     const float fov_rad = c.fov * math::kDegreeToRad;
     const float scale = ComputeScaleAz0(c.type, fov_rad, short_pix, 200, 150, MakeCameraRotation(cfg)).scale;
-    const float edge_px = scale;  // r = 1 in normalized coords is `scale` pixels out
+    const float edge_px = scale * c.rim_r;
     const auto mask = Mask(cfg);
 
     size_t off = 0;

--- a/test/gui/functional/test_preview_background.cpp
+++ b/test/gui/functional/test_preview_background.cpp
@@ -646,33 +646,30 @@ void RegisterPreviewBackgroundTests(ImGuiTestEngine* engine) {
     };
   }
 
-  // A declared, deliberate disagreement between this renderer and the CLI's, pinned so that
-  // settling it cannot happen silently.
+  // How far past the equator this renderer's single-lens domain reaches, pinned at three radii.
   //
-  // The mechanism. For a SINGLE-lens fisheye the CLI's projection is a forward one: it maps world
-  // directions to pixels, and a single lens images one hemisphere, so its image stops at the
-  // equator (theta = 90 deg) whatever the configured FOV. This renderer works backwards from a
-  // pixel through the same projection law, and its only stopping condition is that law's own
-  // domain — for equal area, `r * sin(fov/4) <= 1`, which at fov=180 reaches theta = 180 deg, a
-  // radius of sqrt(2) image radii. (It can do that because it is re-projecting an all-sky
-  // dual-fisheye source texture, not imaging a scene through one lens.)
+  // The mechanism. This renderer works backwards from a pixel through the projection law, and its
+  // only stopping condition is that law's own domain — for equal area, `r * sin(fov/4) <= 1`,
+  // which at fov=180 reaches theta = 180 deg, a radius of sqrt(2) image radii. So a wide-FOV
+  // single-lens preview shows sky well past the equator, out to the antipode of the lens axis.
   //
-  // So between r = img_radius and r = sqrt(2) * img_radius there is an annulus that this renderer
-  // paints with the sky colour and the CLI leaves black. NEITHER SIDE IS A BUG, and neither side
-  // may be quietly changed to match the other: narrowing this shader's domain to the equator is a
-  // product-semantics decision about what a wide-FOV single-lens preview shows, not a defect fix.
-  // This case exists so that whenever that decision is made, it lands here as a red rather than as
-  // a silent change in what users see.
+  // This case used to be a pinned CLI/GUI DIVERGENCE. The CLI's projection is a forward one, and
+  // it culled every single-lens fisheye at the equator whatever the configured FOV, so the
+  // annulus between r = img_radius and r = sqrt(2) * img_radius was sky here and black there. That
+  // was a product-semantics question rather than a defect on either side, and it was settled in
+  // 474.1 the way this renderer already had it: core's cull is now taken per lens type and runs to
+  // theta = 180 deg for equal-area. The annulus is sky on both sides now. The pixel-for-pixel
+  // comparison of the two domains lives in test/unit-correctness/gui/test_visible_mask_gui_parity.cpp,
+  // which asserts equality; what stays here is this renderer's own half of it, in real frames.
   //
   // Three probes, not one, at fov=180 equal-area on a 512x256 frame (img_radius = 128 px):
-  //   r = 100 px  theta = 67.1 deg   inside both domains          -> sky (positive control)
-  //   r = 150 px  theta = 111.9 deg  the divergence annulus       -> sky HERE, black in the CLI
-  //   r = 220 px  beyond 181.0 px    outside both domains         -> black (negative control)
-  // Without the outer two, "the annulus is sky" would also pass on a shader that painted the
+  //   r = 100 px  theta = 67.1 deg   inside the equator            -> sky (positive control)
+  //   r = 150 px  theta = 111.9 deg  past it, inside the domain    -> sky
+  //   r = 220 px  beyond 181.0 px    outside the domain            -> black (negative control)
+  // Without the outer two, "past the equator is sky" would also pass on a shader that painted the
   // entire frame, and without the inner one it would pass on a shader that painted nothing.
   {
-    ImGuiTest* t =
-        IM_REGISTER_TEST(engine, "preview_background", "the_single_lens_domain_divergence_is_visible_in_the_sky");
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "preview_background", "the_single_lens_domain_reaches_past_the_equator");
     t->GuiFunc = PreviewBackgroundGuiFunc;
     t->TestFunc = [](ImGuiTestContext* ctx) {
       ResetTestState();
@@ -688,8 +685,7 @@ void RegisterPreviewBackgroundTests(ImGuiTestEngine* engine) {
       IM_CHECK(!g_req.rgba.empty());
 
       ExpectSkyAt("inside the CLI's equator (r = 100 px)", g_req.rgba, 512, 256, 100.0f, 0.0f);
-      ExpectSkyAt("the divergence annulus (r = 150 px, past the CLI's equator at 128 px)", g_req.rgba, 512, 256, 150.0f,
-                  0.0f);
+      ExpectSkyAt("past the equator at 128 px (r = 150 px)", g_req.rgba, 512, 256, 150.0f, 0.0f);
       ExpectBlackAt("beyond this renderer's own domain (r = 220 px, past 181 px)", g_req.rgba, 512, 256, 220.0f, 0.0f);
     };
   }

--- a/test/gui/parity/test_gui_cli_export_parity.cpp
+++ b/test/gui/parity/test_gui_cli_export_parity.cpp
@@ -87,13 +87,16 @@
 //     (preview_renderer.cpp overlayAuxLines), core's a mask built at a fixed pixel width
 //     (server/render.cpp BuildHorizonMask); on a dual-fisheye frame those two widths part company
 //     near the circle rim. Making them agree is the annotation layer's business, not this gate's.
-//   * The single-lens fisheye domain past theta = 90 degrees, where the preview shader keeps
-//     inverting toward the frame corners and core stops. It is real and large — a 4:3 frame at
-//     fov 150 measured 25% of its pixels lit by the GUI and black in the CLI — and it is the
-//     subject of a separate, actively planned widening effort, not an abandoned one; pinning it
-//     here would freeze a shape that is about to change on purpose. The single-lens scene's fov is
-//     bounded so the frame stays inside the agreed domain; see the note on its row. Re-check that
-//     bound once the domain widens.
+//   * The single-lens fisheye domain past theta = 90 degrees. This USED to be a real and large
+//     exclusion — the preview shader kept inverting toward the frame corners while core stopped at
+//     the equator, and a 4:3 frame at fov 150 measured 25% of its pixels lit by the GUI and black
+//     in the CLI. That gap was closed in 474.1 (core's cull is now per lens type and runs to
+//     theta = 180 deg for equal-area and equidistant), and the pixel-for-pixel comparison of the
+//     two domains lives where it can be made cheaply and exhaustively: the unit-level mask gate
+//     test/unit-correctness/gui/test_visible_mask_gui_parity.cpp. It stays off this fixture's list
+//     not because it diverges but because this fixture compares RENDERED energy on a scene whose
+//     fov keeps the whole frame well inside both domains; widening its fov to exercise the rim
+//     would buy a duplicate of that unit gate at the cost of a much noisier oracle.
 //   * A loaded background IMAGE (GuiState::bg_*). Owner-decided GUI-only: it is never exported, so
 //     there is no honest comparison to make. Neither scene loads one.
 //   * RenderConfig::ray_color. The GUI's tint control does not reach the renderer, and the export
@@ -200,15 +203,19 @@ struct ParityScene {
 // is why the two equal-area scenes are no longer the whole story: they cannot see the factor at all
 // (their relative illumination is identically 1), so on their own they would let it be deleted.
 //
-// SINGLE-LENS FOV BOUND. The single-lens EQUAL-AREA scene's fov is bounded by the frame's corner:
-// the shader keeps inverting past the image circle while core stops, so the corner direction must
-// stay inside the domain both agree on. For an equal-area lens on a 4:3 frame the corner sits at
-// 1.665 image radii, i.e. sin(theta_c/2) = 1.665 * sin(fov/4), and theta_c <= 90 degrees needs
-// fov <= 100. At 96 the measured disagreement is zero pixels either way; at 150 it is 25% of the
-// frame.
+// SINGLE-LENS FOV BOUND. The single-lens EQUAL-AREA scene sits at fov 96, and the reason has
+// changed even though the number has not. It was originally the largest fov whose frame corner
+// stayed inside core's old theta <= 90 deg domain: on a 4:3 frame the corner sits at 1.665 image
+// radii, so sin(theta_c/2) = 1.665 * sin(fov/4) and theta_c <= 90 deg needs fov <= 100. Core's
+// domain now reaches theta = 180 deg for this lens (474.1), so that ceiling is gone — the same
+// corner stays inside the domain out to fov = 360. What keeps the scene at 96 now is that this is
+// a PSNR fixture, not a domain fixture: at 96 the two sides agreed to zero pixels before the
+// widening and still do, which is the quiet baseline the field-by-field breaks below are measured
+// against. Raising the fov would move this scene onto the rim, where the two paths' sampling
+// differs for reasons that have nothing to do with the fields under test.
 //
-// The bound does not bind on the RECTILINEAR scene, and for a structural reason rather than a
-// lucky number: that projection maps the image radius through theta = atan(rho / focal), which is
+// That ceiling never bound the RECTILINEAR scene, and for a structural reason rather than a lucky
+// number: that projection maps the image radius through theta = atan(rho / focal), which is
 // strictly below 90 degrees at every finite radius. There is no image circle to invert past, so no
 // fov below 180 can put the corner outside the shared domain. Re-derive this if the lens is ever
 // changed; do not carry the sentence over.

--- a/test/unit-correctness/gui/test_visible_mask_gui_parity.cpp
+++ b/test/unit-correctness/gui/test_visible_mask_gui_parity.cpp
@@ -22,23 +22,28 @@
 // inverse, so it is restated here (VisibleInGuiTerms) — three lines, and pinned by
 // VisibleRangeMatchesTheGuiRule below against the same rule spelled out from lat = asin(-wz).
 //
-// ============================ THE KNOWN DIVERGENCE =============================================
-// The two sides do NOT agree everywhere, and this file pins the disagreement instead of hiding
-// it, because it is a real product question rather than a bug in either side:
+// ============================ THE SINGLE-FISHEYE DOMAIN ========================================
+// This file used to pin a DIVERGENCE here: for the single-lens fisheye types core's domain ended
+// at the EQUATOR (theta = 90 deg) while the GUI's ended at its asin guard (theta = 180 deg), so
+// core's mask was a strict subset of the GUI's and the difference was the annulus between the two
+// boundaries. That gap is gone. `ProjectExitToPixel`'s `cz <= 0` cull is now taken per lens type
+// rather than for the fisheye family as a whole, and `projection.cpp`'s `Fisheye*Inverse` domain
+// guards were widened to match it, so core RENDERS the past-equator region the GUI was already
+// re-projecting. The tests below therefore assert set EQUALITY for every lens type in the file.
 //
-//   For the four SINGLE-lens fisheye types, core's domain ends at the EQUATOR (theta = 90 deg)
-//   and the GUI's ends at its asin guard (theta = 180 deg). Core's boundary is not a choice: the
-//   r <= 1 inverse domain coincides exactly with `cz <= 0`, the cull ProjectExitToPixel applies
-//   to those types, so beyond it core RENDERS NOTHING and painting a sky background there would
-//   promise sky that cannot appear. The GUI is re-projecting an all-sky texture and can honestly
-//   show more. For equal-area the GUI's radius bound is sqrt(2)x core's; at fov=180 on a square
-//   canvas that is the difference between an image circle inscribed in the frame and one
-//   1.41x larger.
+// Two members of the family are equal for reasons worth stating, because "equal" does not mean
+// the same thing for both:
 //
-// So: the tests below assert set EQUALITY for linear, rectangular, all four dual-fisheye types
-// and globe, and assert the exact SHAPE of the difference for the single-fisheye family (core is
-// a strict subset, and the difference is precisely the annulus between the two boundaries). Both
-// forms fail if either side changes, which is what makes this a gate.
+//   ORTHOGRAPHIC was never divergent. r = sin(theta) peaks at the equator and aliases past it, so
+//   its cull stays at `cz <= 0` and the GUI's own asin guard rejects at exactly the same circle.
+//
+//   STEREOGRAPHIC is equal in practice rather than by construction. The GUI has no guard at all
+//   (r = tan(theta/2) is monotone, so its inverse accepts every pixel), while core caps theta at
+//   179.5 deg — a NUMERICAL safety bound, not a visibility judgement, aligned with the fov ceiling
+//   `render_config.cpp::MaxFov` already imposes on this lens. That cap sits at r = tan(89.75 deg)
+//   = 229.18 image radii, so no frame at any usable resolution reaches it and the two masks are
+//   identical over any real canvas. The fixture below asserts that off-frame-ness explicitly
+//   rather than leaving it implied.
 
 #include <gtest/gtest.h>
 
@@ -218,12 +223,33 @@ TEST(VisibleMaskGuiParity, GlobeAgreesExactly) {
 }
 
 // =================================================================================================
-// The single-fisheye family: pinned divergence
+// The single-fisheye family: the two domains must now coincide
 // =================================================================================================
 
-// Radius, in pixels from the frame centre, where each side's domain ends. Core's is r = 1 in its
-// normalized coordinates, i.e. `scale` pixels. The GUI's is read off the guard in fisheyeInverse
-// (img_radius * r_boundary), and is unbounded for stereographic, which has no guard at all.
+// Core's normalized-radius domain bound per single-fisheye type, i.e. the largest r that
+// `projection.cpp`'s `Fisheye*Inverse` accepts at r_scale = 1. Each is the value of that type's
+// radius formula at the largest theta core will render:
+//   equal-area     sqrt(2) sin(theta/2)  at theta = 180 deg -> sqrt(2)
+//   equidistant    theta / (pi/2)        at theta = 180 deg -> 2
+//   stereographic  tan(theta/2)          at theta = 179.5 deg -> tan(89.75 deg)  (numerical cap)
+//   orthographic   sin(theta)            at theta = 90 deg  -> 1  (aliases past the equator)
+float CoreRadiusBound(LensParam::LensType t) {
+  if (t == LensParam::kFisheyeEqualArea) {
+    return std::sqrt(2.0f);
+  }
+  if (t == LensParam::kFisheyeEquidistant) {
+    return 2.0f;
+  }
+  if (t == LensParam::kFisheyeStereographic) {
+    return std::tan(0.5f * 179.5f * lumice::math::kDegreeToRad);
+  }
+  return 1.0f;  // kFisheyeOrthographic
+}
+
+// Radius, in pixels from the frame centre, where each side's domain ends. Core's is
+// CoreRadiusBound(t) in its normalized coordinates, i.e. that many `scale` pixels. The GUI's is
+// read off the guard in fisheyeInverse (img_radius * r_boundary), and is infinite for
+// stereographic, which has no guard at all.
 struct Boundaries {
   float core_px;
   float gui_px;  // infinity when the GUI never rejects
@@ -233,7 +259,7 @@ Boundaries BoundariesFor(LensParam::LensType t, float fov_deg, float short_pix) 
   const float fov = fov_deg * lumice::math::kDegreeToRad;
   const float half_fov = fov / 2.0f;
   const float img_radius = short_pix / 2.0f;
-  const float core = lumice::ComputeScaleAz0(t, fov, short_pix, 0, 0, lumice::Rotation{}).scale;
+  const float core = lumice::ComputeScaleAz0(t, fov, short_pix, 0, 0, lumice::Rotation{}).scale * CoreRadiusBound(t);
   float gui = std::numeric_limits<float>::infinity();
   if (t == LensParam::kFisheyeEqualArea) {
     gui = img_radius / std::sin(half_fov / 2.0f);
@@ -245,67 +271,63 @@ Boundaries BoundariesFor(LensParam::LensType t, float fov_deg, float short_pix) 
   return { core, gui };
 }
 
-TEST(VisibleMaskGuiParity, SingleFisheyeCoreIsTheEquatorSubsetOfTheGuiDomain) {
-  // Orthographic is excluded here and covered by the test below instead: r = sin(theta) peaks at
-  // the equator, so ITS asin guard lands on theta = 90 deg too and the two boundaries coincide.
+TEST(VisibleMaskGuiParity, SingleFisheyeCoreDomainMatchesGuiDomain) {
+  // fov = 180 is the regime that used to expose the divergence: core's old equator boundary fell
+  // inside the frame while the GUI's ran past it. It is kept as the fixture for exactly that
+  // reason — if the widening were reverted or applied to the wrong lens, this is where it shows.
   const LensParam::LensType types[] = { LensParam::kFisheyeEqualArea, LensParam::kFisheyeEquidistant,
                                         LensParam::kFisheyeStereographic };
   const int w = 160;
   const int h = 120;
   const float short_pix = 120.0f;
+  // Frame half-diagonal for 160x120: the radius past which a boundary cannot be observed at all.
+  const float half_diag = std::sqrt(80.0f * 80.0f + 60.0f * 60.0f);
   for (LensParam::LensType t : types) {
-    // fov = 180 puts core's equator boundary inside the frame, which is the only regime where
-    // the divergence is observable at all (at narrow fov both boundaries sit off-frame and the
-    // two masks are identical — asserted separately below).
-    const RenderConfig cfg = MakeCfg(t, 180.0f, w, h, RenderConfig::kFull, /*el=*/90.0f);
     const Boundaries b = BoundariesFor(t, 180.0f, short_pix);
-    if (!(b.core_px < b.gui_px)) {
-      ADD_FAILURE() << "type " << static_cast<int>(t) << ": the GUI must be the more permissive side (core "
-                    << b.core_px << ", gui " << b.gui_px << ")";
-      continue;
+    if (t == LensParam::kFisheyeStereographic) {
+      // No construction-level equality to assert here: the GUI has no guard and core's is a
+      // numerical cap. What makes the two masks equal is that the cap is unreachable — assert
+      // that, rather than the tautology core_px < gui_px = infinity.
+      EXPECT_GT(b.core_px, half_diag) << "stereographic: core's numerical cap must stay off-frame, or this "
+                                         "fixture is comparing a bound the GUI does not have";
+    } else {
+      EXPECT_NEAR(b.core_px, b.gui_px, 1e-3f)
+          << "type " << static_cast<int>(t) << ": the two domains are supposed to end on the same circle (core "
+          << b.core_px << ", gui " << b.gui_px << ")";
     }
+    // el = 90 (zenith) with `full`: every recovered direction passes the visibility rule, so the
+    // comparison is about the DOMAIN and nothing else.
+    ExpectIdentical(MakeCfg(t, 180.0f, w, h, RenderConfig::kFull, /*el=*/90.0f), "single fisheye fov=180");
+  }
 
-    const auto core = CoreMask(cfg);
-    const auto gui = GuiMask(cfg);
-    size_t core_only = 0;
-    size_t in_annulus_gui_off = 0;
-    size_t annulus = 0;
-    for (size_t i = 0; i < core.size(); ++i) {
-      const auto px = static_cast<float>(i % static_cast<size_t>(w)) + 0.5f - static_cast<float>(w) / 2.0f;
-      const auto py = static_cast<float>(i / static_cast<size_t>(w)) + 0.5f - static_cast<float>(h) / 2.0f;
-      const float r = std::sqrt(px * px + py * py);
-      if (core[i] != 0 && gui[i] == 0) {
-        ++core_only;
-      }
-      // Strictly between the two boundaries (excluding a one-pixel band at each, where a centre
-      // landing within a float ulp of the edge is a coin flip on both sides independently).
-      if (r > b.core_px + 1.0f && r < b.gui_px - 1.0f) {
-        ++annulus;
-        if (core[i] != 0) {
-          ADD_FAILURE() << "type " << static_cast<int>(t) << ": core must stop at the equator, but pixel " << i
-                        << " at r = " << r << " (core edge " << b.core_px << ") is in its mask";
-        }
-        if (gui[i] == 0) {
-          ++in_annulus_gui_off;
-        }
-      }
+  // Non-vacuity: equal-area's shared boundary (sqrt(2) image radii = 84.85 px here) falls between
+  // the frame's inscribed circle and its corners, so the frame really does contain pixels BOTH
+  // sides reject. Without this, "identical" could be satisfied by two masks that are both
+  // everywhere-on.
+  const auto ea = CoreMask(MakeCfg(LensParam::kFisheyeEqualArea, 180.0f, w, h, RenderConfig::kFull, 90.0f));
+  EXPECT_LT(CountOn(ea), ea.size()) << "equal-area at fov=180 must still reject the frame corners";
+}
+
+TEST(VisibleMaskGuiParity, SingleFisheyeAgreesOnTheWidenedRadialMapping) {
+  // Domain equality alone would still pass if one side mapped radius to theta differently past
+  // the old equator. Tilting the camera makes the `visible` cut a curve whose position depends on
+  // theta(r), so comparing `upper` / `lower` over the WIDENED region tests the mapping itself.
+  const LensParam::LensType types[] = { LensParam::kFisheyeEqualArea, LensParam::kFisheyeEquidistant,
+                                        LensParam::kFisheyeStereographic };
+  for (LensParam::LensType t : types) {
+    for (RenderConfig::VisibleRange vis : kAllRanges) {
+      ExpectIdentical(MakeCfg(t, 180.0f, 160, 120, vis, /*el=*/20.0f), "single fisheye fov=180, tilted");
     }
-    EXPECT_EQ(core_only, 0u) << "type " << static_cast<int>(t)
-                             << ": core must be a SUBSET of the GUI domain — a pixel core paints but the GUI "
-                                "rejects would be a genuine defect, not the known divergence";
-    EXPECT_GT(annulus, 0u) << "type " << static_cast<int>(t) << ": this fixture no longer covers the divergence";
-    EXPECT_EQ(in_annulus_gui_off, 0u) << "type " << static_cast<int>(t)
-                                      << ": the GUI stopped imaging the annulus between the two boundaries — the "
-                                         "divergence this test pins has changed shape";
   }
 }
 
 TEST(VisibleMaskGuiParity, OrthographicIsTheSingleFisheyeWhoseTwoBoundariesCoincide) {
-  // The divergence is not a property of "being a fisheye": it is the gap between core's equator
-  // and the GUI's asin guard, and for orthographic there is no gap. r = sin(theta) is not
-  // injective past the equator, so the shader's `s = r * sin(half_fov) > 1` guard rejects at
-  // exactly theta = 90 deg — the same place core's r <= 1 domain ends. Equal-area (sqrt(2)x),
-  // equidistant (2x) and stereographic (unbounded) all run further.
+  // Orthographic is the one member of the family whose two boundaries coincided even before the
+  // widening, and the one that must NOT be widened. r = sin(theta) is not injective past the
+  // equator (sin 120 deg == sin 60 deg), so the shader's `s = r * sin(half_fov) > 1` guard rejects
+  // at exactly theta = 90 deg — the same place core's r <= 1 domain ends and the same place its
+  // `cz <= 0` cull still stands. This test is what fails if a future change widens the family as
+  // a whole instead of per type.
   const float short_pix = 120.0f;
   const Boundaries b = BoundariesFor(LensParam::kFisheyeOrthographic, 180.0f, short_pix);
   EXPECT_NEAR(b.core_px, b.gui_px, 1e-3f) << "orthographic's two boundaries are supposed to be the same circle";


### PR DESCRIPTION
## 问题

`lm_proj::ProjectExitToPixel` 对 kLinear 之外的四种单镜头鱼眼**无差别地**做 `cz <= 0` 剔除，即 core 只渲染 θ ≤ 90°；`projection.cpp` 的 `Fisheye*Inverse` 的 `r ≤ 1` 定义域与之逐点重合。而 GUI 的 `fisheyeInverse` 守卫是 asin 定义域，覆盖 θ ≤ 180°。

半径比：等积 √2×、等距 2×、球极**无界**；**正交是唯一例外，两边界本就重合**（`r = sinθ` 在赤道取极大，scrum-469.2 实测 60px vs 60px）。

可见后果：宽视场下 CLI 的内容止于内切圆，GUI 预览还在 1.41× 半径处继续显示天空。

owner 裁定：**GUI 形态为准，责任在 core 侧**。

## 改动（⛔ 按 lens 分开，不是一律放宽）

| lens | 半径公式 | 处置 |
|---|---|---|
| equal_area | `2 sin(θ/2)` | 放开到 180° |
| equidistant | `θ` | 放开到 180° |
| stereographic | `2 tan(θ/2)` | 放开但带 fov 上限 `kFisheyeStereographicMinCz = cos(179.5°)`（θ→180 发散） |
| orthographic | `sin θ` | **维持 90° 封顶**——θ=90 取极大，θ=120 折回 θ=60 同一半径，结构上不可逆 |

`Fisheye*Inverse` 定义域同步放宽，并由 `SingleFisheyeCullAndInverseDomainAgree` 机械断言前向剔除与逆投影**逐点互逆**。

## 判据改动（设计如此，非绕开回归）

`test/unit-correctness/gui/test_visible_mask_gui_parity.cpp` 的对照闸判据从「core ⊆ GUI + 环带恒定」改为**「相等」**。那条闸钉的是「分歧的形状」，分歧消失后它必须变成等价断言——这正是需要的信号。

## 验证

- AC0 红态先行：等价断言在改动前跑红
- **三后端全部实测，未使用「诚实降级」分支**：CPU 本机 `test.sh pr` 全绿；Metal 本机 parity 12 passed；CUDA 远程参照机 parity 11 passed + 逐投影 battery 12 passed
- 顺带补上 `AGENTS.md` 点名的零 CI 覆盖缺口：**Windows + MSVC + CUDA + `BUILD_TEST=ON`** 真编一次，`BUILD_EXIT=0` / `INSTALL_EXIT=0`
- **参考图：穷举 9 个含单镜头鱼眼的参考 config，16 张全部无需重拍**，并由 e2e PSNR 测试独立佐证
- AC7 一手对照（起 worktree 到基线 commit 单独构建 CLI 做背景对照）：backlog §2 的症状**未被本次改动放大**（同构建 run-to-run 噪声内）；§2/§3 两条同族分歧按裁定不捎带，已记回 backlog
- rebase 到含 #290 后重跑组合态：`test.sh quick` RESULT: PASS（335/335），其中 #290 新建的 `single_lens_rectilinear` parity 场景 PSNR=33.27 dB / 阈值 31.5
- code review APPROVE（0 Critical / 0 Major）

## 连带兑现

task-467 的 GUI lens border 与 core 成像圆的 √2 差距消失；解除 `scrum-473` 的 `lens_border` 阻塞。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hzhUWaC4pkG3xyUzEQ3qG