### PR TITLE
feat(gui): 柱晶高度域扩到 1e-4，滑杆显示格式由映射闭式定下界并在编译期判错

### DIFF
--- a/src/gui/field_editor_registry.cpp
+++ b/src/gui/field_editor_registry.cpp
@@ -437,14 +437,16 @@ const std::unordered_map<std::string, FieldEditorEntry>& Registry() {
     // rest of this registry is out of the gate's reach for a structural reason, not an oversight:
     // most of its domains are FloatDomainFn closures over live GuiState (renderer.fov and friends),
     // so their bounds are not constant expressions and no static_assert can read them.
-    constexpr float kSunDiameterMin = 0.1f;
-    constexpr float kSunDiameterMax = 5.0f;
-    constexpr const char* kSunDiameterFmt = "%.2f";
-    static_assert(
-        slider_format::FormatIsFineEnough(kSunDiameterFmt, SliderScale::kLinear, kSunDiameterMin, kSunDiameterMax),
-        "the sun diameter slider's format is coarser than its linear mapping resolves");
-    map.emplace("sun.diameter", FloatField([](GuiState& s) { return &s.sun.diameter; },
-                                           FixedDomain(kSunDiameterMin, kSunDiameterMax), kSunDiameterFmt));
+    {
+      constexpr float kSunDiameterMin = 0.1f;
+      constexpr float kSunDiameterMax = 5.0f;
+      constexpr const char* kSunDiameterFmt = "%.2f";
+      static_assert(
+          slider_format::FormatIsFineEnough(kSunDiameterFmt, SliderScale::kLinear, kSunDiameterMin, kSunDiameterMax),
+          "the sun diameter slider's format is coarser than its linear mapping resolves");
+      map.emplace("sun.diameter", FloatField([](GuiState& s) { return &s.sun.diameter; },
+                                             FixedDomain(kSunDiameterMin, kSunDiameterMax), kSunDiameterFmt));
+    }
     map.emplace("sun.spectrum", SpectrumField());
 
     // ---- sim ----

--- a/src/gui/field_editor_registry.cpp
+++ b/src/gui/field_editor_registry.cpp
@@ -7,6 +7,7 @@
 #include "gui/app.hpp"
 #include "gui/gui_constants.hpp"
 #include "gui/panels.hpp"
+#include "gui/slider_format_rules.hpp"
 #include "gui/theme.hpp"
 #include "imgui.h"
 #include "include/lumice.h"
@@ -424,8 +425,26 @@ const std::unordered_map<std::string, FieldEditorEntry>& Registry() {
     // ---- sun ----
     map.emplace("sun.altitude",
                 FloatField([](GuiState& s) { return &s.sun.altitude; }, FixedDomain(-90.0f, 90.0f), "%.1f"));
-    map.emplace("sun.diameter",
-                FloatField([](GuiState& s) { return &s.sun.diameter; }, FixedDomain(0.1f, 5.0f), "%.1f"));
+    // The one row in this registry the pairing gate covers, and it is here on evidence rather than
+    // on principle: swept at the measured 179 px slider width, this domain under "%.1f" froze for 4
+    // pixels of drag -- the same order as the axis spread sliders, and nobody had noticed. Band and
+    // format are named once and handed to both the gate and the field, so the assertion cannot
+    // drift away from what renders.
+    //
+    // "%.2f" and not the "%.3g" its axis siblings took: this slider is kLinear, so it quantizes by
+    // a constant AMOUNT per pixel and an absolute format is the family that matches it -- putting a
+    // relative format on it would be the same mismatch as the defect, in the other direction. The
+    // rest of this registry is out of the gate's reach for a structural reason, not an oversight:
+    // most of its domains are FloatDomainFn closures over live GuiState (renderer.fov and friends),
+    // so their bounds are not constant expressions and no static_assert can read them.
+    constexpr float kSunDiameterMin = 0.1f;
+    constexpr float kSunDiameterMax = 5.0f;
+    constexpr const char* kSunDiameterFmt = "%.2f";
+    static_assert(
+        slider_format::FormatIsFineEnough(kSunDiameterFmt, SliderScale::kLinear, kSunDiameterMin, kSunDiameterMax),
+        "the sun diameter slider's format is coarser than its linear mapping resolves");
+    map.emplace("sun.diameter", FloatField([](GuiState& s) { return &s.sun.diameter; },
+                                           FixedDomain(kSunDiameterMin, kSunDiameterMax), kSunDiameterFmt));
     map.emplace("sun.spectrum", SpectrumField());
 
     // ---- sim ----

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -19,6 +19,7 @@
 #include "gui/raypath_segments.hpp"  // FormatSummandText (non-degenerate SoP summary)
 #include "gui/semantic_colors.hpp"
 #include "gui/shape_scalar_domain.hpp"
+#include "gui/slider_format_rules.hpp"
 #include "gui/slider_mapping.hpp"
 #include "gui/theme.hpp"
 #include "imgui.h"
@@ -629,23 +630,58 @@ bool RenderAxisDist(const char* label, AxisDist& axis, float mean_min, float mea
 
   changed |= SliderWithInput("Mean", &axis.mean, mean_min, mean_max);
 
+  // The spread control, whose label and band follow the distribution. Each arm spells its band and
+  // its format ONCE, as named constants, and hands the same tokens to the gate and to the widget --
+  // so the thing asserted about is the thing rendered. A second table listing what these call sites
+  // "should" use would be the shape this repo already paid for once: the shape-scalar domains lived
+  // as prose beside their call sites for exactly as long as it took the two to disagree.
+  //
+  // These four are covered because they are where the mismatch lives: a kSqrt slider quantizes
+  // neither by a constant amount nor by a constant fraction, and all four were paired with "%.1f",
+  // which at the measured 179 px width already froze for 3 (Std, Range) to 5 (Amplitude, Scale)
+  // pixels of drag. "%.3g" is the coarsest format the gate accepts for them -- see
+  // slider_format_rules.hpp for the criterion, and note that the low end of the travel is where the
+  // digits go: the first pixel of Amplitude reads 0.000312 rather than 0.0.
   switch (axis.type) {
     case AxisDistType::kGauss:
     case AxisDistType::kGaussLegacy:
-      changed |= SliderWithInput("Std", &axis.std, 0.0f, 180.0f, "%.1f", SliderScale::kSqrt);
+    default: {
+      constexpr float kStdMin = 0.0f;
+      constexpr float kStdMax = 180.0f;
+      constexpr const char* kStdFmt = "%.3g";
+      static_assert(slider_format::FormatIsFineEnough(kStdFmt, SliderScale::kSqrt, kStdMin, kStdMax),
+                    "the Std slider's format is coarser than its kSqrt mapping resolves");
+      changed |= SliderWithInput("Std", &axis.std, kStdMin, kStdMax, kStdFmt, SliderScale::kSqrt);
       break;
-    case AxisDistType::kUniform:
-      changed |= SliderWithInput("Range", &axis.std, 0.0f, 360.0f, "%.1f", SliderScale::kSqrt);
+    }
+    case AxisDistType::kUniform: {
+      constexpr float kRangeMin = 0.0f;
+      constexpr float kRangeMax = 360.0f;
+      constexpr const char* kRangeFmt = "%.3g";
+      static_assert(slider_format::FormatIsFineEnough(kRangeFmt, SliderScale::kSqrt, kRangeMin, kRangeMax),
+                    "the Range slider's format is coarser than its kSqrt mapping resolves");
+      changed |= SliderWithInput("Range", &axis.std, kRangeMin, kRangeMax, kRangeFmt, SliderScale::kSqrt);
       break;
-    case AxisDistType::kZigzag:
-      changed |= SliderWithInput("Amplitude", &axis.std, 0.0f, 90.0f, "%.1f", SliderScale::kSqrt);
+    }
+    case AxisDistType::kZigzag: {
+      constexpr float kAmplitudeMin = 0.0f;
+      constexpr float kAmplitudeMax = 90.0f;
+      constexpr const char* kAmplitudeFmt = "%.3g";
+      static_assert(slider_format::FormatIsFineEnough(kAmplitudeFmt, SliderScale::kSqrt, kAmplitudeMin, kAmplitudeMax),
+                    "the Amplitude slider's format is coarser than its kSqrt mapping resolves");
+      changed |=
+          SliderWithInput("Amplitude", &axis.std, kAmplitudeMin, kAmplitudeMax, kAmplitudeFmt, SliderScale::kSqrt);
       break;
-    case AxisDistType::kLaplacian:
-      changed |= SliderWithInput("Scale", &axis.std, 0.0f, 90.0f, "%.1f", SliderScale::kSqrt);
+    }
+    case AxisDistType::kLaplacian: {
+      constexpr float kScaleMin = 0.0f;
+      constexpr float kScaleMax = 90.0f;
+      constexpr const char* kScaleFmt = "%.3g";
+      static_assert(slider_format::FormatIsFineEnough(kScaleFmt, SliderScale::kSqrt, kScaleMin, kScaleMax),
+                    "the Scale slider's format is coarser than its kSqrt mapping resolves");
+      changed |= SliderWithInput("Scale", &axis.std, kScaleMin, kScaleMax, kScaleFmt, SliderScale::kSqrt);
       break;
-    default:
-      changed |= SliderWithInput("Std", &axis.std, 0.0f, 180.0f, "%.1f", SliderScale::kSqrt);
-      break;
+    }
   }
 
   ImGui::PopID();

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -53,10 +53,15 @@ static bool RenderNonlinearSlider(const char* slider_id, float* value, float min
       *value = slider_mapping::LogNormToValueSnapped(norm, min_val, max_val);
       changed = true;
     }
-  } else if (scale == SliderScale::kLogLinear && min_val == 0.0f) {
-    float norm = slider_mapping::LogLinearValueToNorm(*value, max_val);
+  } else if (scale == SliderScale::kLogLinear && min_val >= 0.0f) {
+    // Any non-negative floor, not just exactly 0: the law's linear segment now runs
+    // [min_val, kLogLinearX0]. Its upper limit (min_val < kLogLinearX0) is not re-checked here
+    // because it is checked where the floors are written -- shape_scalar_domain.hpp static_asserts
+    // it over every kLogLinear row -- and a runtime test here could only fail after the value had
+    // already been drawn.
+    float norm = slider_mapping::LogLinearValueToNorm(*value, min_val, max_val);
     if (ImGui::SliderFloat(slider_id, &norm, 0.0f, 1.0f, "", ImGuiSliderFlags_NoInput)) {
-      *value = slider_mapping::LogLinearNormToValueSnapped(norm, max_val);
+      *value = slider_mapping::LogLinearNormToValueSnapped(norm, min_val, max_val);
       changed = true;
     }
   } else {

--- a/src/gui/shape_scalar_domain.hpp
+++ b/src/gui/shape_scalar_domain.hpp
@@ -23,8 +23,9 @@
 
 #include <cassert>
 
-#include "gui/panels.hpp"    // SliderScale
-#include "include/lumice.h"  // LUMICE_SHAPE_SCALAR_*
+#include "gui/panels.hpp"          // SliderScale
+#include "gui/slider_mapping.hpp"  // kLogLinearX0 -- the kLogLinear rows' domain requirement
+#include "include/lumice.h"        // LUMICE_SHAPE_SCALAR_*
 
 namespace lumice::gui {
 
@@ -39,12 +40,31 @@ struct ShapeScalarDomain {
 // Indexed by LUMICE_SHAPE_SCALAR_* — the enum's own order, so a new slot added to lumice.h that
 // is not given a row here fails the static_assert below rather than silently reading a neighbour.
 inline constexpr ShapeScalarDomain kShapeScalarDomains[] = {
-  // HEIGHT — prism height spans four orders of magnitude, hence log.
-  { 0.01f, 100.0f, "%.2f", SliderScale::kLog },
+  // HEIGHT — prism height spans six orders of magnitude, hence the hybrid law rather than a plain
+  // linear one. Two things about this row are chosen rather than inherited:
+  //
+  // The floor is 1e-4 because core refuses a prism height that is not strictly greater than its
+  // float epsilon (src/core/crystal.cpp, `h > math::kFloatEps`, with kFloatEps = 1e-5) — a slider
+  // that could reach 1e-5 would let the user park the control on a value core then rejects. 1e-4
+  // keeps a 10x margin above that gate, so an endpoint value survives the round trip through the
+  // config and back with room to spare. The two numbers are deliberately NOT the same constant:
+  // src/gui/ reaches core only through the C API (see the public-API boundary rule), so quoting
+  // core's epsilon here would mean publishing an implementation detail through lumice.h to buy a
+  // single source of truth for a number that has not changed in the project's lifetime. The cost
+  // accepted instead is this cross-reference: if core's epsilon ever moves, re-check this floor.
+  //
+  // The format is %.4g, not %.Nf, because this slider quantizes RELATIVELY (each pixel of travel
+  // is a roughly constant RATIO of the current value once past the switch point), and %f
+  // quantizes ABSOLUTELY. Pairing the two means the low decades render as a run of identical
+  // strings — the handle moves and the number does not. See the pairing test in
+  // test/unit-correctness/gui/test_gui_widget_rules.cpp, which asserts this with margin.
+  { 1e-4f, 100.0f, "%.4g", SliderScale::kLogLinear },
   // UPPER_H — pyramid wedge fraction; natural linear unit.
   { 0.0f, 1.0f, "%.3f", SliderScale::kLinear },
-  // PRISM_H — must allow exactly 0 AND stay finely controllable near 0 over a wide range.
-  { 0.0f, 100.0f, "%.4f", SliderScale::kLogLinear },
+  // PRISM_H — must allow exactly 0 AND stay finely controllable near 0 over a wide range. Same
+  // relative-quantization pairing as HEIGHT above; the floor stays 0 because a pyramid with no
+  // prism section is a legal crystal.
+  { 0.0f, 100.0f, "%.4g", SliderScale::kLogLinear },
   // LOWER_H — pyramid wedge fraction; natural linear unit.
   { 0.0f, 1.0f, "%.3f", SliderScale::kLinear },
   // FACE_0..FACE_5 — near-unit distance multipliers, rarely above 2 in practice.
@@ -57,6 +77,22 @@ inline constexpr ShapeScalarDomain kShapeScalarDomains[] = {
 };
 static_assert(sizeof(kShapeScalarDomains) / sizeof(kShapeScalarDomains[0]) == LUMICE_SHAPE_SCALAR_COUNT,
               "kShapeScalarDomains must carry one row per LUMICE_SHAPE_SCALAR_* slot");
+
+// The kLogLinear law's linear segment runs [min_value, kLogLinearX0], so a row that declares a
+// min_value at or above that threshold gives it a zero or negative denominator: a division by zero,
+// or a slider whose travel runs backwards. Nothing downstream would report it — the widget would
+// simply behave absurdly — and the branch in panels.cpp that routes to this law admits any
+// non-negative floor, so the check belongs here, at the one place the floors are written.
+constexpr bool AllLogLinearRowsLieInTheMappingsDomain() {
+  for (const ShapeScalarDomain& d : kShapeScalarDomains) {
+    if (d.scale == SliderScale::kLogLinear && !(d.min_value >= 0.0f && d.min_value < slider_mapping::kLogLinearX0)) {
+      return false;
+    }
+  }
+  return true;
+}
+static_assert(AllLogLinearRowsLieInTheMappingsDomain(),
+              "a kLogLinear row's min_value must satisfy 0 <= min_value < kLogLinearX0");
 
 // The domain for `scalar_id`. Total over the enum; out-of-range ids are a programming error the
 // caller cannot recover from, so this asserts rather than substituting a domain (a wrong band on

--- a/src/gui/shape_scalar_domain.hpp
+++ b/src/gui/shape_scalar_domain.hpp
@@ -23,9 +23,10 @@
 
 #include <cassert>
 
-#include "gui/panels.hpp"          // SliderScale
-#include "gui/slider_mapping.hpp"  // kLogLinearX0 -- the kLogLinear rows' domain requirement
-#include "include/lumice.h"        // LUMICE_SHAPE_SCALAR_*
+#include "gui/panels.hpp"               // SliderScale
+#include "gui/slider_format_rules.hpp"  // FormatIsFineEnough -- the fmt/scale pairing gate
+#include "gui/slider_mapping.hpp"       // kLogLinearX0 -- the kLogLinear rows' domain requirement
+#include "include/lumice.h"             // LUMICE_SHAPE_SCALAR_*
 
 namespace lumice::gui {
 
@@ -97,6 +98,33 @@ constexpr bool AllLogLinearRowsLieInTheMappingsDomain() {
 }
 static_assert(AllLogLinearRowsLieInTheMappingsDomain(),
               "a kLogLinear row must satisfy 0 <= min_value < kLogLinearX0 < max_value");
+
+// The format each row declares must be at least as fine as the row's own mapping demands, or the
+// slider's readout freezes over a stretch of travel (slider_format_rules.hpp states the criterion
+// and its honest boundary). Checked here rather than at the call sites because this table is
+// TOTAL over the enum -- the static_assert above pins one row per LUMICE_SHAPE_SCALAR_* slot, so a
+// slot added later cannot reach a slider without passing through this loop. That is the whole
+// difference between this and the enumerated test it supplements: a test covers the rows someone
+// remembered to list, this covers the rows that exist.
+//
+// Every row here is worth covering for the same reason, and it is not "it is the whole table": all
+// ten are geometry parameters the user drags to a value core then builds a crystal from, on a table
+// whose two kLogLinear rows are exactly where the mismatch has already bitten once -- the prism
+// height rendered "%.2f" against a relatively-quantizing law, twenty pixels of dead travel at the
+// measured width. The six face rows and the two wedge fractions share the table, the widget and the
+// modal with those two; excluding them would mean asserting that the next row to be edited will not
+// be one of them.
+constexpr bool AllRowsHaveFormatFineEnoughForTheirMapping() {
+  for (const ShapeScalarDomain& d : kShapeScalarDomains) {
+    if (!slider_format::FormatIsFineEnough(d.fmt, d.scale, d.min_value, d.max_value)) {
+      return false;
+    }
+  }
+  return true;
+}
+static_assert(AllRowsHaveFormatFineEnoughForTheirMapping(),
+              "a shape scalar's display format is coarser than its slider's mapping resolves: the "
+              "readout would freeze over part of the travel (see gui/slider_format_rules.hpp)");
 
 // The domain for `scalar_id`. Total over the enum; out-of-range ids are a programming error the
 // caller cannot recover from, so this asserts rather than substituting a domain (a wrong band on

--- a/src/gui/shape_scalar_domain.hpp
+++ b/src/gui/shape_scalar_domain.hpp
@@ -82,17 +82,21 @@ static_assert(sizeof(kShapeScalarDomains) / sizeof(kShapeScalarDomains[0]) == LU
 // min_value at or above that threshold gives it a zero or negative denominator: a division by zero,
 // or a slider whose travel runs backwards. Nothing downstream would report it — the widget would
 // simply behave absurdly — and the branch in panels.cpp that routes to this law admits any
-// non-negative floor, so the check belongs here, at the one place the floors are written.
+// non-negative floor, so the check belongs here, at the one place the floors are written. Checks
+// both halves of the mapping's REQUIRES (slider_mapping.hpp): the floor below kLogLinearX0, and
+// the ceiling above it (a max_value at or below kLogLinearX0 would collapse the log segment the
+// same way a bad floor collapses the linear one).
 constexpr bool AllLogLinearRowsLieInTheMappingsDomain() {
   for (const ShapeScalarDomain& d : kShapeScalarDomains) {
-    if (d.scale == SliderScale::kLogLinear && !(d.min_value >= 0.0f && d.min_value < slider_mapping::kLogLinearX0)) {
+    if (d.scale == SliderScale::kLogLinear && !(d.min_value >= 0.0f && d.min_value < slider_mapping::kLogLinearX0 &&
+                                                d.max_value > slider_mapping::kLogLinearX0)) {
       return false;
     }
   }
   return true;
 }
 static_assert(AllLogLinearRowsLieInTheMappingsDomain(),
-              "a kLogLinear row's min_value must satisfy 0 <= min_value < kLogLinearX0");
+              "a kLogLinear row must satisfy 0 <= min_value < kLogLinearX0 < max_value");
 
 // The domain for `scalar_id`. Total over the enum; out-of-range ids are a programming error the
 // caller cannot recover from, so this asserts rather than substituting a domain (a wrong band on

--- a/src/gui/slider_format_rules.hpp
+++ b/src/gui/slider_format_rules.hpp
@@ -1,0 +1,298 @@
+#ifndef LUMICE_GUI_SLIDER_FORMAT_RULES_HPP
+#define LUMICE_GUI_SLIDER_FORMAT_RULES_HPP
+
+// Whether a slider's display format is fine enough for the law that slider traverses — decided by
+// the mapping, at compile time, instead of by whoever typed the format string.
+//
+// THE DEFECT THIS ADDRESSES. A slider and the number beside it quantize independently. "%.Nf"
+// quantizes ABSOLUTELY (it distinguishes values that differ by more than 10^-N); "%.Ng" quantizes
+// RELATIVELY (by more than a fixed fraction of the value). The slider quantizes by its own law: a
+// kLinear slider moves the value a constant amount per pixel of travel, kLog and kLogLinear's log
+// segment move it a constant fraction, kSqrt neither. Pair a format that is too coarse for the law
+// with the law, and a stretch of travel renders as a run of identical strings: the handle moves and
+// the number does not, which is indistinguishable from a frozen control.
+//
+// THE CRITERION IS `maxrun <= K`, NOT "no two adjacent pixels agree". maxrun is the longest run of
+// consecutive pixels that format to the same string, i.e. the length of the dead travel a user
+// actually drags through. The two orderings are not merely different, they are close to reversed:
+// measured over this GUI's float sliders at the 179 px width, the sun-diameter row produced 130
+// adjacent-pixel collisions but a maxrun of 4, the six `*_alpha` rows produced 79 collisions at a
+// maxrun of 2 (one repeated pixel, benign), while the worst row of all — the prism height under its
+// old "%.2f" — produced only 57 collisions at a maxrun of 20. Counting collisions ranks the worst
+// row as the mildest. K is the tolerance that ordering needs and a collision count cannot express:
+// "the number must change within K pixels of drag".
+//
+// WHAT THIS FILE DOES AND DOES NOT DECIDE. It answers one question — is the format a call site
+// DECLARED fine enough — and never picks the format itself. Deriving the format instead would mean
+// taking the derived bound as the answer, and the bound is a LOWER bound: taken literally it would
+// coarsen rows that are fine today (the six face rows from "%.3f" to "%.2f", the axis mean from
+// "%.3f" to "%.0f"). Rows are free to be finer than the bound; only a row coarser than it is
+// rejected, so this gate only ever subtracts defects, never rewrites working call sites.
+//
+// HONEST BOUNDARY: THE BOUND IS SUFFICIENT, NOT NECESSARY. For the constant-step laws (kLinear,
+// kLog, kLogLinear) the bound agrees with a brute-force pixel scan exactly. For kSqrt, whose step
+// varies along the travel, and for any "%.Ng" whose domain does not start just above a power of ten
+// (see WorstRelativeQuantum below), it is conservative by up to one digit — it can reject a format
+// that would in fact have measured fine. Every disagreement found in cross-checking went that way;
+// none went the other. So the gate does not miss, but it can demand a digit a measurement would
+// not. When it does, the fix is to declare the finer format (or to pick the format family that
+// matches the law, which is what the domain wanted anyway) — NOT to loosen the gate. The
+// cross-check that establishes the direction of the error lives beside the gate's own tests in
+// test/unit-correctness/gui/test_gui_widget_rules.cpp.
+//
+// No <cmath>, and deliberately so: `std::log` is not usable in a constant expression, and
+// `__builtin_logf` is usable in one under GCC but not under Clang, so reaching for it would buy a
+// compile that succeeds on one of this repo's three platforms and fails on another. Nothing below
+// needs a transcendental — the W-th root the log laws would otherwise want is removed by raising
+// both sides of the comparison to the W-th power, leaving repeated multiplication.
+
+#include "gui/panels.hpp"          // SliderScale
+#include "gui/slider_mapping.hpp"  // kLogLinearX0 / kLogLinearTSwitch -- the hybrid law's shape
+
+namespace lumice::gui::slider_format {
+
+// The widest a Value-column slider gets: measured with the crystal edit modal's own layout, from
+// the item rectangle ImGui gave the slider -- 179 px in the horizontal (820 px) modal and 127 px in
+// the vertical (420 px) one. The slider does NOT span the modal: it lives in the single stretch
+// column of a five-column property table, alongside four fixed-width cells.
+inline constexpr int kMeasuredMaxSliderWidthPx = 179;
+
+// The width the gate derives against. Three times the measured one, because collisions appear as a
+// slider gets WIDER (more pixels over the same range means a smaller step per pixel) and never
+// disappear: clearing the gate at 3x today's width means the width at which the row would first
+// break is beyond 3x, which is a margin rather than a coin flip.
+//
+// The multiple lives HERE, inside the derivation, rather than in the test that used to carry it.
+// That relocation is the point: as a test-side constant it was a stand-in for a quantity nobody had
+// derived, and it had a known hole -- a "%.4f" row whose first collision was measured at 675 px sat
+// inside the 3x margin and the gate said nothing. Folded into a bound on the format's precision,
+// the layout margin is a term in the answer instead of a guess bolted onto one.
+inline constexpr int kPairingGateWidthPx = 3 * kMeasuredMaxSliderWidthPx;
+
+// K: the dead travel a reader will tolerate, in pixels. 3 means "drag three pixels and the number
+// must have changed". K = 1 is the strictest setting and is what "no two adjacent pixels agree"
+// amounted to; at K = 1 the six `*_alpha` rows (0..1 paired with "%.2f", measured maxrun 2) would
+// be rejected and pushed to "%.3f", i.e. to rendering 0.530 — which is why the strictest setting is
+// not the right one. Owner-tunable: change this one number and every covered row is re-derived
+// against it at the next compile.
+inline constexpr int kPairingGateSlackPx = 3;
+
+// ---- Format-string parsing ----
+
+// A "%.Nf" / "%.Ng" spelling, split into the two things the derivation needs.
+struct ParsedFormat {
+  bool recognized = false;
+  int digits = 0;
+  char kind = '\0';  // 'f' or 'g'
+};
+
+// Parses exactly "%.Nf" and "%.Ng" with N one or two digits, and NOTHING else.
+//
+// The narrowness is a feature, not a limitation to be widened on demand: every format string in the
+// covered set has this shape, and an unrecognized one leaves `recognized` false, which the gate
+// below reports as "not fine enough". So a call site that invents a spelling this parser cannot
+// read fails the compile with the same message a genuinely-too-coarse format gets, rather than
+// being waved through on a branch nobody wrote a bound for.
+constexpr ParsedFormat ParseSliderFormat(const char* fmt) {
+  if (fmt == nullptr || fmt[0] != '%' || fmt[1] != '.') {
+    return {};
+  }
+  int i = 2;
+  int digits = 0;
+  int seen = 0;
+  while (fmt[i] >= '0' && fmt[i] <= '9') {
+    digits = digits * 10 + (fmt[i] - '0');
+    ++i;
+    ++seen;
+  }
+  if (seen == 0 || seen > 2) {
+    return {};
+  }
+  const char kind = fmt[i];
+  if ((kind != 'f' && kind != 'g') || fmt[i + 1] != '\0') {
+    return {};
+  }
+  // printf reads a precision of 0 for %g as 1 significant digit; mirror that rather than deriving a
+  // bound for a precision the runtime will not use.
+  if (kind == 'g' && digits == 0) {
+    digits = 1;
+  }
+  return { true, digits, kind };
+}
+
+// ---- Arithmetic helpers (no transcendentals, no overflow) ----
+
+// 10^exp for the small exponents a printf precision produces.
+constexpr double Pow10(int exp) {
+  double result = 1.0;
+  for (int i = 0; i < exp; ++i) {
+    result *= 10.0;
+  }
+  for (int i = 0; i > exp; --i) {
+    result /= 10.0;
+  }
+  return result;
+}
+
+// Whether base^n <= limit, for base >= 1 and limit > 0.
+//
+// Written as repeated multiplication with an early exit rather than as a power, because the honest
+// answer for a base that runs away is "no" and the arithmetic that would produce it overflows. A
+// floating-point overflow is not a constant expression: forming it would make the enclosing
+// static_assert fail to COMPILE with a range diagnostic instead of failing with the gate's own
+// message. Stopping the moment the running product passes `limit` keeps every intermediate value
+// bounded by limit * base and answers the comparison exactly.
+constexpr bool PowerAtMost(double base, int n, double limit) {
+  if (base > limit && n >= 1) {
+    return false;
+  }
+  double acc = 1.0;
+  for (int i = 0; i < n; ++i) {
+    if (acc > limit) {
+      return false;
+    }
+    acc *= base;
+  }
+  return acc <= limit;
+}
+
+constexpr double AbsValue(double v) {
+  return v < 0.0 ? -v : v;
+}
+
+// ---- The laws' per-pixel steps, as inequalities rather than as values ----
+
+// The mapping a slider ACTUALLY traverses, which is not always the one its call site names:
+// RenderNonlinearSlider (panels.cpp) falls through to the plain linear branch when the named law
+// cannot be applied to the declared floor -- kLog needs min_val > 0, kSqrt and kLogLinear need
+// min_val >= 0. Deriving against the named law where the widget runs the linear one would be
+// deriving a bound for a slider nobody renders.
+constexpr SliderScale EffectiveScale(SliderScale scale, double min_v) {
+  switch (scale) {
+    case SliderScale::kSqrt:
+      return min_v >= 0.0 ? SliderScale::kSqrt : SliderScale::kLinear;
+    case SliderScale::kLog:
+      return min_v > 0.0 ? SliderScale::kLog : SliderScale::kLinear;
+    case SliderScale::kLogLinear:
+      return min_v >= 0.0 ? SliderScale::kLogLinear : SliderScale::kLinear;
+    case SliderScale::kLinear:
+      break;
+  }
+  return SliderScale::kLinear;
+}
+
+// The log segment of the hybrid law occupies the upper (1 - t_switch) of the travel. Rounding the
+// pixel count UP is the safe direction: fewer pixels over the same ratio means a LARGER step per
+// pixel, so rounding down would credit the row with resolution it does not have.
+constexpr int LogLinearLogSegmentPixels(int width_px) {
+  const double exact = static_cast<double>(width_px) * (1.0 - static_cast<double>(slider_mapping::kLogLinearTSwitch));
+  int pixels = static_cast<int>(exact);
+  if (static_cast<double>(pixels) < exact) {
+    ++pixels;
+  }
+  return pixels < 1 ? 1 : pixels;
+}
+
+// Whether `slack * (smallest absolute step per pixel) >= quantum`, i.e. whether an ABSOLUTE-
+// quantizing format with that quantum resolves every K-pixel drag. The smallest step per law:
+//
+//   kLinear     (hi - lo) / W                          constant along the travel
+//   kSqrt       hi / W^2                               at the bottom (value = norm^2 * hi)
+//   kLog        lo * r,  r = (hi/lo)^(1/W) - 1         at the bottom
+//   kLogLinear  min( (x0 - lo) / (W * t_s),  x0 * r_log )   linear segment vs. log segment's foot
+//
+// The two log forms are not evaluated. `slack * lo * r >= q` rearranges to
+// `hi/lo >= (1 + q/(slack*lo))^W`, which has no fractional power left in it, and PowerAtMost
+// answers that by multiplying.
+constexpr bool AbsoluteStepResolves(SliderScale scale, double min_v, double max_v, int width_px, int slack_px,
+                                    double quantum) {
+  const double w = static_cast<double>(width_px);
+  const double k = static_cast<double>(slack_px);
+  const double x0 = static_cast<double>(slider_mapping::kLogLinearX0);
+  const double ts = static_cast<double>(slider_mapping::kLogLinearTSwitch);
+  switch (EffectiveScale(scale, min_v)) {
+    case SliderScale::kSqrt:
+      // The sqrt slider ignores its declared floor: it travels 0..sqrt(max) and squares back, so
+      // its bottom step is set by max_v alone.
+      return k * max_v / (w * w) >= quantum;
+    case SliderScale::kLog:
+      return PowerAtMost(1.0 + quantum / (k * min_v), width_px, max_v / min_v);
+    case SliderScale::kLogLinear:
+      return k * (x0 - min_v) / (w * ts) >= quantum &&
+             PowerAtMost(1.0 + quantum / (k * x0), LogLinearLogSegmentPixels(width_px), max_v / x0);
+    case SliderScale::kLinear:
+      break;
+  }
+  return k * (max_v - min_v) / w >= quantum;
+}
+
+// Whether `slack * (smallest RELATIVE step per pixel) >= quantum`, for a relatively-quantizing
+// format. Relative step means (step at a pixel) / (value at that pixel); the smallest one per law:
+//
+//   kLinear     (hi - lo) / (W * max|endpoint|)        at the top, where the constant step is
+//                                                      smallest as a fraction
+//   kSqrt       (2W - 1) / (W - 1)^2                   at the top; independent of the domain
+//   kLog        r                                      constant along the travel
+//   kLogLinear  min( (x0 - lo) / (W * t_s * x0),  r_log )
+constexpr bool RelativeStepResolves(SliderScale scale, double min_v, double max_v, int width_px, int slack_px,
+                                    double quantum) {
+  const double w = static_cast<double>(width_px);
+  const double k = static_cast<double>(slack_px);
+  const double x0 = static_cast<double>(slider_mapping::kLogLinearX0);
+  const double ts = static_cast<double>(slider_mapping::kLogLinearTSwitch);
+  switch (EffectiveScale(scale, min_v)) {
+    case SliderScale::kSqrt:
+      return k * (2.0 * w - 1.0) / ((w - 1.0) * (w - 1.0)) >= quantum;
+    case SliderScale::kLog:
+      return PowerAtMost(1.0 + quantum / k, width_px, max_v / min_v);
+    case SliderScale::kLogLinear:
+      return k * (x0 - min_v) / (w * ts * x0) >= quantum &&
+             PowerAtMost(1.0 + quantum / k, LogLinearLogSegmentPixels(width_px), max_v / x0);
+    case SliderScale::kLinear:
+      break;
+  }
+  {
+    const double scale_ref = AbsValue(min_v) > AbsValue(max_v) ? AbsValue(min_v) : AbsValue(max_v);
+    return scale_ref > 0.0 && k * (max_v - min_v) / (w * scale_ref) >= quantum;
+  }
+}
+
+// The coarsest relative quantization "%.Ng" can produce anywhere. N significant digits at a value
+// in [10^e, 10^(e+1)) quantize by 10^(e-N+1), i.e. by a fraction between 10^-N (just under the next
+// decade) and 10^(1-N) (just above 10^e). Taking the larger end is what makes the "%.Ng" arm of the
+// gate hold for every domain without the gate having to know which decades a domain spans; it is
+// also where its conservatism comes from, since the worst relative step and the worst relative
+// quantum need not occur at the same value.
+constexpr double WorstRelativeQuantum(int digits) {
+  return Pow10(1 - digits);
+}
+
+// Whether `fmt` resolves every `slack_px`-pixel drag of a `scale` slider over [min_v, max_v] laid
+// out `width_px` wide -- i.e. whether the declared format is at least as fine as the bound the
+// mapping implies. False for a format string this file cannot parse (see ParseSliderFormat).
+constexpr bool FormatIsFineEnough(const char* fmt, SliderScale scale, float min_v, float max_v, int width_px,
+                                  int slack_px) {
+  const ParsedFormat parsed = ParseSliderFormat(fmt);
+  if (!parsed.recognized || width_px < 2 || slack_px < 1) {
+    return false;
+  }
+  const double lo = static_cast<double>(min_v);
+  const double hi = static_cast<double>(max_v);
+  if (!(hi > lo)) {
+    return false;
+  }
+  if (parsed.kind == 'f') {
+    return AbsoluteStepResolves(scale, lo, hi, width_px, slack_px, Pow10(-parsed.digits));
+  }
+  return RelativeStepResolves(scale, lo, hi, width_px, slack_px, WorstRelativeQuantum(parsed.digits));
+}
+
+// The gate at its configured settings — the spelling every call site should use, so that the width
+// and the tolerance are not re-typed per row.
+constexpr bool FormatIsFineEnough(const char* fmt, SliderScale scale, float min_v, float max_v) {
+  return FormatIsFineEnough(fmt, scale, min_v, max_v, kPairingGateWidthPx, kPairingGateSlackPx);
+}
+
+}  // namespace lumice::gui::slider_format
+
+#endif  // LUMICE_GUI_SLIDER_FORMAT_RULES_HPP

--- a/src/gui/slider_mapping.hpp
+++ b/src/gui/slider_mapping.hpp
@@ -18,9 +18,14 @@
 
 namespace lumice::gui::slider_mapping {
 
-// LogLinear hybrid mapping constants. Tuned for prism_h [0, 100] range;
-// re-validate before reusing for other ranges. REQUIRES: min_val == 0,
-// max_val > kLogLinearX0 at call site.
+// LogLinear hybrid mapping constants. Tuned for the [0, 100] prism-height range; re-validate
+// before reusing for other ranges. REQUIRES at every call site: 0 <= min_val < kLogLinearX0 and
+// max_val > kLogLinearX0. The lower bound is what makes the linear segment [min_val, x0]
+// non-degenerate -- a min_val at or above x0 turns its denominator (x0 - min_val) into zero or a
+// negative number, i.e. a division by zero or a slider whose travel runs backwards. The rows that
+// can reach here are static data (gui/shape_scalar_domain.hpp), and that file static_asserts this
+// requirement over every kLogLinear row it carries, so the constraint is checked at compile time
+// rather than left to this comment.
 constexpr float kLogLinearX0 = 0.01f;       // Value threshold: linear below, log above
 constexpr float kLogLinearTSwitch = 0.15f;  // Slider position threshold (fraction of [0,1])
 
@@ -38,28 +43,34 @@ inline float LogNormToValue(float norm, float min_val, float max_val) {
   return min_val * std::exp(norm * log_ratio);
 }
 
-// LogLinear hybrid: compute normalized [0,1] position from value in [0, max_val].
-// Linear in [0, x0], log in [x0, max_val], C0 continuous at x0.
-// NOTE: This pair (LogLinearValueToNorm / LogLinearNormToValue) is purpose-built
-// for the min_val == 0 case; it is NOT a general LogLinear primitive with a
-// configurable min. Do not pattern-match LogValueToNorm's (value, min, max) signature.
-inline float LogLinearValueToNorm(float value, float max_val) {
-  value = std::clamp(value, 0.0f, max_val);
+// LogLinear hybrid: compute normalized [0,1] position from value in [min_val, max_val].
+// Linear in [min_val, x0], log in [x0, max_val], C0 continuous at x0.
+// REQUIRES: 0 <= min_val < kLogLinearX0 < max_val (see the constants above).
+//
+// The linear segment's lower end is a parameter rather than a hardcoded 0 so that one law serves
+// both a scalar that must reach exactly 0 (min_val = 0) and one whose floor is a small positive
+// number (min_val = 1e-4): a pure log law cannot express the first, and a log law with a tiny
+// min_val spends most of its travel on decades nobody edits. Only the LINEAR segment sees min_val;
+// the log segment is anchored at kLogLinearX0 and is therefore unchanged, which is why the C0
+// continuity at the switch point needs no re-derivation. At min_val = 0 both formulas reduce to
+// the expressions they replaced, term for term.
+inline float LogLinearValueToNorm(float value, float min_val, float max_val) {
+  value = std::clamp(value, min_val, max_val);
   float log_ratio = std::log(max_val / kLogLinearX0);
   float norm = 0.0f;
   if (value <= kLogLinearX0) {
-    norm = kLogLinearTSwitch * value / kLogLinearX0;
+    norm = kLogLinearTSwitch * (value - min_val) / (kLogLinearX0 - min_val);
   } else {
     norm = kLogLinearTSwitch + (1.0f - kLogLinearTSwitch) * std::log(value / kLogLinearX0) / log_ratio;
   }
   return std::clamp(norm, 0.0f, 1.0f);
 }
 
-// LogLinear hybrid: compute value from normalized [0,1] position.
-inline float LogLinearNormToValue(float norm, float max_val) {
+// LogLinear hybrid: compute value from normalized [0,1] position. Same REQUIRES as above.
+inline float LogLinearNormToValue(float norm, float min_val, float max_val) {
   float log_ratio = std::log(max_val / kLogLinearX0);
   if (norm <= kLogLinearTSwitch) {
-    return kLogLinearX0 * norm / kLogLinearTSwitch;
+    return min_val + (kLogLinearX0 - min_val) * norm / kLogLinearTSwitch;
   }
   float t_log = (norm - kLogLinearTSwitch) / (1.0f - kLogLinearTSwitch);
   return kLogLinearX0 * std::exp(t_log * log_ratio);
@@ -102,16 +113,18 @@ inline float LogNormToValueSnapped(float norm, float min_val, float max_val) {
   return LogNormToValue(norm, min_val, max_val);
 }
 
-// LogLinear hybrid inverse with both ends snapped. The lower end is 0 by construction (this pair
-// is purpose-built for min_val == 0; see LogLinearValueToNorm's note).
-inline float LogLinearNormToValueSnapped(float norm, float max_val) {
+// LogLinear hybrid inverse with both ends snapped. The lower end is min_val -- the floor the
+// domain declares, which is 0 for a scalar that must reach zero and a small positive number for
+// one whose control refuses zero. Snapping to it rather than to a literal 0 is what keeps "the
+// handle is at the left stop" meaning "the value is exactly the declared floor".
+inline float LogLinearNormToValueSnapped(float norm, float min_val, float max_val) {
   if (norm <= 0.0f) {
-    return 0.0f;
+    return min_val;
   }
   if (norm >= 1.0f) {
     return max_val;
   }
-  return LogLinearNormToValue(norm, max_val);
+  return LogLinearNormToValue(norm, min_val, max_val);
 }
 
 }  // namespace lumice::gui::slider_mapping

--- a/test/gui/functional/test_edit_modal.cpp
+++ b/test/gui/functional/test_edit_modal.cpp
@@ -1384,9 +1384,15 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
   // to stand here, one per row and bound; they are the same act (type an out-of-domain value, OK,
   // read back) over a table of rows, so the table is the honest shape.
   //
-  // The input path applies std::clamp only — it does NOT exercise the non-linear drag mapping. The
-  // kLog vs kLinear distinction is still caught, though, because the two rows below have different
-  // bounds and a row that lost its declared range would land on the wrong number here.
+  // The input path applies std::clamp only — it does NOT exercise the non-linear drag mapping. A
+  // row that lost its declared range is still caught, though, because the rows below have different
+  // bounds and such a row would land on the wrong number here.
+  //
+  // The expectations are written as literals rather than read out of kShapeScalarDomains, on
+  // purpose: the table is what the clamp itself reads, so deriving from it would make this case
+  // agree with any domain the table happened to hold. The literals are the second authority. What
+  // they are supposed to be is pinned separately, against the enum, by kExpected in
+  // test/unit-correctness/gui/test_gui_widget_rules.cpp.
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "edit_modal", "each_shape_row_clamps_typed_values_to_its_declared_domain");
     t->TestFunc = [](ImGuiTestContext* ctx) {
@@ -1397,9 +1403,14 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
         float expected;
         const char* why;
       };
-      // Height is kLog over [0.01, 100]; the pyramid H rows are kLinear over [0, 1].
+      // Height is the kLogLinear hybrid over [1e-4, 100]; the pyramid H rows are kLinear over
+      // [0, 1]. Height's floor is positive not because its law cannot express zero — the hybrid
+      // reaches its own floor exactly, which is why the pyramid's Prism H can be switched off from
+      // its slider — but because core rejects a prism height that is not strictly greater than
+      // 1e-5 (src/core/crystal.cpp), so the control refuses to offer one.
       const Row kRows[] = {
-        { gui::CrystalType::kPrism, "**/##Height##modal_cr_input", 0.0f, 0.01f, "kLog cannot reach zero" },
+        { gui::CrystalType::kPrism, "**/##Height##modal_cr_input", 0.0f, 1e-4f,
+          "the declared floor is positive, to stay clear of core's gate" },
         { gui::CrystalType::kPyramid, "**/##Upper H##modal_cr_input", 0.0f, 0.0f, "kLinear starts at zero" },
         { gui::CrystalType::kPyramid, "**/##Upper H##modal_cr_input", 1.5f, 1.0f, "clamped to the upper bound" },
         { gui::CrystalType::kPyramid, "**/##Upper H##modal_cr_input", 0.5f, 0.5f, "an in-range value is identity" },
@@ -2208,7 +2219,7 @@ void RegisterEditModalTests(ImGuiTestEngine* engine) {
       // normalizes Height too, so leaving it behind would only mean core rewrites the face on
       // commit); height→face is the source-side scope — the row has no swatch, but it is the
       // group's leader, and an edit to the leader is exactly the edit the whole group must follow.
-      // Both values sit inside BOTH sliders' ranges (Height's [0.01, 100] and a face's [0, 2]), so
+      // Both values sit inside BOTH sliders' ranges (Height's [1e-4, 100] and a face's [0, 2]), so
       // nothing here is a clamp; cross-range clamping has its own case.
       ctx->ItemInputValue("**/##Face 3##modal_fd_input", 0.75f);
       ctx->Yield(2);

--- a/test/gui/references/modal_layout_crystal_prism.png
+++ b/test/gui/references/modal_layout_crystal_prism.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2588ac065321be1da8aad0186743eb4b90f2731939a20028308fce244489ce60
-size 42870
+oid sha256:20b34e7edd9b329dce26620c708dade1a9294d55364759f2e59509af95562bee
+size 41927

--- a/test/gui/references/modal_layout_crystal_pyramid.png
+++ b/test/gui/references/modal_layout_crystal_pyramid.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a56f324693405faef742fa9fb52344c739d5e2e90c12215922f08b7f08f5e4a1
-size 64221
+oid sha256:16c44422217f423f471a9a24728cfb0f09faebe96ba1c93e08a05e65d57d4da8
+size 63092

--- a/test/unit-correctness/gui/test_gui_widget_rules.cpp
+++ b/test/unit-correctness/gui/test_gui_widget_rules.cpp
@@ -443,7 +443,9 @@ TEST(SliderMapping, EndpointSnappingWritesBackTheBoundExactly) {
   EXPECT_EQ(SqrtNormToValueSnapped(-1.0f, sqrt_max_360, 360.0f), 0.0f);
   EXPECT_FLOAT_EQ(SqrtNormToValueSnapped(3.0f, sqrt_max_360, 360.0f), 9.0f);
 
-  // Prism height: log scale over [0.01, 100].
+  // The pure log law over [0.01, 100]. No shape scalar rides it today — the prism height moved to
+  // the hybrid below when it gained a floor of its own — but the law is still reachable from the
+  // domain table, so its snapping stays pinned here.
   EXPECT_EQ(LogNormToValueSnapped(1.0f, 0.01f, 100.0f), 100.0f);
   EXPECT_EQ(LogNormToValueSnapped(0.0f, 0.01f, 100.0f), 0.01f);
   EXPECT_EQ(LogNormToValueSnapped(2.0f, 0.01f, 100.0f), 100.0f);

--- a/test/unit-correctness/gui/test_gui_widget_rules.cpp
+++ b/test/unit-correctness/gui/test_gui_widget_rules.cpp
@@ -15,6 +15,8 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdio>
+#include <cstring>
 #include <limits>
 #include <string>
 #include <vector>
@@ -225,9 +227,9 @@ struct ExpectedRow {
 };
 
 constexpr ExpectedRow kExpected[] = {
-  { LUMICE_SHAPE_SCALAR_HEIGHT, "Height", 0.01f, 100.0f, "%.2f", SliderScale::kLog },
+  { LUMICE_SHAPE_SCALAR_HEIGHT, "Height", 1e-4f, 100.0f, "%.4g", SliderScale::kLogLinear },
   { LUMICE_SHAPE_SCALAR_UPPER_H, "Upper H", 0.0f, 1.0f, "%.3f", SliderScale::kLinear },
-  { LUMICE_SHAPE_SCALAR_PRISM_H, "Prism H", 0.0f, 100.0f, "%.4f", SliderScale::kLogLinear },
+  { LUMICE_SHAPE_SCALAR_PRISM_H, "Prism H", 0.0f, 100.0f, "%.4g", SliderScale::kLogLinear },
   { LUMICE_SHAPE_SCALAR_LOWER_H, "Lower H", 0.0f, 1.0f, "%.3f", SliderScale::kLinear },
   { LUMICE_SHAPE_SCALAR_FACE_0 + 0, "Face 0", 0.0f, 2.0f, "%.3f", SliderScale::kLinear },
   { LUMICE_SHAPE_SCALAR_FACE_0 + 1, "Face 1", 0.0f, 2.0f, "%.3f", SliderScale::kLinear },
@@ -334,7 +336,7 @@ using lumice::gui::slider_mapping::LogNormToValue;
 using lumice::gui::slider_mapping::LogValueToNorm;
 
 // ============================================================
-// Convention 1 — Prism Height: [0.01, 100] kLog
+// Convention 1 — the two nonlinear laws: kLog and the kLogLinear hybrid
 // ============================================================
 
 // ---- Slider value <-> normalized position, one convention per shape scalar ----
@@ -352,9 +354,10 @@ TEST(SliderMapping, EachLawPinsItsEndsAndItsCharacteristicPoint) {
     float norm;
     float value_tol;
   };
-  // Prism height is logarithmic over [0.01, 100], so the geometric midpoint -- not the arithmetic
-  // one -- sits at the middle of the slider. That is the whole point of the law: 0.1 and 10 are
-  // equally far from 1.
+  // The pure log law, over the [0.01, 100] band the background-scale field uses: the geometric
+  // midpoint -- not the arithmetic one -- sits at the middle of the slider. That is the whole point
+  // of the law: 0.1 and 10 are equally far from 1. (No shape scalar rides this law today; the two
+  // that span decades take the hybrid below, which can also reach its own floor exactly.)
   const AnchorCase kLogCases[] = {
     { "log, low end", 0.01f, 0.0f, 1e-6f },
     { "log, geometric midpoint", 1.0f, 0.5f, 1e-4f },
@@ -368,15 +371,16 @@ TEST(SliderMapping, EachLawPinsItsEndsAndItsCharacteristicPoint) {
   // The pyramid prism height must reach exactly zero, which a pure log law cannot do, so it is
   // linear below a switch point and logarithmic above it. The switch is the characteristic point
   // here, and it must be continuous: the two halves have to agree on the value there, or the slider
-  // jumps under the cursor as it crosses.
+  // jumps under the cursor as it crosses. These cases pin the min_val = 0 instance; the
+  // positive-floor instance is pinned by TheHybridLawHonoursWhateverFloorItIsGiven below.
   const AnchorCase kLogLinearCases[] = {
     { "log-linear, exact zero", 0.0f, 0.0f, 0.0f },
     { "log-linear, the switch point", kLogLinearX0, kLogLinearTSwitch, 1e-6f },
     { "log-linear, high end", 100.0f, 1.0f, 1e-3f },
   };
   for (const AnchorCase& c : kLogLinearCases) {
-    EXPECT_NEAR(LogLinearValueToNorm(c.value, 100.0f), c.norm, 1e-6f) << c.name;
-    EXPECT_NEAR(LogLinearNormToValue(c.norm, 100.0f), c.value, c.value_tol) << c.name;
+    EXPECT_NEAR(LogLinearValueToNorm(c.value, 0.0f, 100.0f), c.norm, 1e-6f) << c.name;
+    EXPECT_NEAR(LogLinearNormToValue(c.norm, 0.0f, 100.0f), c.value, c.value_tol) << c.name;
   }
 }
 
@@ -400,12 +404,12 @@ TEST(SliderMapping, EachLawIsInvertibleAndNeverGoesBackwards) {
   // law stitched from two pieces can be invertible on each piece and still lose the seam.
   constexpr float kLogLinearSamples[] = { 0.0f, 0.005f, 0.01f, 0.05f, 0.2f, 1.0f, 10.0f, 50.0f, 100.0f };
   for (float value : kLogLinearSamples) {
-    const float round_trip = LogLinearNormToValue(LogLinearValueToNorm(value, 100.0f), 100.0f);
+    const float round_trip = LogLinearNormToValue(LogLinearValueToNorm(value, 0.0f, 100.0f), 0.0f, 100.0f);
     EXPECT_NEAR(round_trip, value, std::max(value, 1e-3f) * 1e-3f) << "log-linear value=" << value;
   }
-  float prev_log_linear = LogLinearNormToValue(0.0f, 100.0f);
+  float prev_log_linear = LogLinearNormToValue(0.0f, 0.0f, 100.0f);
   for (int i = 1; i <= 40; ++i) {
-    const float value = LogLinearNormToValue(static_cast<float>(i) / 40.0f, 100.0f);
+    const float value = LogLinearNormToValue(static_cast<float>(i) / 40.0f, 0.0f, 100.0f);
     // Non-decreasing rather than increasing: the two pieces may tie exactly at the seam.
     EXPECT_GE(value, prev_log_linear) << "log-linear step " << i;
     prev_log_linear = value;
@@ -447,11 +451,197 @@ TEST(SliderMapping, EndpointSnappingWritesBackTheBoundExactly) {
   EXPECT_FLOAT_EQ(LogNormToValueSnapped(0.5f, 0.01f, 100.0f), LogNormToValue(0.5f, 0.01f, 100.0f));
 
   // Pyramid prism height: log-linear hybrid over [0, 100].
-  EXPECT_EQ(LogLinearNormToValueSnapped(1.0f, 100.0f), 100.0f);
-  EXPECT_EQ(LogLinearNormToValueSnapped(0.0f, 100.0f), 0.0f);
-  EXPECT_EQ(LogLinearNormToValueSnapped(1.25f, 100.0f), 100.0f);
-  EXPECT_EQ(LogLinearNormToValueSnapped(-0.25f, 100.0f), 0.0f);
-  EXPECT_FLOAT_EQ(LogLinearNormToValueSnapped(0.5f, 100.0f), LogLinearNormToValue(0.5f, 100.0f));
+  EXPECT_EQ(LogLinearNormToValueSnapped(1.0f, 0.0f, 100.0f), 100.0f);
+  EXPECT_EQ(LogLinearNormToValueSnapped(0.0f, 0.0f, 100.0f), 0.0f);
+  EXPECT_EQ(LogLinearNormToValueSnapped(1.25f, 0.0f, 100.0f), 100.0f);
+  EXPECT_EQ(LogLinearNormToValueSnapped(-0.25f, 0.0f, 100.0f), 0.0f);
+  EXPECT_FLOAT_EQ(LogLinearNormToValueSnapped(0.5f, 0.0f, 100.0f), LogLinearNormToValue(0.5f, 0.0f, 100.0f));
+}
+
+// ---- The hybrid law under a floor other than zero ----
+//
+// The linear segment of the log-linear law used to start at a hardcoded 0. It now starts at the
+// floor the domain declares, which is what lets one law serve both a scalar that must reach exactly
+// zero and one whose control refuses to go below a small positive number. Two propositions have to
+// hold for that generalization to be safe, and they pull in opposite directions: the zero-floor
+// instance must be untouched, and the positive-floor instance must actually honour its floor.
+
+TEST(SliderMapping, TheHybridLawIsUnchangedWhereItsFloorIsZero) {
+  // The expectations here are the PRE-generalization formulas, written out independently rather
+  // than obtained by calling the functions under test with a second set of arguments -- calling the
+  // new code twice would agree with itself no matter what the edit did. EXPECT_EQ, not
+  // EXPECT_FLOAT_EQ: with min_val = 0 the new expressions reduce to the old ones term for term
+  // (x + 0, y - 0), so the result is bit-identical, and anything less than bit-identical here would
+  // mean the reduction is not what it is claimed to be.
+  constexpr float kSamples[] = { 0.0f, 1e-5f, 0.001f, 0.005f, kLogLinearX0, 0.05f, 1.0f, 25.0f, 100.0f };
+  for (float value : kSamples) {
+    const float clamped = std::clamp(value, 0.0f, 100.0f);
+    float expect_norm = 0.0f;
+    if (clamped <= kLogLinearX0) {
+      expect_norm = kLogLinearTSwitch * clamped / kLogLinearX0;  // the old linear segment
+    } else {
+      expect_norm = kLogLinearTSwitch +
+                    (1.0f - kLogLinearTSwitch) * std::log(clamped / kLogLinearX0) / std::log(100.0f / kLogLinearX0);
+    }
+    EXPECT_EQ(LogLinearValueToNorm(value, 0.0f, 100.0f), std::clamp(expect_norm, 0.0f, 1.0f)) << "value=" << value;
+  }
+  for (int i = 0; i <= 40; ++i) {
+    const float norm = static_cast<float>(i) / 40.0f;
+    float expect_value = 0.0f;
+    if (norm <= kLogLinearTSwitch) {
+      expect_value = kLogLinearX0 * norm / kLogLinearTSwitch;  // the old linear segment's inverse
+    } else {
+      const float t_log = (norm - kLogLinearTSwitch) / (1.0f - kLogLinearTSwitch);
+      expect_value = kLogLinearX0 * std::exp(t_log * std::log(100.0f / kLogLinearX0));
+    }
+    EXPECT_EQ(LogLinearNormToValue(norm, 0.0f, 100.0f), expect_value) << "norm=" << norm;
+  }
+  // And the snapped inverse still writes back a literal zero at the left stop, which is the whole
+  // reason the pyramid's prism height can be switched off from the slider at all.
+  EXPECT_EQ(LogLinearNormToValueSnapped(0.0f, 0.0f, 100.0f), 0.0f);
+  EXPECT_EQ(LogLinearNormToValueSnapped(-1.0f, 0.0f, 100.0f), 0.0f);
+}
+
+TEST(SliderMapping, TheHybridLawHonoursWhateverFloorItIsGiven) {
+  // The prism height's band. Its floor exists to stay clear of the gate core applies to the same
+  // quantity (a height must be strictly greater than 1e-5), so "the left stop is the floor" is not
+  // cosmetic: a stop that landed a few ULP below would hand core a value it rejects.
+  const ShapeScalarDomain& height = ShapeScalarDomainFor(LUMICE_SHAPE_SCALAR_HEIGHT);
+  const float floor_v = height.min_value;
+  const float max_v = height.max_value;
+  EXPECT_GT(floor_v, 1e-5f) << "the floor must clear core's strictly-greater-than gate";
+  EXPECT_LT(floor_v, kLogLinearX0) << "the linear segment [floor, x0] must be non-degenerate";
+
+  // Ends. EXPECT_EQ rather than EXPECT_NEAR: the endpoint snap exists precisely so the value at a
+  // stop is the bound itself and not the bound recovered through a round trip.
+  EXPECT_EQ(LogLinearValueToNorm(floor_v, floor_v, max_v), 0.0f);
+  EXPECT_EQ(LogLinearNormToValue(0.0f, floor_v, max_v), floor_v);
+  EXPECT_EQ(LogLinearNormToValueSnapped(0.0f, floor_v, max_v), floor_v);
+  EXPECT_EQ(LogLinearNormToValueSnapped(-0.25f, floor_v, max_v), floor_v);
+  EXPECT_EQ(LogLinearNormToValueSnapped(1.0f, floor_v, max_v), max_v);
+
+  // Below the floor is clamped up to it, not down to zero -- the failure this replaces would have
+  // let the left third of the travel report a value the control does not offer.
+  EXPECT_EQ(LogLinearValueToNorm(0.0f, floor_v, max_v), 0.0f);
+  EXPECT_GE(LogLinearNormToValue(0.0f, floor_v, max_v), floor_v);
+
+  // The seam. The log segment is anchored at kLogLinearX0 whatever the floor is, so the two halves
+  // must still meet there; a discontinuity is a slider that jumps under the cursor.
+  EXPECT_NEAR(LogLinearValueToNorm(kLogLinearX0, floor_v, max_v), kLogLinearTSwitch, 1e-6f);
+  EXPECT_NEAR(LogLinearNormToValue(kLogLinearTSwitch, floor_v, max_v), kLogLinearX0, 1e-6f);
+
+  // Invertible and never backwards over the whole travel, seam included.
+  float prev = LogLinearNormToValue(0.0f, floor_v, max_v);
+  for (int i = 1; i <= 200; ++i) {
+    const float norm = static_cast<float>(i) / 200.0f;
+    const float value = LogLinearNormToValue(norm, floor_v, max_v);
+    EXPECT_GE(value, prev) << "step " << i;
+    EXPECT_NEAR(LogLinearValueToNorm(value, floor_v, max_v), norm, 1e-4f) << "step " << i;
+    prev = value;
+  }
+}
+
+// ---- Display quantization must match the slider's own quantization ----
+//
+// A slider and the number beside it quantize independently, and the two kinds have to agree.
+// "%.Nf" quantizes ABSOLUTELY: it can tell values apart when they differ by more than a fixed
+// step. "%.Ng" quantizes RELATIVELY: by more than a fixed fraction of the value. A kLinear slider
+// moves the value by a constant amount per pixel of travel; kLog and kLogLinear (above its switch
+// point) move it by a constant fraction per pixel. Pair a relative slider with an absolute format
+// and the low decades render as a run of identical strings: the handle moves and the number does
+// not, which is indistinguishable from a frozen control.
+//
+// The assertion below is deliberately about MARGIN rather than about today's state. A row can be
+// one pixel of extra slider width away from breaking and still pass a "no collisions right now"
+// check, looking exactly like a row with twenty times the headroom.
+
+// The widest a Value-column slider gets: measured with the crystal edit modal's own layout, from
+// the item rectangle ImGui gave the slider -- 179 px in the horizontal (820 px) modal and 127 px in
+// the vertical (420 px) one. The slider does NOT span the modal: it lives in the single stretch
+// column of a five-column property table, alongside four fixed-width cells.
+constexpr int kMeasuredMaxSliderWidthPx = 179;
+
+// The travel model is one sample per pixel. ImGui's actual position resolution is 1/(w - grab_w),
+// i.e. COARSER than this, so a row that resolves every pixel here resolves every position ImGui can
+// actually produce. Keyboard nudges are outside the model.
+struct NonlinearRow {
+  const char* name;
+  float min_value;
+  float max_value;
+  const char* fmt;
+  SliderScale scale;
+  bool excluded;
+};
+
+float NormToValueForRow(const NonlinearRow& row, float norm) {
+  switch (row.scale) {
+    case SliderScale::kLog:
+      return LogNormToValue(norm, row.min_value, row.max_value);
+    case SliderScale::kLogLinear:
+      return LogLinearNormToValue(norm, row.min_value, row.max_value);
+    case SliderScale::kSqrt: {
+      const float sqrt_val = norm * std::sqrt(row.max_value);
+      return sqrt_val * sqrt_val;
+    }
+    case SliderScale::kLinear:
+      break;
+  }
+  return row.min_value + (row.max_value - row.min_value) * norm;
+}
+
+// The number of adjacent pixel pairs that format to the same string over the whole travel.
+int CountAdjacentPixelCollisions(const NonlinearRow& row, int width_px) {
+  char prev[64] = { 0 };
+  char cur[64] = { 0 };
+  int collisions = 0;
+  for (int i = 0; i <= width_px; ++i) {
+    const float norm = static_cast<float>(i) / static_cast<float>(width_px);
+    std::snprintf(cur, sizeof(cur), row.fmt, NormToValueForRow(row, norm));
+    if (i > 0 && std::strcmp(cur, prev) == 0) {
+      ++collisions;
+    }
+    std::memcpy(prev, cur, sizeof(prev));
+  }
+  return collisions;
+}
+
+TEST(ShapeScalarDomain, EveryNonlinearRowResolvesEveryPixelOfItsSliderWithMargin) {
+  const ShapeScalarDomain& height = ShapeScalarDomainFor(LUMICE_SHAPE_SCALAR_HEIGHT);
+  const ShapeScalarDomain& prism_h = ShapeScalarDomainFor(LUMICE_SHAPE_SCALAR_PRISM_H);
+  const NonlinearRow kRows[] = {
+    { "Height", height.min_value, height.max_value, height.fmt, height.scale, false },
+    { "Prism H", prism_h.min_value, prism_h.max_value, prism_h.fmt, prism_h.scale, false },
+    // The crystal axis orientation sliders (app_panels.cpp), listed rather than omitted so the
+    // boundary of this assertion is visible where the assertion is. They are excluded on a
+    // mechanism, not on a name: a kSqrt slider's step per pixel is proportional to the square root
+    // of the value, which is neither a constant amount nor a constant fraction, so neither family
+    // of format matches it and "pick the format that matches the law" has no answer to give here
+    // yet. Their domains are spelled at their call sites.
+    { "Std", 0.0f, 180.0f, "%.1f", SliderScale::kSqrt, true },
+    { "Range", 0.0f, 360.0f, "%.1f", SliderScale::kSqrt, true },
+    { "Amplitude", 0.0f, 90.0f, "%.1f", SliderScale::kSqrt, true },
+    { "Scale", 0.0f, 90.0f, "%.1f", SliderScale::kSqrt, true },
+  };
+
+  for (const NonlinearRow& row : kRows) {
+    // The exclusion is derived from the row's law, not from its name: this is what stops a row
+    // from being quietly parked outside the assertion by adding a flag to it.
+    EXPECT_EQ(row.excluded, row.scale == SliderScale::kSqrt) << row.name;
+    if (row.excluded) {
+      continue;
+    }
+    // Today's width, then two and three times it. The multiples are the point: collisions appear
+    // as the slider gets WIDER (more pixels over the same range means a smaller step per pixel),
+    // never disappear, so zero collisions at 3x the measured width means the width at which this
+    // row would first break is beyond 3x -- a margin, not a coin flip. A row that only clears the
+    // 1x check is one layout change away from a frozen readout and would be indistinguishable, in
+    // a green run, from a row with room to spare.
+    for (int multiple : { 1, 2, 3 }) {
+      const int width = kMeasuredMaxSliderWidthPx * multiple;
+      EXPECT_EQ(CountAdjacentPixelCollisions(row, width), 0)
+          << row.name << " at " << multiple << "x the measured slider width (" << width << " px)";
+    }
+  }
 }
 
 using lumice::gui::AspectFitResult;

--- a/test/unit-correctness/gui/test_gui_widget_rules.cpp
+++ b/test/unit-correctness/gui/test_gui_widget_rules.cpp
@@ -27,6 +27,7 @@
 #include "gui/gui_constants.hpp"
 #include "gui/shape_scalar_domain.hpp"
 #include "gui/sim_state_rules.hpp"
+#include "gui/slider_format_rules.hpp"
 #include "gui/slider_mapping.hpp"
 #include "gui/sun_circle_rules.hpp"
 #include "gui/window_sizing.hpp"
@@ -549,19 +550,26 @@ TEST(SliderMapping, TheHybridLawHonoursWhateverFloorItIsGiven) {
 // "%.Nf" quantizes ABSOLUTELY: it can tell values apart when they differ by more than a fixed
 // step. "%.Ng" quantizes RELATIVELY: by more than a fixed fraction of the value. A kLinear slider
 // moves the value by a constant amount per pixel of travel; kLog and kLogLinear (above its switch
-// point) move it by a constant fraction per pixel. Pair a relative slider with an absolute format
-// and the low decades render as a run of identical strings: the handle moves and the number does
-// not, which is indistinguishable from a frozen control.
+// point) move it by a constant fraction per pixel. Pair a format that is too coarse for the law
+// and a stretch of travel renders as a run of identical strings: the handle moves and the number
+// does not, which is indistinguishable from a frozen control.
 //
-// The assertion below is deliberately about MARGIN rather than about today's state. A row can be
-// one pixel of extra slider width away from breaking and still pass a "no collisions right now"
-// check, looking exactly like a row with twenty times the headroom.
-
-// The widest a Value-column slider gets: measured with the crystal edit modal's own layout, from
-// the item rectangle ImGui gave the slider -- 179 px in the horizontal (820 px) modal and 127 px in
-// the vertical (420 px) one. The slider does NOT span the modal: it lives in the single stretch
-// column of a five-column property table, alongside four fixed-width cells.
-constexpr int kMeasuredMaxSliderWidthPx = 179;
+// WHAT IS ASSERTED, AND WHY IT IS NOT "no two adjacent pixels agree". That earlier criterion
+// counted collisions, and collisions rank these rows almost backwards: at the measured width the
+// sun-diameter row scored 130 collisions with a maxrun of 4, the six `*_alpha` rows 79 collisions
+// at a maxrun of 2 (a single repeated pixel, which nobody can perceive), while the worst row ever
+// found here -- the prism height under its old "%.2f" -- scored only 57 collisions at a maxrun of
+// 20. The quantity a reader actually experiences is the RUN: how far the handle travels with the
+// number standing still. So the assertion is `maxrun <= kPairingGateSlackPx`, and the tolerance is
+// a named constant in gui/slider_format_rules.hpp rather than a hardcoded zero, because zero is
+// merely its strictest setting and not an obviously right one.
+//
+// This runtime scan and the compile-time gate in gui/slider_format_rules.hpp are complements, not
+// duplicates. The gate is TOTAL over the tables it sits on, so a row added later cannot escape it
+// by not being listed here; but it answers only yes/no, and its bound is sufficient rather than
+// necessary. This scan covers only the rows written below, but it MEASURES -- it is where the
+// number that says how bad a mismatch is comes from, and it is the oracle the gate is checked
+// against further down.
 
 // The travel model is one sample per pixel. ImGui's actual position resolution is 1/(w - grab_w),
 // i.e. COARSER than this, so a row that resolves every pixel here resolves every position ImGui can
@@ -572,7 +580,6 @@ struct NonlinearRow {
   float max_value;
   const char* fmt;
   SliderScale scale;
-  bool excluded;
 };
 
 float NormToValueForRow(const NonlinearRow& row, float norm) {
@@ -591,68 +598,172 @@ float NormToValueForRow(const NonlinearRow& row, float norm) {
   return row.min_value + (row.max_value - row.min_value) * norm;
 }
 
-// The number of adjacent pixel pairs that format to the same string over the whole travel.
-int CountAdjacentPixelCollisions(const NonlinearRow& row, int width_px) {
+// The longest stretch of consecutive pixels over the whole travel that format to the same string,
+// i.e. the dead travel in pixels. 1 means every pixel of drag changes the readout.
+int LongestIdenticalReadoutRun(const NonlinearRow& row, int width_px) {
   char prev[64] = { 0 };
   char cur[64] = { 0 };
-  int collisions = 0;
+  int longest = 0;
+  int run = 0;
   for (int i = 0; i <= width_px; ++i) {
     const float norm = static_cast<float>(i) / static_cast<float>(width_px);
     std::snprintf(cur, sizeof(cur), row.fmt, NormToValueForRow(row, norm));
-    if (i > 0 && std::strcmp(cur, prev) == 0) {
-      ++collisions;
-    }
+    run = (i > 0 && std::strcmp(cur, prev) == 0) ? run + 1 : 1;
+    longest = std::max(longest, run);
     std::memcpy(prev, cur, sizeof(prev));
   }
-  return collisions;
+  return longest;
 }
 
-TEST(ShapeScalarDomain, EveryNonlinearRowResolvesEveryPixelOfItsSliderWithMargin) {
+TEST(ShapeScalarDomain, EveryPairedRowChangesItsReadoutWithinTheToleratedDrag) {
   const ShapeScalarDomain& height = ShapeScalarDomainFor(LUMICE_SHAPE_SCALAR_HEIGHT);
   const ShapeScalarDomain& prism_h = ShapeScalarDomainFor(LUMICE_SHAPE_SCALAR_PRISM_H);
+  // The two shape-table rows are read from the table; the five call-site rows below are written out
+  // independently, the same way kExpected[] above is written out rather than read from the table it
+  // checks. Their production spellings are function-local constants inside RenderAxisDist
+  // (panels.cpp) and the sun.diameter registration (field_editor_registry.cpp), which no other
+  // translation unit can see -- and even if they could, a scan that sourced its inputs from the
+  // thing under test would agree with it by construction. A divergence here is therefore a real
+  // signal, not a missed sync: it means one of the two sides moved.
+  //
+  // The kSqrt rows are LISTED rather than excluded, which is the change this makes to the earlier
+  // shape of this test. They used to be skipped on the argument that a kSqrt slider's step is
+  // neither a constant amount nor a constant fraction, so "pick the format that matches the law"
+  // had no answer for them. The premise was right and the conclusion was not: a format does not
+  // have to MATCH the law, it has to be at least as fine as the law's smallest step, and kSqrt's
+  // smallest step -- absolute or relative -- is a finite positive number like everyone else's.
   const NonlinearRow kRows[] = {
-    { "Height", height.min_value, height.max_value, height.fmt, height.scale, false },
-    { "Prism H", prism_h.min_value, prism_h.max_value, prism_h.fmt, prism_h.scale, false },
-    // The crystal axis orientation sliders (app_panels.cpp), listed rather than omitted so the
-    // boundary of this assertion is visible where the assertion is. They are excluded on a
-    // mechanism, not on a name: a kSqrt slider's step per pixel is proportional to the square root
-    // of the value, which is neither a constant amount nor a constant fraction, so neither family
-    // of format matches it and "pick the format that matches the law" has no answer to give here
-    // yet. Their domains are spelled at their call sites.
-    { "Std", 0.0f, 180.0f, "%.1f", SliderScale::kSqrt, true },
-    { "Range", 0.0f, 360.0f, "%.1f", SliderScale::kSqrt, true },
-    { "Amplitude", 0.0f, 90.0f, "%.1f", SliderScale::kSqrt, true },
-    { "Scale", 0.0f, 90.0f, "%.1f", SliderScale::kSqrt, true },
+    { "Height", height.min_value, height.max_value, height.fmt, height.scale },
+    { "Prism H", prism_h.min_value, prism_h.max_value, prism_h.fmt, prism_h.scale },
+    { "Std", 0.0f, 180.0f, "%.3g", SliderScale::kSqrt },
+    { "Range", 0.0f, 360.0f, "%.3g", SliderScale::kSqrt },
+    { "Amplitude", 0.0f, 90.0f, "%.3g", SliderScale::kSqrt },
+    { "Scale", 0.0f, 90.0f, "%.3g", SliderScale::kSqrt },
+    { "sun.diameter", 0.1f, 5.0f, "%.2f", SliderScale::kLinear },
   };
 
   for (const NonlinearRow& row : kRows) {
-    // The exclusion is derived from the row's law, not from its name: this is what stops a row
-    // from being quietly parked outside the assertion by adding a flag to it.
-    EXPECT_EQ(row.excluded, row.scale == SliderScale::kSqrt) << row.name;
-    if (row.excluded) {
-      continue;
-    }
-    // Today's width, then two and three times it. The multiples are the point: collisions appear
-    // as the slider gets WIDER (more pixels over the same range means a smaller step per pixel),
-    // never disappear, so zero collisions at 3x the measured width means the width at which this
-    // row would first break is beyond 3x -- a margin, not a coin flip. A row that only clears the
-    // 1x check is one layout change away from a frozen readout and would be indistinguishable, in
-    // a green run, from a row with room to spare.
+    // Today's width, then two and three times it. The multiples are the point: runs get LONGER as
+    // the slider gets wider (more pixels over the same range means a smaller step per pixel), never
+    // shorter, so clearing the tolerance at 3x the measured width means the width at which this row
+    // would first exceed it is beyond 3x -- a margin, not a coin flip. A row that only clears the
+    // 1x check is one layout change away from a frozen readout and would be indistinguishable, in a
+    // green run, from a row with room to spare.
     //
-    // 3x is a deliberately temporary threshold, not a derived one, and it has a known coverage
-    // gap: substituting the measured 179 px width gives a threshold of 537 px, and a %.4f-format
-    // row's first pixel collision was measured at 675 px -- inside the 3x margin, so this gate
-    // would not have caught that mismatch (>=4x would). The gap is accepted here rather than
-    // closed by raising the multiple, because the multiple itself is a stand-in for a quantity a
-    // follow-up is expected to derive directly (a format's distinguishable precision vs. the
-    // mapping's per-pixel relative step), and fitting the constant to today's one known bad row
-    // buys a defense that is retired as soon as that quantity lands.
+    // Note for anyone re-deriving the red state this replaced: a mismatch does not have to show at
+    // every width. Under the old "%.1f", Std and Range measured a maxrun of 3 at 1x -- inside the
+    // tolerance -- and 9 and 7 at 3x. Failing at the widest bucket only is the ordinary shape of
+    // this defect, not a sign that the measurement is wrong.
     for (int multiple : { 1, 2, 3 }) {
-      const int width = kMeasuredMaxSliderWidthPx * multiple;
-      EXPECT_EQ(CountAdjacentPixelCollisions(row, width), 0)
+      const int width = slider_format::kMeasuredMaxSliderWidthPx * multiple;
+      EXPECT_LE(LongestIdenticalReadoutRun(row, width), slider_format::kPairingGateSlackPx)
           << row.name << " at " << multiple << "x the measured slider width (" << width << " px)";
     }
   }
+}
+
+// ---- The compile-time gate, checked against the scan above ----
+//
+// FormatIsFineEnough is what makes the pairing rule total over the tables it guards, so it is the
+// piece whose being WRONG would be silent: a bound that answered true for everything would compile
+// exactly as cleanly as a correct one. These tests exist to deny it that.
+
+TEST(SliderFormatGate, AFormatSpellingItCannotReadIsRejectedRatherThanAssumedFine) {
+  // The parser handles "%.Nf" and "%.Ng" and nothing else. An unreadable spelling must fail the
+  // gate, not slip past it: the gate's job is to be impossible to satisfy by accident.
+  using slider_format::FormatIsFineEnough;
+  EXPECT_FALSE(FormatIsFineEnough("%f", SliderScale::kLinear, 0.0f, 1.0f));
+  EXPECT_FALSE(FormatIsFineEnough("%.3", SliderScale::kLinear, 0.0f, 1.0f));
+  EXPECT_FALSE(FormatIsFineEnough("%.3e", SliderScale::kLinear, 0.0f, 1.0f));
+  EXPECT_FALSE(FormatIsFineEnough("%.3f mm", SliderScale::kLinear, 0.0f, 1.0f));
+  EXPECT_FALSE(FormatIsFineEnough("", SliderScale::kLinear, 0.0f, 1.0f));
+  EXPECT_FALSE(FormatIsFineEnough(nullptr, SliderScale::kLinear, 0.0f, 1.0f));
+  EXPECT_TRUE(FormatIsFineEnough("%.3f", SliderScale::kLinear, 0.0f, 1.0f));
+}
+
+TEST(SliderFormatGate, EveryLawHasABoundThatCanSayNo) {
+  // One law per row of the mapping table, each with a format it must accept and a format it must
+  // refuse. The refusals are what matter: a branch that returned true unconditionally would pass
+  // the acceptance half and is only caught here.
+  //
+  // kLog is included even though no row of either guarded table uses it today -- the one production
+  // kLog slider (bg_scale, in a registry whose domains are mostly runtime closures) is outside the
+  // gate's reach. Without this case "the gate covers four laws" would rest on the branch existing
+  // rather than on the branch working. Its band is bg_scale's own, so the case is a statement about
+  // a slider that exists: under "%.2f" that slider stands still for 30 pixels at the gate width.
+  using slider_format::FormatIsFineEnough;
+  struct Case {
+    const char* name;
+    SliderScale scale;
+    float min_value;
+    float max_value;
+    const char* fine_enough;
+    const char* too_coarse;
+  };
+  const Case kCases[] = {
+    { "kLinear", SliderScale::kLinear, 0.0f, 1.0f, "%.3f", "%.1f" },
+    { "kSqrt", SliderScale::kSqrt, 0.0f, 90.0f, "%.3g", "%.1f" },
+    { "kLog", SliderScale::kLog, 0.2f, 5.0f, "%.3g", "%.2f" },
+    { "kLogLinear", SliderScale::kLogLinear, 1e-4f, 100.0f, "%.4g", "%.2f" },
+  };
+  for (const Case& c : kCases) {
+    EXPECT_TRUE(FormatIsFineEnough(c.fine_enough, c.scale, c.min_value, c.max_value)) << c.name;
+    EXPECT_FALSE(FormatIsFineEnough(c.too_coarse, c.scale, c.min_value, c.max_value)) << c.name;
+  }
+}
+
+TEST(SliderFormatGate, NothingTheBoundAcceptsMeasuresFrozen) {
+  // The gate against its oracle, over every (law, band, format) combination below. The claim being
+  // pinned is one-sided ON PURPOSE:
+  //
+  //   accepted  => the scan measures a run within tolerance   <- asserted; a violation is a MISS,
+  //                                                              i.e. the gate waving through a
+  //                                                              defect, which is the failure mode
+  //                                                              that matters
+  //   rejected  => nothing is claimed                         <- the bound is sufficient, not
+  //                                                              necessary, so it may refuse a
+  //                                                              format that would have measured
+  //                                                              fine (kSqrt rows and "%.Ng" on a
+  //                                                              band that does not begin just
+  //                                                              above a power of ten)
+  //
+  // The counts below are reported so the second line stays honest: if a change ever made the bound
+  // reject everything, every assertion here would still pass, and only `accepted` collapsing to a
+  // handful would show it.
+  const NonlinearRow kBands[] = {
+    { "Height", 1e-4f, 100.0f, "", SliderScale::kLogLinear },
+    { "Prism H", 0.0f, 100.0f, "", SliderScale::kLogLinear },
+    { "Upper H", 0.0f, 1.0f, "", SliderScale::kLinear },
+    { "Face", 0.0f, 2.0f, "", SliderScale::kLinear },
+    { "sun.diameter", 0.1f, 5.0f, "", SliderScale::kLinear },
+    { "ray_num_millions", 0.1f, 100.0f, "", SliderScale::kLinear },
+    { "Std", 0.0f, 180.0f, "", SliderScale::kSqrt },
+    { "Range", 0.0f, 360.0f, "", SliderScale::kSqrt },
+    { "Amplitude", 0.0f, 90.0f, "", SliderScale::kSqrt },
+    { "bg_scale", 0.2f, 5.0f, "", SliderScale::kLog },
+    { "wide log", 0.01f, 100.0f, "", SliderScale::kLog },
+  };
+  const char* kFormats[] = { "%.1f", "%.2f", "%.3f", "%.4f", "%.5f", "%.1g", "%.2g", "%.3g", "%.4g", "%.5g" };
+  int accepted = 0;
+  int rejected_but_measures_fine = 0;
+  for (const NonlinearRow& band : kBands) {
+    for (const char* fmt : kFormats) {
+      const NonlinearRow row = { band.name, band.min_value, band.max_value, fmt, band.scale };
+      const int run = LongestIdenticalReadoutRun(row, slider_format::kPairingGateWidthPx);
+      if (slider_format::FormatIsFineEnough(fmt, row.scale, row.min_value, row.max_value)) {
+        ++accepted;
+        EXPECT_LE(run, slider_format::kPairingGateSlackPx) << band.name << " " << fmt;
+      } else if (run <= slider_format::kPairingGateSlackPx) {
+        ++rejected_but_measures_fine;
+      }
+    }
+  }
+  EXPECT_GT(accepted, 40) << "the bound accepts too little for this to have tested anything";
+  // Today's conservatism, pinned as a fact rather than as a target: three combinations measure fine
+  // and are refused anyway. Both directions of a change to this number are worth a look -- upward
+  // means the bound got looser in the honest direction but demands more digits, downward means it
+  // got tighter and the MISS assertions above are carrying more weight than they used to.
+  EXPECT_LE(rejected_but_measures_fine, 8) << "the bound became far more conservative than measured";
 }
 
 using lumice::gui::AspectFitResult;

--- a/test/unit-correctness/gui/test_gui_widget_rules.cpp
+++ b/test/unit-correctness/gui/test_gui_widget_rules.cpp
@@ -638,6 +638,15 @@ TEST(ShapeScalarDomain, EveryNonlinearRowResolvesEveryPixelOfItsSliderWithMargin
     // row would first break is beyond 3x -- a margin, not a coin flip. A row that only clears the
     // 1x check is one layout change away from a frozen readout and would be indistinguishable, in
     // a green run, from a row with room to spare.
+    //
+    // 3x is a deliberately temporary threshold, not a derived one, and it has a known coverage
+    // gap: substituting the measured 179 px width gives a threshold of 537 px, and a %.4f-format
+    // row's first pixel collision was measured at 675 px -- inside the 3x margin, so this gate
+    // would not have caught that mismatch (>=4x would). The gap is accepted here rather than
+    // closed by raising the multiple, because the multiple itself is a stand-in for a quantity a
+    // follow-up is expected to derive directly (a format's distinguishable precision vs. the
+    // mapping's per-pixel relative step), and fitting the constant to today's one known bad row
+    // buys a defense that is retired as soon as that quantity lands.
     for (int multiple : { 1, 2, 3 }) {
       const int width = kMeasuredMaxSliderWidthPx * multiple;
       EXPECT_EQ(CountAdjacentPixelCollisions(row, width), 0)


### PR DESCRIPTION
## 背景

两个不同根因，一起交付：

1. **柱晶高度域比 core 窄得多**。GUI 把高度钉死在 `[0.01, 100]`，而 core 的闸是 `h > 1e-5`（`crystal.cpp`，严格大于）。GUI 的域就是产品的真实域，所以用户「希望能一直调到零」在今天的 GUI 上够不着。
2. **显示量化种类与滑杆映射种类错配**。`%f` 是恒定绝对量化，`%g` 是恒定相对量化；而映射有 `kLinear`（恒定绝对步长）/ `kLog`·`kLogLinear`（恒定相对步长）/ `kSqrt`（步长 ∝ √value）。配错的后果是**滑杆动了但数字不变**。

## 改了什么

- 柱晶高度下限 `0.01 → 1e-4`（在 core 闸之上留 10× 余量；GUI 按 API 边界规则不能 include core 头，故注释里交叉引用而不共享常量）。
- `kLogLinear` 三个映射纯函数的线性段下端，从硬编码 `0` 泛化为传入的 `min_value`；`RenderNonlinearSlider` 的分支前置条件相应从 `min_val == 0` 放宽为 `min_val >= 0`。`min_value = 0` 的既有行（`Prism H`）走同一条路径且行为逐字不变。
- 新增 `src/gui/slider_format_rules.hpp`：格式串解析 + 四族映射的每像素步长下界**闭式**表达 + `FormatIsFineEnough` 谓词。闭式不依赖任何超越函数——`std::log` / `__builtin_logf` 在 clang 下都不是 `constexpr`，所以这是能落到编译期的前提。
- 把这个谓词装成 `static_assert`，且装在**表**上而不是逐行枚举（`AllRowsHaveFormatFineEnoughForTheirMapping()`），所以新增一行滑杆而格式配错时，编译期就红。
- 由该闸判出并修掉五行真缺陷：axis 四行 `%.1f → %.3g`，`sun.diameter` `%.1f → %.2f`。另有两行 `Height` / `Prism H` 的 `%.4g`。
- `modal_layout` 两张参考图 regen（数字显示宽度变了）。

## 判据本身被换掉了，这是本 PR 最值得看的一处

立项时用的判据是**相邻像素零碰撞**。实测下来它与用户可感知的缺陷**排序反向**：

| 行 | 碰撞计数 | maxrun | 真实形态 |
|---|---|---|---|
| `Height`（旧 `%.2f`） | 57 | **20** | 真坏 |
| `sun.diameter` | **130** | 4 | 轻微 |
| 六个 `*_alpha` | 79 | **2** | 良性 |

按零碰撞扫全部 30 个滑杆会报 12 行 FAIL，其中多数是良性的一像素重复——它会把六个 alpha 滑杆逼成 `%.3f`（显示 `0.530`），那是判据错误的产物，不是缺陷修复。

所以判据换成 **maxrun ≤ K**（K=3，W=537）：maxrun 就是「拖过全行程时最长连续显示同一字符串的像素数」，即**控件看起来冻住**这件事本身，而不是它的代理量。六个 `*_alpha` 与 `layer probability`（maxrun=2）**有意不纳入闸**，理由与实测值写在代码注释里。

## 验证

- **编译期闸的红态是一手施加的**：把 axis `Std` 的格式改回 `%.1f` 重新构建 ⇒ `BUILD_EXIT=1`，断言指名到行（`the Std slider's format is coarser than its kSqrt mapping resolves`）；把 `HEIGHT` 行改回 `%.2f` ⇒ 表级断言触发，证明闸装在表上不是装在被枚举的行上。还原后重建 EXIT=0。
- `./scripts/test.sh quick` → `RESULT: PASS`（gui_test 339/339）。另有一次 `fast-e2e` 红已定性为机器争用假红：该哨兵跑的是 `Lumice` CLI 二进制，`ninja -t commands Lumice` 不含 `src/gui/*`，本 PR 改动全在 `src/gui/` 与 `test/`，结构上不可能进入被测二进制；隔离重跑 3.8s（阈值 30s）。
- 五道工程门禁全部 EXIT=0；参考图除 `modal_layout` 两张外核实无需 regen（`RenderAxisDist` 只在 Edit Entry 的 Axis 分页调用，而 `modal_layout` 场景表没有 Axis 分页场景）。

## 已知边界（都不是缺陷）

- `EffectiveScale` 与 `RenderNonlinearSlider` 的回落判断是同一条规则的两份实现，靠 cross-check 测试对齐，无单一权威源。
- `ParseSliderFormat` 对 `"%.0f"` 没有用例钉住（当前 15 行覆盖范围内不出现该形状）。
- 闸今天覆盖 15 行；推广到全部 30 行需先就「良性 maxrun=2 不该判红」达成一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WnNzCQv1gKx1pWNuV4Hyqg
