### PR TITLE
test(e2e): smoke 按 config 拆成独立 pytest item —— 收集粒度对齐调度粒度，零覆盖损失

### DIFF
--- a/doc/testing-architecture.md
+++ b/doc/testing-architecture.md
@@ -1102,11 +1102,18 @@ cost distribution and states the tail it did not look at:
   cheapest leg of the build matrix. Both proportions are recomputable from that table.
 - **Not enumerated at all**: the individual cases inside a scope. `gui_test` runs 344 cases across
   38 categories (338 in its correctness pool, 6 in the real-timing pool, per the binary's own run
-  summary); the fast e2e set collects 92; neither was gone through case by case. One
+  summary); the fast e2e set collects 105; neither was gone through case by case. One
   measured statement about that distribution is worth carrying, because it bounds what scheduling
-  can achieve: in the fast e2e set, a single case (`test_smoke.py::test_all_configs_run_successfully`,
-  87.3s) accounts for 92% of the whole set's 94.8s parallel wall clock. Below that one test, no
-  amount of parallelism makes the set faster.
+  can achieve — and the shape of that bound is itself worth knowing. It used to be a single case:
+  `test_smoke.py` ran every showcase config inside one `test_all_configs_run_successfully` item,
+  which at 87.3s accounted for 92% of the whole set's 94.8s parallel wall clock. `subTest` made
+  that look like 14 cases in the report, but xdist distributes by *collected item*, so all 14
+  configs were pinned to one worker no matter how many were free. Splitting it into one item per
+  config (`test_config_<stem>`) removed the pin without touching a single assertion — measured
+  wall clock fell while total `user` CPU stayed flat, which is the evidence that nothing was
+  dropped, only repacked. The general form is worth carrying past this one case: **a loop inside
+  a test item is invisible to the scheduler, and a report that shows N sub-cases does not mean
+  the runner sees N items.**
 
 ### §7.1 What each scope costs
 

--- a/test/e2e-correctness/test_smoke.py
+++ b/test/e2e-correctness/test_smoke.py
@@ -93,59 +93,50 @@ def _discover_configs():
 class TestSmoke(LumiceTestCase):
     """Smoke tests: run every config and verify basic outputs."""
 
-    def test_all_configs_run_successfully(self):
-        """Every config should exit 0, produce non-empty images of correct size and PSNR."""
-        configs = _discover_configs()
-        self.assertTrue(len(configs) > 0, "No configs found in test/e2e/configs/")
+    def _check_one_config(self, cfg_path):
+        """Run one config and verify exit code, outputs and PSNR."""
+        config_name = cfg_path.stem
+        result = self.run_lumice(
+            ["-f", str(cfg_path), "-o", self.output_dir]
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"{config_name} failed:\n{result.stderr}",
+        )
 
-        for cfg_path in configs:
-            config_name = cfg_path.stem
-            with self.subTest(config=config_name):
-                result = self.run_lumice(
-                    ["-f", str(cfg_path), "-o", self.output_dir]
-                )
-                self.assertEqual(
-                    result.returncode,
-                    0,
-                    f"{config_name} failed:\n{result.stderr}",
-                )
+        # Check output files exist and are non-empty
+        output_imgs = sorted(
+            glob.glob(os.path.join(self.output_dir, "img_*.jpg"))
+        )
+        self.assertTrue(
+            len(output_imgs) > 0,
+            f"{config_name}: no output images in {self.output_dir}",
+        )
 
-                # Check output files exist and are non-empty
-                output_imgs = sorted(
-                    glob.glob(os.path.join(self.output_dir, "img_*.jpg"))
-                )
-                self.assertTrue(
-                    len(output_imgs) > 0,
-                    f"{config_name}: no output images in {self.output_dir}",
-                )
+        for img_path in output_imgs:
+            size = os.path.getsize(img_path)
+            self.assertGreater(
+                size, 0, f"{img_path} is empty"
+            )
 
-                for img_path in output_imgs:
-                    size = os.path.getsize(img_path)
-                    self.assertGreater(
-                        size, 0, f"{img_path} is empty"
-                    )
+            if HAS_PILLOW:
+                # Check PSNR against reference image
+                renderer_id = Path(img_path).stem.split("_")[-1]
+                ref_name = f"{config_name}_{renderer_id}.jpg"
+                ref_path = REFERENCES_DIR / ref_name
+                threshold_key = f"{config_name}_{renderer_id}"
 
-                    if HAS_PILLOW:
-                        # Check PSNR against reference image
-                        renderer_id = Path(img_path).stem.split("_")[-1]
-                        ref_name = f"{config_name}_{renderer_id}.jpg"
-                        ref_path = REFERENCES_DIR / ref_name
-                        threshold_key = f"{config_name}_{renderer_id}"
-
-                        if ref_path.exists() and threshold_key in PSNR_THRESHOLDS:
-                            threshold = PSNR_THRESHOLDS[threshold_key]
-                            if threshold is not None:
-                                mse = compute_mse(img_path, str(ref_path))
-                                psnr = compute_psnr(mse)
-                                self.assertGreaterEqual(
-                                    psnr,
-                                    threshold,
-                                    f"{ref_name}: PSNR {psnr:.1f} dB < threshold {threshold} dB",
-                                )
-
-                # Clean output_dir for next config
-                for f in glob.glob(os.path.join(self.output_dir, "*")):
-                    os.remove(f)
+                if ref_path.exists() and threshold_key in PSNR_THRESHOLDS:
+                    threshold = PSNR_THRESHOLDS[threshold_key]
+                    if threshold is not None:
+                        mse = compute_mse(img_path, str(ref_path))
+                        psnr = compute_psnr(mse)
+                        self.assertGreaterEqual(
+                            psnr,
+                            threshold,
+                            f"{ref_name}: PSNR {psnr:.1f} dB < threshold {threshold} dB",
+                        )
 
     def test_stdout_contains_stats(self):
         """Lumice stdout should contain Stats: and Saved: lines."""
@@ -159,3 +150,24 @@ class TestSmoke(LumiceTestCase):
         self.assertEqual(result.returncode, 0)
         self.assertIn("Stats:", result.stdout)
         self.assertIn("Saved:", result.stdout)
+
+
+def _make_config_test(cfg_path):
+    def _test(self):
+        self._check_one_config(cfg_path)
+
+    _test.__name__ = f"test_config_{cfg_path.stem}"
+    _test.__doc__ = f"{cfg_path.stem}: exits 0, produces non-empty images, PSNR >= threshold."
+    return _test
+
+
+# One pytest item per config, rather than one item looping over all of them: xdist
+# distributes by item, so a single looping item pins every config to one worker and
+# becomes the whole set's wall clock. `unittest.TestCase` methods cannot be driven by
+# @pytest.mark.parametrize (pytest does not support it there), hence the setattr
+# generation below. The assert makes "discovered nothing" an import-time hard failure
+# instead of a silent collection of zero cases.
+_CONFIGS = _discover_configs()
+assert _CONFIGS, "No configs with reference images found in test/e2e/configs/"
+for _cfg in _CONFIGS:
+    setattr(TestSmoke, f"test_config_{_cfg.stem}", _make_config_test(_cfg))


### PR DESCRIPTION
起点是 scrum-477 量到的一个数：fast e2e 的并行墙钟里，`test_smoke.py::TestSmoke::test_all_configs_run_successfully` 单项占 **87.30s / 94.76s（92%）**，是整条套件的硬下限。

## 结论：不是覆盖太多，是收集粒度不对

它是**一个** pytest item，内部 `for cfg_path in configs` 串行遍历 14 个 config。`subTest` 只改**报告**粒度，不改**收集**粒度——而 xdist 按 **item** 分发 ⇒ 这 14 个 config 恒定钉在同一个 worker 上，加多少并行度都没用。

⇒ 拆成「每 config 一个 item」。**断言体、`PSNR_THRESHOLDS` 阈值表、`_discover_configs()` 逐字不动**。scrum 立下的「任何精简必须先证明砍的是时间不是覆盖」这条纪律，最终的答案是**什么都没砍**。

实现上不能用 `@pytest.mark.parametrize`——pytest 不支持参数化 `unittest.TestCase` 的方法。改用模块末尾 `setattr` 动态挂载 `test_config_<stem>`，闭包传参避开晚绑定。顺带加 `assert _CONFIGS`，让「一个 config 都没发现」从静默收集 0 项变成导入期硬失败。

## 验证

| 判据 | 结果 |
|---|---|
| 收集粒度 | 15 items（14 × `test_config_<stem>` + `test_stdout_contains_stats`），与 `_discover_configs()` 返回集合逐一核对相等（非硬编码 14） |
| 功能不回归 | `./scripts/test.sh quick` 净机 `RESULT: PASS`；fast e2e 91 passed → **104 passed**，skip 数不变 |
| 改动范围 | 只有 `test_smoke.py` 一个文件；阈值表 / config / 参考图均未触碰 |
| 墙钟与 CPU | 净机同机同 `-n auto` 前后各 2 轮：墙钟 **−9.76% / −5.10%**，`user` CPU **+1.85%** |
| 护栏红态 | 临时让 `_discover_configs()` 返回空 → `assert _CONFIGS` 收集期硬失败，探针已还原 |

⭐ **`user` CPU 总量前后不变，是「零覆盖损失」的机制层证据**：没有工作消失，只是被重新打包。若拆分砍掉了覆盖，`user` 会跟着掉。这比「断言逐字没改」的黑盒自洽强一档。

## 诚实边界（必读）

- ⛔ **本改动不缩短 CI。** `ci.yml:584` 的 fast leg 装的是 `Pillow pytest numpy`，**没有 pytest-xdist**；`:590` 是 `pytest -v -m "not slow"`，**无 `-n`** ⇒ xdist 惰性、串行、零收益。`:780` 的 `-n 3` 只作用于 `-m slow`，smoke 未打该标。收益**仅限本地** `./scripts/test.sh {quick,full,pr}`。
- 另有一组 −20~25% 的数字来自 explore 阶段更净的窗口，与上表的 −5~10% 差异**来自测量时机器负载不同，不是矛盾**（本机是日常使用机，期间有多条并行 drive）。两组数不可跨条件互相替代。
- **收益已接近上限**：整套已 CPU 饱和，`user`/12 ≈ 75s 的理论下限 vs 实测 103s（1.37×）。再要墙钟只能减少 CPU 总量（= 砍覆盖）或加核。

`doc/testing-architecture.md` §7 同步更新：那条引用的测试全名已随拆分消失，收集数 92→105；并把该段从**一个数字**改写成**一条判据**——循环对调度器不可见，报告里的 N 个 sub-case ≠ runner 看见 N 个 item。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hzhUWaC4pkG3xyUzEQ3qG