### PR TITLE
feat(ci/doc): 测试时间预算的 owner —— 实测拓扑、分片重装箱、分层契约

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -620,6 +620,25 @@ jobs:
         # Trigger to redo it: the two legs differing by >=1.3x across 2-3 runs.
         # A single run is not enough — the same leg has been seen to swing 10-30%.
         #
+        # ⛔ Bin packing alone is NOT sufficient, and getting this wrong turns a
+        # leg RED, not merely slow. Two constraints sit on top of it:
+        #   (a) A file's cost is a property of the file AND its co-tenants, not
+        #       of the file. These tests saturate CPU/GPU, so moving one changes
+        #       the measured cost of the others: across two groupings the same
+        #       exit-seam file measured 594s and 749s, and projection-parity
+        #       measured 979s and 596s. Re-derive costs after every regrouping;
+        #       never carry a number across a regrouping.
+        #   (b) The capi_runner-based scenes impose a per-scene wall-clock limit
+        #       (`_TIMEOUT = 180` in the exit-seam and projection-parity tests,
+        #       passed to run_scene_capi_buffered). Starve one of CPU and it does
+        #       not run slower, it raises. Concretely: exit-seam parity and
+        #       test_capi_sentinel_overflow must not share a leg — the latter is
+        #       a single indivisible ~376s case that pins one worker for the
+        #       whole run, and pairing them made an exit-seam scene cross 180s.
+        # Practical rule when regrouping: keep the two heavyweight capi_runner
+        # parity files (exit-seam, projection) on opposite legs, and keep
+        # test_capi_sentinel_overflow off the exit-seam leg.
+        #
         # Why the legs are expressed differently: the "rest" leg has to keep
         # picking up newly added test files on its own, so it names test ROOTS
         # and subtracts the files moved away (--ignore does apply to those, since
@@ -642,12 +661,12 @@ jobs:
           - name: macOS ARM64 parity
             os: macos-15
             cache_key: macos-arm64
-            pytest_args: "test/parity-cross-backend/backend/test_metal_projection_parity.py test/parity-cross-backend/backend/test_metal_batch_invariance.py test/regression-sentinel/test_gpu_color_mask_batch_leak.py"
+            pytest_args: "test/parity-cross-backend/backend/test_metal_projection_parity.py test/regression-sentinel/test_capi_sentinel_overflow.py test/parity-cross-backend/backend/test_metal_batch_invariance.py test/regression-sentinel/test_gpu_color_mask_batch_leak.py"
 
           - name: macOS ARM64 rest
             os: macos-15
             cache_key: macos-arm64
-            pytest_args: "test/e2e-correctness test/parity-cross-backend test/performance test/gui test/regression-sentinel --ignore=test/parity-cross-backend/backend/test_metal_projection_parity.py --ignore=test/parity-cross-backend/backend/test_metal_batch_invariance.py --ignore=test/regression-sentinel/test_gpu_color_mask_batch_leak.py"
+            pytest_args: "test/e2e-correctness test/parity-cross-backend test/performance test/gui test/regression-sentinel --ignore=test/parity-cross-backend/backend/test_metal_projection_parity.py --ignore=test/regression-sentinel/test_capi_sentinel_overflow.py --ignore=test/parity-cross-backend/backend/test_metal_batch_invariance.py --ignore=test/regression-sentinel/test_gpu_color_mask_batch_leak.py"
 
     runs-on: ${{ matrix.os }}
     name: E2E Slow (${{ matrix.name }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -671,11 +671,24 @@ jobs:
           # Phase 1 — parallel (pytest-xdist, -n 3). xdist runs each test in a
           # separate WORKER PROCESS, so capi_runner's process-global os.environ +
           # log callback stay per-process isolated (validated: the full slow suite
-          # passes under -n 3, ~4min vs ~14min serial). The projection-parity
-          # tests (the bulk of the macOS "rest" leg) dominate wall-time; this is
-          # what keeps the leg under the step timeout. Throughput gates are
+          # passes under -n 3, ~4min vs ~14min serial). Throughput gates are
           # EXCLUDED here — they must not measure under concurrent GPU load.
-          pytest ${{ matrix.pytest_args }} --ignore=test/performance -n 3 -v -m slow
+          #
+          # That exclusion is done by dropping the token from the positional list,
+          # NOT by --ignore: pytest applies --ignore only to paths it DISCOVERS by
+          # recursing into a positional argument, never to a positional argument
+          # itself. Legs that list `test/performance` positionally therefore kept
+          # running the gates here under exactly the concurrent GPU load this
+          # comment forbids (measured with --collect-only: 2 perf cases collected
+          # in phase 1). The --ignore= flags already inside pytest_args stay — they
+          # name files reached by recursion, which is the case --ignore does cover.
+          phase1_args=""
+          for arg in ${{ matrix.pytest_args }}; do
+            if [ "$arg" != "test/performance" ]; then
+              phase1_args="$phase1_args $arg"
+            fi
+          done
+          pytest $phase1_args -n 3 -v -m slow
           # Phase 2 — serial + GPU-isolated: the throughput gates run alone so the
           # measured rate is not deflated by concurrent tests. Only legs whose args
           # include test/performance run this (the metal-exit-seam parity leg has

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -751,8 +751,9 @@ jobs:
           pytest $phase1_args -n 3 -v -m slow
           # Phase 2 — serial + GPU-isolated: the throughput gates run alone so the
           # measured rate is not deflated by concurrent tests. Only legs whose args
-          # include test/performance run this (the metal-exit-seam parity leg has
-          # no perf tests → skipped). Cheap (~2 gates); no -n on purpose.
+          # include test/performance run this (the leg named "parity" lists files
+          # explicitly and has no perf tests → skipped). Cheap (~2 gates); no -n
+          # on purpose.
           case "${{ matrix.pytest_args }}" in
             *test/performance*) pytest test/performance -v -m slow ;;
           esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -600,6 +600,39 @@ jobs:
         # core contention) to keep each leg's wall-clock under the step timeout
         # without bumping it high enough to drag overall PR latency. Ubuntu skips
         # all metal tests (Darwin guard) so it stays a single fast leg.
+        #
+        # HOW THE TWO macOS LEGS ARE BALANCED, and how to re-balance them. The
+        # groupings below are the answer to one past measurement, not a constant:
+        # every slow test added or removed shifts the load, so they go stale.
+        #
+        # Deriving them (repeat this when the legs drift apart):
+        #   1. `gh run view <run-id> --log` on the "Run slow E2E tests" step of
+        #      both macOS legs. Under `-v -n 3` every test prints a timestamped
+        #      `[gwN] [ x%] PASSED <test id>` line as it finishes, and an xdist
+        #      worker is serial internally, so the gap between two consecutive
+        #      lines from the SAME worker approximates the later test's duration.
+        #      Sum those per file. Job-level totals (`gh run view --json jobs`)
+        #      are NOT a substitute — they carry no per-file breakdown to pack.
+        #   2. Sort files by that cost descending and greedily place each one on
+        #      whichever leg is cheaper so far (longest-processing-time bin
+        #      packing). Replace BOTH lists with the result rather than patching
+        #      one of them: which grouping is optimal changes wholesale.
+        # Trigger to redo it: the two legs differing by >=1.3x across 2-3 runs.
+        # A single run is not enough — the same leg has been seen to swing 10-30%.
+        #
+        # Why the legs are expressed differently: the "rest" leg has to keep
+        # picking up newly added test files on its own, so it names test ROOTS
+        # and subtracts the files moved away (--ignore does apply to those, since
+        # they are reached by recursing into a root — see the phase-1 comment in
+        # the run step below for the case where --ignore does NOT apply). The
+        # other leg names files explicitly, the only way to say "just these".
+        # Consequence: a new slow test file lands on the "rest" leg by default.
+        #
+        # The `name:` fields are historical labels, not content classifications —
+        # the leg called "parity" carries the three heaviest GPU files and the
+        # "rest" leg carries the exit-seam parity test. They are left alone on
+        # purpose: they are branch-protection required-check names, so renaming
+        # them is a repository-settings change, not a workflow change.
         include:
           - name: Ubuntu x86_64
             os: ubuntu-24.04
@@ -609,12 +642,12 @@ jobs:
           - name: macOS ARM64 parity
             os: macos-15
             cache_key: macos-arm64
-            pytest_args: test/parity-cross-backend/backend/test_metal_exit_seam_parity.py
+            pytest_args: "test/parity-cross-backend/backend/test_metal_projection_parity.py test/parity-cross-backend/backend/test_metal_batch_invariance.py test/regression-sentinel/test_gpu_color_mask_batch_leak.py"
 
           - name: macOS ARM64 rest
             os: macos-15
             cache_key: macos-arm64
-            pytest_args: "test/e2e-correctness test/parity-cross-backend test/performance test/gui test/regression-sentinel --ignore=test/parity-cross-backend/backend/test_metal_exit_seam_parity.py"
+            pytest_args: "test/e2e-correctness test/parity-cross-backend test/performance test/gui test/regression-sentinel --ignore=test/parity-cross-backend/backend/test_metal_projection_parity.py --ignore=test/parity-cross-backend/backend/test_metal_batch_invariance.py --ignore=test/regression-sentinel/test_gpu_color_mask_batch_leak.py"
 
     runs-on: ${{ matrix.os }}
     name: E2E Slow (${{ matrix.name }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -639,6 +639,14 @@ jobs:
         # parity files (exit-seam, projection) on opposite legs, and keep
         # test_capi_sentinel_overflow off the exit-seam leg.
         #
+        # Because of (a), converging takes more than one CI run: each grouping
+        # has to be measured, and the measurement only describes that grouping.
+        # The three groupings tried here, by job duration (rest / parity):
+        #   sentinel+light | projection+batch_inv+color_mask   584 RED / 397
+        #   light          | +sentinel                         385 / 595  (1.55x)
+        #   +batch_inv     | projection+sentinel+color_mask     <- current
+        # Expect to spend a couple of runs this way rather than one.
+        #
         # Why the legs are expressed differently: the "rest" leg has to keep
         # picking up newly added test files on its own, so it names test ROOTS
         # and subtracts the files moved away (--ignore does apply to those, since
@@ -661,12 +669,12 @@ jobs:
           - name: macOS ARM64 parity
             os: macos-15
             cache_key: macos-arm64
-            pytest_args: "test/parity-cross-backend/backend/test_metal_projection_parity.py test/regression-sentinel/test_capi_sentinel_overflow.py test/parity-cross-backend/backend/test_metal_batch_invariance.py test/regression-sentinel/test_gpu_color_mask_batch_leak.py"
+            pytest_args: "test/parity-cross-backend/backend/test_metal_projection_parity.py test/regression-sentinel/test_capi_sentinel_overflow.py test/regression-sentinel/test_gpu_color_mask_batch_leak.py"
 
           - name: macOS ARM64 rest
             os: macos-15
             cache_key: macos-arm64
-            pytest_args: "test/e2e-correctness test/parity-cross-backend test/performance test/gui test/regression-sentinel --ignore=test/parity-cross-backend/backend/test_metal_projection_parity.py --ignore=test/regression-sentinel/test_capi_sentinel_overflow.py --ignore=test/parity-cross-backend/backend/test_metal_batch_invariance.py --ignore=test/regression-sentinel/test_gpu_color_mask_batch_leak.py"
+            pytest_args: "test/e2e-correctness test/parity-cross-backend test/performance test/gui test/regression-sentinel --ignore=test/parity-cross-backend/backend/test_metal_projection_parity.py --ignore=test/regression-sentinel/test_capi_sentinel_overflow.py --ignore=test/regression-sentinel/test_gpu_color_mask_batch_leak.py"
 
     runs-on: ${{ matrix.os }}
     name: E2E Slow (${{ matrix.name }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -617,8 +617,35 @@ jobs:
         #      whichever leg is cheaper so far (longest-processing-time bin
         #      packing). Replace BOTH lists with the result rather than patching
         #      one of them: which grouping is optimal changes wholesale.
-        # Trigger to redo it: the two legs differing by >=1.3x across 2-3 runs.
-        # A single run is not enough — the same leg has been seen to swing 10-30%.
+        # WHEN to redo it. The trigger is NOT how far apart the two legs are.
+        # A run's wall-clock is its longest job and nothing else, so evening the
+        # legs out is only worth CI time while one of them IS that longest job.
+        # Measured on the commit that produced the grouping below, taking the
+        # push run and the pull_request run of the same SHA together (neither
+        # alone carries every job: `build` is push-only, `e2e-slow` is PR/main):
+        #   Windows MSVC x86_64       740s  <- longest, this sets the wall-clock
+        #   shared-gui-test-build     666s
+        #   Ubuntu x86_64             635s
+        #   E2E Slow (macOS parity)   597s
+        #   E2E Slow (macOS rest)     391s
+        # Both macOS legs sit under that ceiling, so packing them closer buys
+        # ZERO wall-clock — the ceiling is somewhere else entirely. Trigger to
+        # redo the packing: either macOS leg becoming the longest job of a run.
+        # The ratio between the legs is a bad proxy for that and is recorded
+        # here only as a fact, not as a target: this grouping measured 1.28x and
+        # 1.53x on two runs of identical code (mean ~1.39x). A single run cannot
+        # judge either number — the same leg has been seen to swing 10-30%.
+        #
+        # A floor sits under the parity leg that no repacking removes:
+        # test_capi_sentinel_overflow is ONE indivisible case that pins a worker
+        # for the whole run (~204s in this grouping), leaving projection-parity's
+        # 12 evenly-sized cases (63-82s each) two workers, i.e. ~430s of
+        # makespan; with build and setup on top the leg lands near 600s. So at
+        # whole-file granularity the ratio cannot go far below ~1.4x no matter
+        # how the files are dealt. Going below it means splitting one file
+        # case-by-case, which costs the "both legs' union is unchanged" check
+        # the mechanical simplicity that makes it worth running — and per the
+        # numbers above, buys no wall-clock in exchange.
         #
         # ⛔ Bin packing alone is NOT sufficient, and getting this wrong turns a
         # leg RED, not merely slow. Two constraints sit on top of it:
@@ -633,8 +660,9 @@ jobs:
         #       passed to run_scene_capi_buffered). Starve one of CPU and it does
         #       not run slower, it raises. Concretely: exit-seam parity and
         #       test_capi_sentinel_overflow must not share a leg — the latter is
-        #       a single indivisible ~376s case that pins one worker for the
-        #       whole run, and pairing them made an exit-seam scene cross 180s.
+        #       a single indivisible case that pins one worker for the whole run
+        #       (376s while starved beside exit-seam, ~204s in the grouping that
+        #       shipped), and pairing them made an exit-seam scene cross 180s.
         # Practical rule when regrouping: keep the two heavyweight capi_runner
         # parity files (exit-seam, projection) on opposite legs, and keep
         # test_capi_sentinel_overflow off the exit-seam leg.
@@ -644,7 +672,8 @@ jobs:
         # The three groupings tried here, by job duration (rest / parity):
         #   sentinel+light | projection+batch_inv+color_mask   584 RED / 397
         #   light          | +sentinel                         385 / 595  (1.55x)
-        #   +batch_inv     | projection+sentinel+color_mask     <- current
+        #   +batch_inv     | projection+sentinel+color_mask     <- current,
+        #                                            479 / 615 then 391 / 597
         # Expect to spend a couple of runs this way rather than one.
         #
         # Why the legs are expressed differently: the "rest" leg has to keep

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,10 +146,13 @@ CMake build tree is `build/cmake_build/<flavor>/` and compiler output lands in
   `gui_test` is therefore **built on three platforms and run on one**: the `Ubuntu x86_64` leg of
   `.github/workflows/ci.yml` supplies a display with `xvfb-run` + Mesa's llvmpipe software
   rasterizer and runs the `modal_layout` and `defaults_panel_layout` reference groups there; the
-  macOS and Windows legs still only compile it. Which groups may run under a software rasterizer
-  is a measured fact, not a preference — the per-scene numbers, the reason `lens_proj` is
-  excluded despite its pixels being portable, and **the checklist a red in this layer obliges you
-  to follow instead of calling it a known flake** are all in `doc/testing-architecture.md` §4.6
+  macOS and Windows legs still only compile it. Those two groups are the whole of it — the filter
+  is **positive**, so the binary's other 36 categories (every `functional/` case and the entire
+  `parity/` tag among them) are evaluated on a developer machine and nowhere else. Which groups
+  may run under a software rasterizer is a measured fact, not a preference — the per-scene
+  numbers, the reason `lens_proj` is excluded despite its pixels being portable, and **the
+  checklist a red in this layer obliges you to follow instead of calling it a known flake** are
+  all in `doc/testing-architecture.md` §4.6
   (whose numbers, as that section itself flags, were measured on an arm64 proxy for the amd64
   runner this step actually runs on — read the caveat, not just the table).
   Read that before widening the CI filter, and before dispositioning a visual-regression failure.
@@ -219,7 +222,13 @@ CMake build tree is `build/cmake_build/<flavor>/` and compiler output lands in
   design is constrained by measured facts (only equal-area projections are comparable, since the
   CLI bakes the projection's solid-angle Jacobian and the GUI's resampling of an equal-area texture
   does not) rather than by preference. `doc/testing-architecture.md` §4.10 has the full statement,
-  including the CMake shape a second child-process test would need.
+  including the CMake shape a second child-process test would need. A fourth thing, easiest of all
+  to get wrong because it is invisible from a green pipeline: **no CI job runs this tag today**.
+  The one leg that executes `gui_test` names a positive filter of two reference groups that does
+  not include it, and the `E2E Slow` legs build with `-DBUILD_GUI=OFF` and have no such binary, so
+  `./scripts/test.sh {quick,full,pr}` on a machine with a GL context is the only place this fixture
+  is ever evaluated. `doc/testing-architecture.md` §7.5 has the mechanism, the measured cost of
+  enabling it, and why the llvmpipe leg is not currently the right home for it.
 - `scripts/check_loop_fatal_asserts.py` is a **fourth** diff-scoped entry point, alongside
   `check_policies.py`, `check_new_refs.py`, and `check_new_gui_tests.py` above (same "checker is
   the rule" discipline; CI `new-refs` job on PRs vs merge-base, pre-commit hook on the staged
@@ -267,6 +276,11 @@ CMake build tree is `build/cmake_build/<flavor>/` and compiler output lands in
     | Broader regression sweep — unsure how far a change reaches | `./scripts/test.sh full` |
     | Before opening a PR — reproduce the CI e2e-slow shape locally | `./scripts/test.sh pr` |
     | Confirm one specific gate/test actually fails on a deliberately-broken state (not a general sweep) | run that one check directly against the broken state, then again after the fix: `ctest -R <label>`, `pytest <file>::<test> -m ''`, or `gui_test --filter <name>` |
+
+    What each row **costs** in measured seconds, what each scope catches that the cheaper one is
+    structurally unable to report, and the budget rule naming who has to answer for the spend and
+    when, are in `doc/testing-architecture.md` §7. They are deliberately not duplicated here: two
+    copies of a measurement drift apart, and the copy in this table would be the stale one.
 
   - **Judgment discipline**: a command's exit code is the only thing that says pass/fail, and two
     common habits obscure it in different ways. A pipe (`cmd | tail`) leaves `$?` reporting
@@ -520,7 +534,7 @@ Valuable design/architecture docs live in `doc/` (tracked). Consult the relevant
     这个缺口一次攒下三处 MSVC 不兼容、三周无信号；它们已修，但缺口本身还在 ⇒ 动 `test/` 或
     `bench/` 后别拿 mac/Linux 的绿推断 Windows 也绿。
     与 `windows-remote-testing.md`（GUI VSync 物理桌面）场景正交。
-  - `testing-architecture.md` — **authoritative test-organization spec**: verification-purpose primary axis × subsystem tag, seven layers (unit-correctness / golden-analytic / parity-cross-backend / e2e-correctness / performance / gui / regression-sentinel), the "how to add a test" decision tree, cross-cutting rules (perf denominator = legacy CPU; parity metric-masks-bugs battery; reference ownership), and the layer×subsystem physical-layout blueprint. Read before adding or reorganizing any test.
+  - `testing-architecture.md` — **authoritative test-organization spec**: verification-purpose primary axis × subsystem tag, seven layers (unit-correctness / golden-analytic / parity-cross-backend / e2e-correctness / performance / gui / regression-sentinel), the "how to add a test" decision tree, cross-cutting rules (perf denominator = legacy CPU; parity metric-masks-bugs battery; reference ownership), and the layer×subsystem physical-layout blueprint. **§7 is the test-scope contract**: measured per-scope cost (local `quick`/`full`/`pr` and all 16 CI jobs), what each scope catches that the cheaper one structurally cannot, the budget rule (who declares expected test spend, and when they reconcile it), and why independent re-verification is a fixed-cost multiplier that makes cutting base suite cost worth more than its face value. Read before adding or reorganizing any test — and before claiming any change shortens CI.
 - **Engineering policy**: `env-var-policy.md` — **环境变量使用策略**: user-facing behavior switches must NOT live only in env vars (they cause silent per-machine drift / undebuggable bugs); use CLI/config/API instead. A-class runtime knobs (`LUMICE_TRACE_BACKEND` + 6 perf knobs, with file:line) vs B-class test/build infra (leave alone); three disposition rules; and the **decision gate to answer before adding any new `getenv`**. Read before introducing a new env knob.
 - Example config: `examples/config_example.json`
 

--- a/doc/testing-architecture.md
+++ b/doc/testing-architecture.md
@@ -1077,3 +1077,263 @@ double gate (267.3 corr-blind reinforcement), `test_capi_sentinel_overflow.py` a
 
 > **Legacy CPU red line**: legacy CPU is the parity ground truth (§1.4, §4.2) and the perf
 > denominator (§1.6, §4.1). It and its tests are **never** a cleanup target in any layer.
+
+---
+
+## §7 Test-scope contract: what each scope costs, and what it additionally catches
+
+§1–§6 say where a test belongs. This section says what running them **costs**, what each scope
+**buys over the one below it**, and who is required to do that arithmetic before spending it. It
+exists because the scope table in `AGENTS.md` answers "which command do I run" without answering
+"what does it cost and what does the cheaper one structurally miss" — and a recommendation to run
+the cheap scope first is only followed by someone who knows what the cheap scope cannot see.
+
+### §7.0 What this section covers, and what it does not
+
+This is **not** an audit of the suite, and must not be cited as one. It looks at the head of the
+cost distribution and states the tail it did not look at:
+
+- **Covered in depth**: the three local scopes end to end, and the 8 CI jobs of 391s or longer —
+  4427s of the 5089s of machine time in §7.1's table, i.e. **87%**.
+- **Listed but not analyzed**: the 8 remaining CI jobs, together 662s, i.e. **13%**. Four are
+  second-scale gates (`policy` 24s, `format-check` 13s, `new-refs` 8s, `benchmark-summary` 7s) and
+  three are compile-only jobs (`windows-cuda-compile` 225s, `cuda-compile` 141s, `bench-compile`
+  63s) whose duration says nothing about which tests should run, plus `Ubuntu ARM64` (181s), the
+  cheapest leg of the build matrix. Both proportions are recomputable from that table.
+- **Not enumerated at all**: the individual cases inside a scope. `gui_test` runs 344 cases across
+  38 categories (338 in its correctness pool, 6 in the real-timing pool, per the binary's own run
+  summary); the fast e2e set collects 92; neither was gone through case by case. One
+  measured statement about that distribution is worth carrying, because it bounds what scheduling
+  can achieve: in the fast e2e set, a single case (`test_smoke.py::test_all_configs_run_successfully`,
+  87.3s) accounts for 92% of the whole set's 94.8s parallel wall clock. Below that one test, no
+  amount of parallelism makes the set faster.
+
+### §7.1 What each scope costs
+
+**Local.** Machine: the development Mac that `doc/machines.md` binds to the **Metal reference
+machine** role — Apple silicon, macOS ARM64, 12 logical cores (8 performance). Read every local
+figure below as a property of that machine and not of the suite; `doc/machines.md` is the single
+source for which host holds which role, and a different host moves all of them. Cache state: **warm** static build
+tree at the measured commit — `scripts/test.sh` does not build the static flavor, so no compile
+time is inside these numbers. Concurrency as noted per layer. Machine otherwise idle (load average
+2.2 at the start of the run).
+
+| Scope | Layer | Wall clock | Concurrency |
+|---|---|---|---|
+| `quick` | `ctest -L "unit-correctness\|composition-correctness\|parity\|golden-analytic"` | 36s | ctest default |
+| `quick` | fast e2e (`pytest`, `-m "not slow"` via `pyproject.toml` `addopts`) | 96s | `-n auto` → 12 workers |
+| `quick` | `gui_test` correctness pool (`--fixed-dt`, negative filter) | 47s | single process |
+| | **`quick` total** | **179s** | |
+| `full` | `quick` + `gui_test` real-timing pool (no `--fixed-dt`, positive filter) | +11s | single process |
+| | **`full` total** | **190s** | |
+| `pr` | `full` + shared-lib build (the flavor was absent: cold configure + 43 TUs + install) | +14s | 12-way build |
+| `pr` | slow e2e phase 1 (`pytest --ignore=test/performance -n 3 -m slow`) | 361s | `-n 3` |
+| `pr` | slow e2e phase 2 (throughput gates, alone so they do not measure under load) | 14s | serial, single process |
+| | **`pr` total** | **627s** | |
+
+Three things the `pr` row does not show on its face. **The shared-library layer is not a constant**:
+it cost 14s here because the shared flavor did not exist and had to be built (43 translation units,
+no GUI, no tests, CPM dependencies already cached), and on any later run in the same tree it is a
+freshness check costing effectively nothing — so the first `pr` of a session and the ones after it
+are different prices. **Phase 1 skipped 29 of its 109 collected items** (80 passed): the backend
+guards deselect what the machine cannot run, so this figure is what a Metal-capable Mac pays, not
+what the set costs everywhere. **The layers sum to 579s against a 627s wall clock**; the ~48s
+difference is the script's own preconditions — the static build-tree and `addopts` checks, the
+extraction of the two `gui_test` filters from `scripts/build.sh`, and the probe that asks
+`test/e2e/capi_runner.py` which library the slow layer would load — none of which is a test.
+
+A standalone `quick` measured 172s on the previous day on the same machine, against 179s inside
+this run: treat single-run figures here as accurate to roughly ±5%, not better.
+
+**Compile is not in the table above, and is not negligible.** Measured on the same machine:
+a cold configure-plus-build of the static flavor with GUI and tests is **167s**; an incremental
+rebuild after touching one leaf `.cpp` is **33s**; after touching `src/core/math.hpp`, included by
+63 translation units, **49s**. So the honest first-run cost of `quick` on a cold tree is about
+350s, and its steady-state cost during an edit-test loop is about 210s.
+
+**CI.** Runners: GitHub-hosted, per job (`ubuntu-24.04`, `ubuntu-24.04-arm`, `macos-15`,
+`windows-2025`; the CUDA compile leg uses `windows-2022`). Cache state:
+CPM dependencies come from `actions/cache`, so warmth **depends on that run's cache hit** and is
+not guaranteed; nothing else is cached between runs. Concurrency: the jobs below run in parallel as
+a matrix, so the run's wall clock is its **longest job**, not the sum; within a job, the fast e2e
+leg runs `pytest` serially and the slow e2e legs run `-n 3` (with the throughput gates re-run
+serially afterwards, so they do not measure under load).
+
+The figures are the union of a push run and a pull-request run of the same commit (`495c6f6b`),
+because neither event alone runs every job: the build matrix, `policy` and `format-check` are
+push-only, while `e2e-test`, the `E2E Slow` legs and `new-refs` run on pull requests and `main`.
+
+| CI job | Seconds | In §7.0's covered head? |
+|---|---|---|
+| Windows MSVC x86_64 | **740** | yes — longest job, sets the run's wall clock |
+| shared-gui-test-build | 666 | yes |
+| Ubuntu x86_64 | 635 | yes |
+| E2E Slow (macOS ARM64 parity) | 597 | yes |
+| e2e-test | 512 | yes |
+| macOS ARM64 | 464 | yes |
+| E2E Slow (Ubuntu x86_64) | 422 | yes |
+| E2E Slow (macOS ARM64 rest) | 391 | yes |
+| windows-cuda-compile | 225 | no — compile-only |
+| Ubuntu ARM64 | 181 | no |
+| cuda-compile | 141 | no — compile-only |
+| bench-compile | 63 | no — compile-only |
+| policy | 24 | no — second-scale gate |
+| format-check | 13 | no — second-scale gate |
+| new-refs | 8 | no — second-scale gate |
+| benchmark-summary | 7 | no — second-scale gate |
+| | **5089s total machine time** | head = 4427s (87%) |
+
+Where a job's time goes differs by job, and the split cannot be assumed. Step-level timestamps
+from an earlier run of the same shape: `Windows MSVC x86_64` was 78% compile (568s of 726s);
+`shared-gui-test-build`, which runs nothing, 92% compile (589s of 641s); `E2E Slow (macOS rest)`
+was 8% compile and **89% test execution** (612s of 686s); `e2e-test` 84% test execution (377s of
+450s). Those percentages come from a different run than the totals above and are shape, not
+precision.
+
+**Two facts about this table that any CI-time proposal has to answer to.**
+
+1. **The critical path is `Windows MSVC x86_64` (740s) and, behind it, `shared-gui-test-build`
+   (666s).** A run's wall clock is its longest job and nothing else. Therefore: *any proposal to
+   "shorten CI" that does not touch those two jobs buys zero wall clock*, however much machine time
+   it saves. Anywhere a claim of the form "this saves N seconds of CI" is made — in a plan, a PR
+   description, or a review comment — it must first answer **"does it shorten the longest job?"**.
+   The corollary that keeps catching people: rebalancing two shards against each other is worth CI
+   time only while one of them **is** the longest job. The two `E2E Slow` macOS legs sit 143s and
+   349s under the ceiling, so packing them closer is currently worth nothing (`ci.yml`'s `e2e-slow`
+   matrix comment carries the same statement next to the code it constrains).
+2. **A floor sits under the `E2E Slow (macOS ARM64 parity)` leg that no repacking removes.**
+   `test_capi_sentinel_overflow` is **one indivisible pytest case** (3 configs × 12 rounds inside a
+   single function) that pins one xdist worker for the leg's whole duration — ~204s in the grouping
+   that shipped — which is what puts that leg near 600s. Splitting files across legs cannot go below
+   it; only splitting that case could. Quote this number **with its grouping**: the case's cost is a
+   property of the file *and its co-tenants*, and the same case measured 376s when it was starved
+   beside the exit-seam parity file. Costs never survive a regrouping; re-derive them after one.
+
+### §7.2 What each scope catches that the one below it cannot
+
+The three local scopes are strictly nested (`quick` ⊂ `full` ⊂ `pr`), so each answer below is about
+the increment. The answers are mechanisms, not directory lists — the point of each scope is a class
+of defect the cheaper scope is *structurally* unable to report, not merely a set of files it skips.
+
+**`quick` → `full`: wall-clock-dependent behaviour.** `quick` runs `gui_test` with `--fixed-dt`,
+which injects a deterministic 1/60s frame delta. Six cases depend on real elapsed time: the two
+in the `perf_test` category (main-loop FPS and rays-per-second), an accumulation gated on a
+wall-clock deadline rather than a frame count, a background thread that only advances between real
+`ctx->Yield()` calls, and two more of the same shape. `scripts/build.sh` names them twice — once as
+a negative filter (one category, four case names) for the correctness pool, once as the positive
+filter for the real-timing pool — which is the mechanical statement of what `quick` withholds.
+Under `--fixed-dt` those cases are not skipped; they are **starved**, and a starved assertion
+produces a *wrong answer*, not a missing one. That is why they are a separate pool rather than a
+slower part of the same one, and it is the reason a green `quick` is **not evidence** about this
+class: the scope did not fail to reach the question, it answered it from a state that cannot be
+right. The increment costs 11s — about 6% on top of
+`quick`, the cheapest step in this whole table.
+
+**`full` → `pr`: the shared-library route, and the `slow` set.** Two distinct additions.
+*(a)* Everything marked `@pytest.mark.slow` is excluded from `quick` and `full` structurally, by
+`pyproject.toml`'s `addopts = ["-m", "not slow"]` — the cross-backend parity batteries, the
+throughput gates, and the issue-repro sentinels (§6's "do not touch" list) are all in there. *(b)*
+More importantly, `pr` is the **only** local scope in which the library is loaded as a library:
+those tests drive `liblumice` through `ctypes` (`test/e2e/capi_runner.py`), so the export surface,
+the dynamic-symbol resolution, the rpath and the C API's cross-boundary object lifetimes are
+exercised here and nowhere else. `quick` and `full` link the same sources into a test binary, which
+cannot see a defect in how the code is *packaged*. The scope carries a freshness layer for exactly
+this reason: a stale `.dylib` silently tests old code and reports green, so `pr` refuses to trust a
+library it cannot prove is newer than its sources.
+
+**`pr` → CI: the platform matrix, and only that.** CI adds MSVC, x86_64 and ARM64 Linux, and a
+software rasterizer (Xvfb + Mesa llvmpipe) that renders GUI reference scenes without a GPU. None of
+these is reproducible from one developer machine, and the compiler dimension is where they earn
+their keep: `AGENTS.md` records three MSVC incompatibilities that a Clang-only local run could not
+have seen, and that sat undetected for weeks behind platform guards.
+
+**But the containment does not run the other way, and this is the trap.** CI is *not* a superset of
+`pr`. The one CI leg that runs `gui_test` passes a hand-picked **positive** filter naming two
+reference groups, so **2 of that binary's 38 categories run in CI**; the local scopes select by a
+**negative** filter, so every category runs locally — `quick` withholds the one category and four
+cases named above, `full` withholds nothing. For the other 36 categories, including every
+functional case and the whole `parity` tag (§7.5), a developer machine is the only place the
+assertion is ever evaluated. A green CI is not evidence about them.
+
+### §7.3 The budget rule: who answers, and when
+
+The rule below exists because the alternative is the state this section was written out of: every
+individual decision to add a test is locally justified, no one is ever asked what the total costs,
+and the total only grows. The burden of proof therefore sits on the side that spends.
+
+1. **Whoever proposes a change states its expected test spend in the written plan, before
+   implementation starts**: which scopes it will run, how many times, and the estimated wall clock.
+   "I cannot estimate this" is an acceptable answer and should be written down as such. Writing
+   nothing is not acceptable.
+2. **The same person reconciles it at close-out**, in the description of the PR that lands the
+   change: actual against estimate. If the actual exceeds the estimate by more than about 1.5×,
+   record the deviation and its cause — **do not retro-fit the estimate to what happened**, which
+   destroys the only signal this rule produces.
+3. **Whoever reviews the plan checks that declaration 1 is present**; whoever reviews the code
+   checks that reconciliation 2 is present. Neither is a judgement about whether the number is big;
+   both are a check that the question was asked.
+
+The rule is deliberately about *stating and reconciling*, not about staying under a limit. There is
+no budget ceiling to enforce, and inventing one would only produce estimates shaped to fit it.
+
+This section is the first change written under the rule, and it says so rather than presenting the
+rule as established practice: earlier changes in this repository carry no such declaration, and none
+was back-filled for them.
+
+### §7.4 Independent re-verification is a fixed-cost multiplier
+
+**The rule.** A change's own report about itself does not settle whether the work is done. An
+independent pass — someone, or some agent, that did not do the work re-asking whether it meets what
+was asked — is a required step, not an optimization to be dropped when the evidence looks tidy.
+
+**It cannot be replaced by an evidence chain.** This is the substitution that keeps getting
+proposed: attach the logs, the run ids, the commit hashes, and let provenance stand in for the
+second pass. It does not work, because the two answer different questions. A provenance chain
+proves *this output came from that run*. Re-verification asks *whether that run asked the right
+question*. Classes of defect that have actually been caught this way in this repository, none of
+which any amount of provenance could have caught: a self-reported severity that did not match how
+reachable the defect was for a user; a self-reported execution path that was the **opposite** of
+what the configuration file's filter actually did; and a self-reported direction of net change that
+measurement contradicted. In each, the logs were genuine and the run was real. The report about
+them was wrong.
+
+**The consequence, and the reason this sits next to the cost tables.** Because re-verification is
+required and re-reads the same ground, it behaves as a **fixed-cost multiplier** on the suite:
+whatever the base costs, the delivered cost of a change is that base taken more than once. Two
+things follow, and they are the practical output of this whole section:
+
+- Every second removed from the base is removed again under the multiplier. **Cutting base suite
+  cost is worth more than its face value** — this is the argument for §7.0's observation that one
+  87.3s case sets the floor of a 94.8s set.
+- Optimizing scheduling, sharding or parallelism **without** cutting the base leaves the multiplied
+  portion untouched. That is why §7.1's fact 1 is stated as a gate: rebalancing moves work between
+  machines; it does not remove work, so the multiplier keeps charging for it.
+
+### §7.5 Where the `parity` tag runs, and why not in CI
+
+§4.10 introduces `test/gui/parity/`; this is the platform-reach half of it, stated once here and
+pointed at from the other two places that describe it (`AGENTS.md`, and the fixture's own header
+comment in `test/gui/parity/test_gui_cli_export_parity.cpp`).
+
+**Where it runs today.** Nowhere in CI, and this is a mechanical fact of `.github/workflows/ci.yml`,
+not an inference: the single step that executes `gui_test` runs
+`xvfb-run -a … gui_test --fixed-dt --filter "modal_layout,defaults_panel_layout" --no-user-config`
+inside the `Ubuntu x86_64` leg — a positive filter naming two categories, of which `parity` is not
+one — and the three `E2E Slow` legs configure with `-DBUILD_TEST=OFF -DBUILD_GUI=OFF`, so they do
+not have the binary at all. Where it does run is a developer machine with a working GL context:
+`scripts/build.sh`'s correctness pool selects by a negative filter, so the category is included by
+default and `./scripts/test.sh {quick,full,pr}` executes it. Read that as §7.2's last paragraph
+applied to one tag: **a green CI is not evidence about this fixture.**
+
+**Why it is not enabled under llvmpipe today.** Not because of cost. The fixture asserts an *exact*
+equality on the simulated ray count, through the shared `ExpectedSimRayNum()` helper in
+`test/gui/test_gui_shared.hpp` — structurally the same assertion shape as `lens_proj`, which §4.6
+excludes from the CI filter because that count comes up short under the software rasterizer for an
+upstream reason that is still unfixed. Enabling `parity` there would re-import that known defect as
+a red in a required check. For scale, the cost if it were enabled is not the blocker either: the
+`parity` filter takes 24.6s on the 12-core machine of §7.1, which extrapolates to roughly 70–90s on
+a 4-vCPU runner — **an extrapolation, not a measurement** — and it would land inside the
+`Ubuntu x86_64` leg, which sits at 635s — 105s below the `Windows MSVC` ceiling — so by §7.1's
+fact 1 it would still cost close to zero wall clock. The blocker is the known red, so the sequence
+is: close the upstream ray-count shortfall first, re-measure on a real runner, then widen the
+filter. Widening it is a measurement, not an edit.


### PR DESCRIPTION
## 立项理由

owner 原话：CI 已经很长，本地开发一次任务光测试就要几十分钟到一小时。但判定这不该按「给它加一条 CI」处理——那等于又开一次**没有预算的口子**。

根因与代码膨胀同源：**没有人拥有测试时间的预算**。每笔加测试都局部正当，而从来没有人被要求回答「这一笔花了多少、该拿掉什么」。

## ⭐ 最值钱的结果：立项直觉被实测推翻

**关键路径的大头是编译，不是测试。** 逐 step 时间戳：

| job | 编译占比 |
|---|---|
| `Windows MSVC x86_64`（740s，全场最长） | **78% 编译**（568s / 726s） |
| `shared-gui-test-build`（666s，第二）| **92% 编译**（589s / 641s，且它一个测试都不跑） |
| `E2E Slow (macOS rest)` | 8% 编译，**89% 测试执行** |

⇒ **「精简测试」对关键路径无效**。这条现在写进了 `doc/testing-architecture.md` §7.1，并配了一条可执行判据：任何「这能省 N 秒 CI」的主张——无论出现在 plan、PR 描述还是评审意见里——**必须先回答「它缩短了最长的那个 job 吗」**。

## 三个子任务

- **477.1**（explore）时间拓扑普查：上表 + 本地 `quick`=172s 与 owner 感知「十多分钟」的差额归属 + `export_parity` 进不进 CI 的裁定
- **477.2** macOS 两条 E2E Slow 分片按**实测逐文件耗时**三轮重装箱（含 co-tenancy 硬约束——同腿邻居会互相饿死，不只是配平）；顺带修掉一个真缺陷：phase-1 对吞吐 gate 的排除失效（`--ignore` 对位置参数无效）
- **477.3** 分层契约落盘：每档实测耗时 / 每档比下一档多抓什么 / 预算规则 / 独立复核乘数

## ⚠️ 一条声明未达成的收益，如实记录

issue 原本声明「配平后关键路径掉约 230s」。**未达成，且不可能由分片配平达成**——两条 macOS 腿分别在天花板下 143s 和 349s，压近它们买到 0 秒。

AC1 原判据「两腿比值 ≤1.3×」在第二次独立 CI run 上被推翻（1.28× / 1.53×，均值 1.39×），经裁决判为**坏代理量**（a16：它推导不到「缩短关键路径」这个目标语义），替换为可推导的 AC1'：**两条腿均不得成为该 run 的最长 job**。⛔ 未授权为了凑那个数去做 case 级拆分——那要推翻 plan-review 已核可的决策点，而理由只是「达到一个买不到收益的数字」。

## 另一条不可移除的地板

`test_capi_sentinel_overflow` 是**一个不可再分的 pytest 用例**（3 configs × 12 rounds 在同一个函数里），单独钉住一个 xdist worker 全程 ~204s，这就是 parity 腿接近 600s 的原因。文件级重划分无法低于它。⚠️ 该数字**必须连同它的分组一起引用**：同一用例在与 exit-seam parity 文件同腿被饿死时测得 376s——成本从不跨分组存活。

## ⛔ 立项时定的两条硬约束，均已遵守

- **不得以「梳理完备」为交付判据**（PR #261 先例：预先承诺 −30% 落到 −8.7%，其中 1000–1500 行来自「20 个面板零遗漏」这类完备性主张）。本 PR 按时间排序取头部，尾部显式声明不看。
- **owner 独立复核不可省**，⛔ 不得提议用「可核验证据链」替代它——hash 链证明的是出处，不是判断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hzhUWaC4pkG3xyUzEQ3qG