### PR TITLE
fix(core): ClampUniformToIndex 的 n==0 前提由 assert 改为 FatalAbort 硬守卫

### DIFF
--- a/src/core/math.cpp
+++ b/src/core/math.cpp
@@ -14,6 +14,7 @@
 #include "core/lat_lut.hpp"
 #include "core/shared/lat_path_selection.hpp"
 #include "core/shared/pcg_shared.h"
+#include "util/fatal.hpp"
 
 
 namespace lumice {
@@ -419,7 +420,14 @@ float RandomNumberGenerator::GetUniform() {
 namespace detail {
 
 size_t ClampUniformToIndex(float u, size_t n) {
-  assert(n > 0);
+  if (n == 0) {
+    // Deliberately not an assert: assert() is a no-op under NDEBUG, and there the
+    // `n - 1` below underflows to SIZE_MAX and is handed back as if it were a
+    // valid subscript. There is no index that is correct for an empty range, so
+    // returning any value at all only hides the caller's bug — this guard is the
+    // whole reason the single owner of this conversion exists.
+    FatalAbort("ClampUniformToIndex: n must be > 0 (got n == 0)");
+  }
   const size_t j = static_cast<size_t>(u * static_cast<float>(n));
   return j >= n ? n - 1 : j;
 }

--- a/src/core/math.hpp
+++ b/src/core/math.hpp
@@ -226,7 +226,9 @@ namespace detail {
 //!   the C++ standard. Changing toolchain or platform does not make the clamp unnecessary; it
 //!   only changes which implementations reach it.
 //! @param u a draw from RandomNumberGenerator::GetUniform(); values outside [0, 1] are not expected
-//! @param n the exclusive upper bound; must be > 0
+//! @param n the exclusive upper bound; must be > 0. `n == 0` calls lumice::FatalAbort (it is a
+//!   hard guard, not an assert, so it holds under NDEBUG too): no subscript is correct for an
+//!   empty range, and the pre-guard body underflowed `n - 1` into SIZE_MAX and returned it.
 size_t ClampUniformToIndex(float u, size_t n);
 
 }  // namespace detail

--- a/test/unit-correctness/core/test_rng.cpp
+++ b/test/unit-correctness/core/test_rng.cpp
@@ -153,6 +153,9 @@ TEST_F(RngTest, ClampUniformToIndexLeavesInteriorDrawsUnchanged) {
 }
 
 
+// Deliberately a bare TEST, not TEST_F(RngTest, ...) like its neighbours: a death
+// test forks, and running RngTest's fixture setup in the child would add unrelated
+// side effects to the one call being isolated here.
 TEST(ClampUniformToIndexDeathTest, ZeroNTripsFatalAbort) {
   // n == 0 has no correct answer: there is no subscript into an empty range. The
   // pre-guard body reached `n - 1` and underflowed it to SIZE_MAX, then returned

--- a/test/unit-correctness/core/test_rng.cpp
+++ b/test/unit-correctness/core/test_rng.cpp
@@ -153,6 +153,22 @@ TEST_F(RngTest, ClampUniformToIndexLeavesInteriorDrawsUnchanged) {
 }
 
 
+TEST(ClampUniformToIndexDeathTest, ZeroNTripsFatalAbort) {
+  // n == 0 has no correct answer: there is no subscript into an empty range. The
+  // pre-guard body reached `n - 1` and underflowed it to SIZE_MAX, then returned
+  // that as if it were an index — a defect that neither reports nor crashes, only
+  // subscripts somewhere semantically wrong. FatalAbort turns it into an immediate,
+  // visible failure.
+  //
+  // FatalAbort calls std::abort() unconditionally. Unlike an assert() it is NOT
+  // compiled out under NDEBUG, so this case runs identically in Debug and Release
+  // and needs no `#ifndef NDEBUG` split. The matcher pins the diagnostic text, not
+  // just the fact that the process died: fatal.hpp writes it to stderr and fflush()es
+  // before abort(), so a death test can see it.
+  EXPECT_DEATH(lumice::detail::ClampUniformToIndex(0.5f, 0u), "n must be > 0");
+}
+
+
 TEST_F(RngTest, GetUniformIndexConsumesExactlyOneDraw) {
   // The "RNG draw sequence is bit-unchanged" acceptance condition, at the unit
   // level: swapping a hand-written `(size_t)(GetUniform() * n)` for


### PR DESCRIPTION
> ⚠️ **本 PR 叠在 #307 之上**（base = `fix/gui-test-harness-gates`，不是 main），
> 因为它的绿 AC 依赖 #307 修掉的那道恒红闸。**请在 #307 合入之后再合本 PR**；
> #307 合入时 GitHub 会自动把本 PR 的 base 改回 main，diff 只含下面两个 commit。

## 问题

`detail::ClampUniformToIndex(float u, size_t n)`（`src/core/math.cpp`）是 PR #303 刚确立的
「`GetUniform()` 抽样转下标」单一 owner，但它内部只用 `assert(n > 0)` 守着前提：

```cpp
size_t ClampUniformToIndex(float u, size_t n) {
  assert(n > 0);                      // Release 下是 no-op
  const size_t j = static_cast<size_t>(u * static_cast<float>(n));
  return j >= n ? n - 1 : j;          // n==0 时命中此支，n-1 下溢成 SIZE_MAX
}
```

Release 下 `n == 0` 会静默返回 `SIZE_MAX`——不报错、不崩溃，只是把一个巨大的、语义错误的下标
交给调用方。**今天不是活缺陷**（四个生产调用点结构上都保证 `n >= 1`，本次已复核仍成立、
无第五个调用点），本 PR 是把这个单一 owner 内部**唯一还靠调用方自觉的软约束**换成硬约束。

## 修法：选 `FatalAbort` 而不是 `return 0`

`n == 0` 意味着要从空区间里取下标——**不存在任何对它而言正确的返回值**。`return 0` 不是把错误
变安全，只是把一个显眼的错值（`SIZE_MAX`）换成一个看起来合法的错值；调用方紧接着的
`container[0]` 在空容器上仍是 UB，只是不再显眼。而 `src/util/fatal.hpp` 已经是本仓
"unrecoverable-invariant trap" 的单一 owner，现有三个调用点都是同一形态。

`FatalAbort` 无条件 `std::abort()`，不随 `NDEBUG` 消失——这正是本 PR 要的性质。

## 红态自证

把守卫改回 `assert(n > 0)`（**Release 构建**，`NDEBUG` 生效），新测试如期转红：

```
test_rng.cpp: Failure
Death test: lumice::detail::ClampUniformToIndex(0.5f, 0u)
    Result: failed to die.
[  FAILED  ] ClampUniformToIndexDeathTest.ZeroNTripsFatalAbort
```

即旧实现下进程根本没死——它算出 `SIZE_MAX` 并正常返回了。改回修复版后转绿。

## ⚠️ 请特别看一眼 CI：这是本仓第一条真正执行的 gtest 死亡测试

计划阶段一度把 `RenderConsumerEmptyBatchDeathTest` 当作「死亡测试在本仓三平台已验证可用」的
先例。**该依据不成立**：那条测试整体包在 `#ifndef NDEBUG` 内
（`test/unit-correctness/server/test_render_consumer_empty_batch.cpp:80`），`#else` 分支是
`GTEST_SKIP()`，而 CI 与本地都构建 Release ⇒ **它在任何 CI 腿上都没有真正跑过**。

⇒ 本 PR 新增的这条会是本仓第一条在 Release 下真正执行的死亡测试；且既有那条用的是空 matcher
`""`，「匹配实际诊断消息」在本仓同样无先例。matcher 能成立的机制已白盒核实
（`fatal.hpp` 写 stderr + `abort()` 前显式 `fflush`），但**跨平台行为只能由本 PR 的 CI 回答**，
没有可以免检的历史先例。按 a51 不预先设计平台特化——先让它在三条腿上真跑一次。

## 验证

- 红/绿双态自证如上（Release 构建）
- `./scripts/test.sh quick` 全绿
- 五道工程门禁 rc=0：`check_policies.py` / `check_new_refs.py` / `check_new_gui_tests.py` /
  `check_loop_fatal_asserts.py` / `format.sh --check`
- 改动严格限于 `src/core/math.{hpp,cpp}` 与 `test/unit-correctness/core/test_rng.cpp`；
  未碰 `GetUniformIndex` 语义、四个调用点、`GetUniform()`

## 评审

两位独立评审 APPROVE（0 Critical / 0 Major）。Minor 1（死亡测试用裸 `TEST` 而非 `TEST_F`
的理由没写进代码）已由第二个 commit 采纳。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYUQjkoHUfvHDF1xzk829e