### PR TITLE
test(gui-unit): 心跳用例改 wait-until，墙钟余量 250ms → 秒级

### DIFF
--- a/test/unit-correctness/gui/test_server_poller.cpp
+++ b/test/unit-correctness/gui/test_server_poller.cpp
@@ -772,13 +772,19 @@ TEST_F(ServerPoller, TheIdleHeartbeatKeepsTickingAndRepublishesNothing) {
   // budget below, seconds rather than milliseconds, AND returns as soon as the property holds --
   // the case gets both more robust and faster.
   const auto wait_start = std::chrono::steady_clock::now();
-  const bool got_two_ticks =
-      WaitFor([&local, ticks_before] { return local->HeartbeatTickCountForTest() - ticks_before >= 2; }, 5000);
+  // The predicate latches the delta it decided on, so the failure message reports the count that
+  // actually produced the verdict rather than a fresh read taken after the wait returned.
+  uint64_t ticks_gained = 0;
+  const bool got_two_ticks = WaitFor(
+      [&local, &ticks_gained, ticks_before] {
+        ticks_gained = local->HeartbeatTickCountForTest() - ticks_before;
+        return ticks_gained >= 2;
+      },
+      5000);
   const auto waited_ms =
       std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - wait_start).count();
-  EXPECT_TRUE(got_two_ticks) << "the heartbeat stopped after its first tick (saw "
-                             << (local->HeartbeatTickCountForTest() - ticks_before) << " further ticks in " << waited_ms
-                             << "ms)";
+  EXPECT_TRUE(got_two_ticks) << "the heartbeat stopped after its first tick (saw " << ticks_gained
+                             << " further ticks in " << waited_ms << "ms)";
 
   // The lower bound the wait-until form would otherwise drop: that the heartbeat is THROTTLED, not
   // just alive. Without it a heartbeat degenerating to the full-speed cadence (kPollIntervalMs, 20ms)
@@ -792,14 +798,15 @@ TEST_F(ServerPoller, TheIdleHeartbeatKeepsTickingAndRepublishesNothing) {
   // rewrite exists to stop being sensitive to. One interval already separates a throttled heartbeat
   // (>=475ms) from an un-throttled one (~40ms) by an order of magnitude.
   //
-  // The 25ms tolerance covers a timed wait firing marginally early: the measured tick spacing on
-  // this machine spans 496-503ms, i.e. up to 4ms under the nominal interval.
+  // The tolerance covers a timed wait firing marginally early: the measured tick spacing on this
+  // machine spans 496-503ms, i.e. up to 4ms under the nominal interval, so 25ms is ~6x that.
   //
   // Note what is deliberately NOT asserted: an upper bound on how long the ticks took. Any such
   // bound is a wall-clock margin of the kind that made the old form fragile, and the WaitFor budget
   // above is the only ceiling this case keeps.
   if (got_two_ticks) {
-    EXPECT_GE(waited_ms, gui::kIdleHeartbeatIntervalMs - 25)
+    constexpr int kEarlyWakeToleranceMs = 25;
+    EXPECT_GE(waited_ms, gui::kIdleHeartbeatIntervalMs - kEarlyWakeToleranceMs)
         << "two heartbeat ticks arrived in " << waited_ms << "ms; the heartbeat is not throttled";
   }
 

--- a/test/unit-correctness/gui/test_server_poller.cpp
+++ b/test/unit-correctness/gui/test_server_poller.cpp
@@ -746,7 +746,9 @@ TEST_F(ServerPoller, AnUnboundedRunNeverSelfPauses) {
 // terminal edge was the ONLY chance to get the terminal truth on screen. The heartbeat is what makes
 // that observation retryable, which is the whole difference between a level-triggered reconciler and
 // an edge-triggered one. It also asserts what a tick must NOT do: republish a texture. Each tick is
-// a safe no-op or the preview re-uploads twice a second forever.
+// a safe no-op or the preview re-uploads twice a second forever. Both cadence facts it pins — the
+// heartbeat keeps firing, and it stays throttled while doing so — are asserted by waiting for ticks
+// rather than by sleeping a window and counting; see the comment at that wait for why.
 TEST_F(ServerPoller, TheIdleHeartbeatKeepsTickingAndRepublishesNothing) {
   ASSERT_TRUE(srv.get() != nullptr);
   ASSERT_EQ(CommitSceneJson(srv, kFiniteSceneJson), LUMICE_OK);
@@ -762,8 +764,44 @@ TEST_F(ServerPoller, TheIdleHeartbeatKeepsTickingAndRepublishesNothing) {
   ASSERT_TRUE(before != nullptr);
   const uint64_t ticks_before = local->HeartbeatTickCountForTest();
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(5 * gui::kIdleHeartbeatIntervalMs / 2));
-  EXPECT_GE(local->HeartbeatTickCountForTest() - ticks_before, 2u) << "the heartbeat stopped after its first tick";
+  // Wait UNTIL two further ticks arrive rather than sleeping a fixed window and counting what
+  // landed. The fixed form slept 2.5 intervals and the second tick lands at 2 intervals, so the
+  // whole margin against scheduler jitter was the last 20% of the window: measured on this machine
+  // the ticks arrive at +503ms and +1007ms, i.e. 243-250ms of slack, and CI has spent it (PR #291
+  // saw one tick in that window on the macOS ARM64 leg). Waiting instead makes the margin the
+  // budget below, seconds rather than milliseconds, AND returns as soon as the property holds --
+  // the case gets both more robust and faster.
+  const auto wait_start = std::chrono::steady_clock::now();
+  const bool got_two_ticks =
+      WaitFor([&local, ticks_before] { return local->HeartbeatTickCountForTest() - ticks_before >= 2; }, 5000);
+  const auto waited_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - wait_start).count();
+  EXPECT_TRUE(got_two_ticks) << "the heartbeat stopped after its first tick (saw "
+                             << (local->HeartbeatTickCountForTest() - ticks_before) << " further ticks in " << waited_ms
+                             << "ms)";
+
+  // The lower bound the wait-until form would otherwise drop: that the heartbeat is THROTTLED, not
+  // just alive. Without it a heartbeat degenerating to the full-speed cadence (kPollIntervalMs, 20ms)
+  // would satisfy the assertion above in 40ms and stay green forever.
+  //
+  // The floor is ONE interval, not two, and that is a deliberate weakening of what this case could
+  // assert in the abstract. The counter is read at some point T0 within the interval that follows a
+  // tick, so the next two ticks land at (2 - phase) intervals from T0 with phase in [0, 1) — the
+  // only bound that holds for every phase is one interval. Asserting two would subtract however
+  // long the main thread took to observe the FIRST tick, which is exactly the scheduling delay this
+  // rewrite exists to stop being sensitive to. One interval already separates a throttled heartbeat
+  // (>=475ms) from an un-throttled one (~40ms) by an order of magnitude.
+  //
+  // The 25ms tolerance covers a timed wait firing marginally early: the measured tick spacing on
+  // this machine spans 496-503ms, i.e. up to 4ms under the nominal interval.
+  //
+  // Note what is deliberately NOT asserted: an upper bound on how long the ticks took. Any such
+  // bound is a wall-clock margin of the kind that made the old form fragile, and the WaitFor budget
+  // above is the only ceiling this case keeps.
+  if (got_two_ticks) {
+    EXPECT_GE(waited_ms, gui::kIdleHeartbeatIntervalMs - 25)
+        << "two heartbeat ticks arrived in " << waited_ms << "ms; the heartbeat is not throttled";
+  }
 
   Snapshot after = local->LoadSnapshot();
   ASSERT_TRUE(after != nullptr);


### PR DESCRIPTION
## 问题

`ServerPoller.TheIdleHeartbeatKeepsTickingAndRepublishesNothing` 睡固定 `5 * kIdleHeartbeatIntervalMs / 2` = 1250ms，再断言至少来了 2 次心跳 tick。心跳每 500ms 一次 ⇒ 第 2 次落在约 1000ms，**整个抗抖动余量就是窗口最后那 20%**。

本机 1ms 粒度探针实测：tick 落在 **+503ms / +1007ms**（六次运行 496–503 / 996–1007），delta 恒为 2 从不为 3 ⇒ 余量 243–250ms。PR #291 在 `macOS ARM64` 上花掉了它：

```
test_server_poller.cpp:766: Failure
Expected: (local->HeartbeatTickCountForTest() - ticks_before) >= (2u), actual: 1 vs 2
```

它红的时候读起来像真缺陷（"the heartbeat stopped after its first tick"），所以放着不管的代价不止一次重跑——它训练人在恰恰最该看的那个信号上按重跑。

## 改法

固定睡眠 + 计数 → `WaitFor(delta >= 2, 5000)`。命题一字未改（仍是「≥2 次 tick」），余量从 250ms 变成秒级，且**用例更快**：等到即返回而非睡满，实测 1834–1870ms → **1563–1609ms**。

未采用「把窗口放大到 4–5×」：CI 每次跑这个二进制 6 遍（`ctest -L` 与 AC6 证据步各一次 × 3 条 `build_gui: ON` 的腿），放窗口是 +1250ms × 6，而且形态照旧脆弱，只是常数变大。

wait-until 会丢掉一条隐含性质——「心跳是被**节流**的、不是空转」——所以补了一条下界断言。基准取 **1 个 interval 而非 2 个**：`ticks_before` 是在某次 tick 之后的区间内某点读到的，等待时长 ∈ (I, 2I] 取决于相位，`2I − 容差` 会把「主线程发现第 1 次 tick 花了多久」直接减掉，正是本次要脱敏的调度延迟 ⇒ 2I 版本在重负载下会假红，等于把刚修掉的缺陷换个位置重新引入。判别力没有损失：节流 ≥475ms vs 空转约 42ms，差一个数量级。故意**不设上界**（任何上界都是墙钟余量），变慢一侧由 5000ms 预算兜底。

## 为什么不是删掉这个用例

CI 的 `gui_test` 是正向过滤 `--filter "modal_layout,defaults_panel_layout"`，`run_lifecycle` 整族在 CI 里一次都不跑 ⇒ **这个用例是心跳（`doc/gui-preview-lifecycle-architecture.md` 不变量 I3b）在 CI 上唯一的覆盖**。它守的缺陷族——后端跑完了但 GUI 仍显示 Simulating、完成后预览空白——在本仓反复出现过。它还独占「一次 tick 不得 bump `texture_serial`」这条断言，且那条零时间成本。

## 验证

- 净机串行 10 次跑 `ServerPoller.TheIdleHeartbeat*` / `AnUnboundedRun*` / `ServerPollerShutdown.*`：**10/10 全绿**
- **两条断言各做一次红态自证**，随后完整还原（`git status` 空、重建全绿）：
  - 心跳分支在第一次 tick 后转 `kPaused` ⇒ `the heartbeat stopped after its first tick (saw 0 further ticks in 5000ms)`
  - 心跳 `wait_for` 换成 `kPollIntervalMs`（退化成全速轮询）⇒ `two heartbeat ticks arrived in 42ms; the heartbeat is not throttled`；此时前一条断言仍绿，两条各守一个失效方向
- `./scripts/test.sh quick`：**RESULT: PASS**
- `check_new_refs.py` / `check_new_gui_tests.py` / `format.sh --check` 均通过

## 未改动

同文件另两个墙钟用例（`AnUnboundedRunNeverSelfPauses`、`StopQuiescesTheHeartbeatBeforeReturning`）核对后不改：二者都是否定式断言，负载只会让它们更容易通过，失效方向是假绿而非假红；且「某事永不发生」无 wait-until 形态可换。

🤖 Generated with [Claude Code](https://claude.com/claude-code)