### PR TITLE
feat(bench): 让「本地构建不是出货二进制」这件事在取数字的地方可见（ISA 出处）

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,41 @@ if(MSVC)
   set(CMAKE_DEBUG_POSTFIX "d")
 endif()
 
+# Make the local-build-vs-shipped-binary ISA gap visible at configure time. Local
+# scripts/build.sh does not pass LUMICE_NATIVE_ARCH and therefore takes the ON default,
+# while release.yml and every ci.yml job pass -DLUMICE_NATIVE_ARCH=OFF explicitly. That
+# default is deliberate (a developer machine should build for itself and run fast); what
+# it must not do is stay invisible at the point where someone reads a throughput number
+# off this build and compares it with another platform. See doc/performance-testing.md,
+# section "Local builds are not the shipped binary".
+# Deliberately conditional wording ("would apply"): this message runs once at configure
+# time, whereas the -march=native gate below adds $<CONFIG:Release> and is only resolved
+# per-configuration at generate/build time, so an assertive phrasing would be wrong for a
+# Debug build with the option ON.
+if(MSVC)
+  message(STATUS "LUMICE_NATIVE_ARCH: not applicable to MSVC (no equivalent flag is wired "
+                 "up); this build already matches the release ISA baseline.")
+elseif(LUMICE_NATIVE_ARCH)
+  message(STATUS "LUMICE_NATIVE_ARCH=ON (local default): a Release build would apply "
+                 "-march=native, so its binary is NOT the one release ships. Fine for local "
+                 "iteration; take any cross-platform or externally quoted throughput number "
+                 "with -DLUMICE_NATIVE_ARCH=OFF instead. See doc/performance-testing.md.")
+else()
+  message(STATUS "LUMICE_NATIVE_ARCH=OFF: this build matches the release ISA baseline.")
+endif()
+
+# Persist the compiler id into CMakeCache.txt for test tooling that has to answer "was
+# -march=native actually compiled into this binary?" from a source independent of the
+# C++ macro path it is checking. CMake itself keeps CMAKE_CXX_COMPILER_ID only in
+# CMakeFiles/<cmake-version>/CMakeCXXCompiler.cmake, whose per-version directory name is
+# an internal layout detail; this snapshot is a plain cache entry instead.
+# MUST stay outside any if(MSVC)/if(NOT MSVC) branch: the value is equally needed on
+# MSVC (where it reads "MSVC"), and burying it in one branch would silently downgrade
+# that cross-check to a skip on the platforms it did not run on.
+set(LUMICE_COMPILER_ID_SNAPSHOT "${CMAKE_CXX_COMPILER_ID}" CACHE STRING
+    "Snapshot of CMAKE_CXX_COMPILER_ID at configure time (read by test tooling)." FORCE)
+mark_as_advanced(LUMICE_COMPILER_ID_SNAPSHOT)
+
 # MinGW: statically link GCC runtime (libgcc, libstdc++, libwinpthread) so the
 # distributed .exe is self-contained and doesn't require MinGW DLLs on the target machine.
 if(MINGW)
@@ -685,10 +720,25 @@ if(NOT MSVC)
   # Debug 构建不设置此标志，所有符号均可见，便于调试。
   # NOTE: 当前仅支持 GCC/Clang。若需支持 MSVC 共享库，需将 pragma 改为
   # LUMICE_API 宏（__declspec(dllexport/dllimport)），参见 lumice.h 中的注释。
+  # Single source of truth for "this compile actually applies -march=native". Both the
+  # compile-option gate below and the LUMICE_NATIVE_ARCH_ACTIVE macro that reports the ISA
+  # tier in --benchmark output reference this one variable, so the flag and the number's
+  # provenance cannot independently drift out of sync. (Its inner $<CONFIG:Release> is
+  # redundant with the outer $<$<CONFIG:Release>:...> wrapper below; that redundancy is the
+  # price of the two gates being literally the same expression.)
+  set(LUMICE_NATIVE_ARCH_ACTIVE_COND "$<AND:$<CONFIG:Release>,$<BOOL:${LUMICE_NATIVE_ARCH}>>")
+
   target_compile_options(lumice_obj PRIVATE
     $<$<CONFIG:Debug>:-O0 -g -ggdb>
-    $<$<CONFIG:Release>:$<$<BOOL:${LUMICE_NATIVE_ARCH}>:-march=native> -ffunction-sections -fdata-sections -fvisibility=hidden>
+    $<$<CONFIG:Release>:$<${LUMICE_NATIVE_ARCH_ACTIVE_COND}:-march=native> -ffunction-sections -fdata-sections -fvisibility=hidden>
     $<$<CONFIG:MinSizeRel>:-ffunction-sections -fdata-sections -fvisibility=hidden>)
+
+  # PUBLIC, not PRIVATE: src/main.cpp is not part of lumice_obj — it reaches this macro
+  # through Lumice --PRIVATE--> lumice --PUBLIC--> lumice_obj, the same two-hop usage
+  # requirement chain LUMICE_CUDA_ENABLED already relies on above. No MSVC counterpart is
+  # needed: the macro should never be defined there, and #if defined() gives that for free.
+  target_compile_definitions(lumice_obj PUBLIC
+    $<${LUMICE_NATIVE_ARCH_ACTIVE_COND}:LUMICE_NATIVE_ARCH_ACTIVE=1>)
 endif()
 
 # Library target — static or shared per BUILD_SHARED_LIBS; reuses lumice_obj objects.

--- a/doc/performance-testing.md
+++ b/doc/performance-testing.md
@@ -172,6 +172,50 @@ discipline:
    after the fact — the fix is rule 3's `ray_num` floor, large enough that the run reliably
    spans multiple poll intervals and lands on `steady` instead.
 
+## ⚠️ A local build is not the shipped binary: `-march=native` is on by default here and off everywhere else
+
+This one is not about *which* number `--benchmark` reports; it is about *which binary* produced
+it. It has already cost one cross-platform conclusion, which was written down and acted on
+before the cause was found.
+
+**Mechanism.** `option(LUMICE_NATIVE_ARCH ... ON)` (`CMakeLists.txt:43`) expands to
+`-march=native` for Release builds on GCC/Clang (`CMakeLists.txt:733`). Three facts about who
+passes it:
+
+- **Local**: `scripts/build.sh` does not pass the option at all, so every local build takes the
+  `ON` default. That default is deliberate — a developer machine should build for itself.
+- **Shipped**: `.github/workflows/release.yml:135` and all seven configure steps in
+  `.github/workflows/ci.yml` pass `-DLUMICE_NATIVE_ARCH=OFF` explicitly. What ships, and what CI
+  measures, is the baseline ISA.
+- **MSVC**: the option is only read inside the `if(NOT MSVC)` branch, so a Windows/MSVC build has
+  no equivalent to turn on. It is *structurally* incapable of being on the local side of this gap.
+
+**Consequence.** A throughput number taken from a local non-MSVC build is systematically
+optimistic relative to the binary that ships (measured on this codebase, Zen 5 / GCC 13.3:
+1.9–2.3×). Worse, a Windows-vs-anything A/B run on two default local builds compares a
+native-ISA binary against a baseline-ISA one, and nothing anywhere warns you: both builds
+succeed, both print plausible numbers, and the ratio between them is partly an artifact of a
+compiler flag rather than of whatever you were trying to measure.
+
+**Rules.**
+
+1. **Any number that leaves your machine — a cross-platform comparison, a figure quoted in an
+   issue, a doc, or a review — must be taken with `-DLUMICE_NATIVE_ARCH=OFF`.** That is the
+   configuration release and CI use, and the only one comparable across platforms.
+2. **Day-to-day local iteration can keep the `ON` default.** This is not a rule against
+   `-march=native`; it is a rule about where the resulting number is allowed to travel. A
+   before/after A/B of your own change, taken on the same machine with the same setting on both
+   arms, is unaffected.
+3. **Read the `isa` key rather than trying to remember.** Every `[BENCHMARK]` line carries
+   `"isa": "native"` or `"isa": "baseline"` (`src/main.cpp`, `RunBenchmarkPass`, gated by the
+   `LUMICE_NATIVE_ARCH_ACTIVE` macro that `CMakeLists.txt`'s `LUMICE_NATIVE_ARCH_ACTIVE_COND`
+   defines from the same condition as the `-march=native` flag itself). An old log therefore
+   answers "which build was this?" on its own, with no configure log needed. `baseline` is the
+   comparable tier; two rows may only be compared with each other when their `isa` values match.
+4. **Watch the configure line.** Every `cmake` configure prints one `-- LUMICE_NATIVE_ARCH=...`
+   status line saying which tier this build tree is on.
+
+
 ## 1. CLI Pipeline Benchmark
 
 Pure pipeline throughput test without GUI, VSync, or display overhead.
@@ -187,8 +231,8 @@ efficiency, followed by a multi-worker pass for parallel throughput. Two JSON li
 output:
 
 ```
-[BENCHMARK] {"mode": "single", "workers": 1, "cores": 8, "rays": 2000000, "wall_sec": 8.51, "setup_sec": 0.01, "active_sec": 8.5, "rays_per_sec": 235294.1, "rate_basis": "steady"}
-[BENCHMARK] {"mode": "multi", "workers": 8, "cores": 8, "rays": 10000000, "wall_sec": 0.6, "setup_sec": 0.02, "active_sec": 0.58, "rays_per_sec": 17241379.3, "rate_basis": "steady"}
+[BENCHMARK] {"mode": "single", "workers": 1, "cores": 8, "rays": 2000000, "wall_sec": 8.51, "setup_sec": 0.01, "active_sec": 8.5, "rays_per_sec": 235294.1, "rate_basis": "steady", "isa": "native"}
+[BENCHMARK] {"mode": "multi", "workers": 8, "cores": 8, "rays": 10000000, "wall_sec": 0.6, "setup_sec": 0.02, "active_sec": 0.58, "rays_per_sec": 17241379.3, "rate_basis": "steady", "isa": "native"}
 ```
 
 `rays_per_sec` is the **steady trace rate** over `active_sec` (the window from

--- a/doc/performance-testing_zh.md
+++ b/doc/performance-testing_zh.md
@@ -67,6 +67,43 @@ CLI 基准测试和 GUI 性能测试均支持日志级别选项。
 | `texture FPS` | GUI 性能测试 steady_state | 稳态纹理刷新率 |
 | `Consume profile` | CLI -v / GUI --log-level debug | 每批次 filter/proj/accum 分解 |
 
+## ⚠️ 本地构建不是出货的那个二进制：`-march=native` 在这里默认开、在别处一律关
+
+这一条讲的不是 `--benchmark` 报的是*哪个*数字，而是这个数字出自*哪个二进制*。它已经害过一次
+跨平台结论——那条结论被写下来、被当作待办流传了一段时间，才查出成因。
+
+**机制。** `option(LUMICE_NATIVE_ARCH ... ON)`（`CMakeLists.txt:43`）在 GCC/Clang 的 Release
+构建上展开为 `-march=native`（`CMakeLists.txt:733`）。关于谁传这个开关，有三件事：
+
+- **本地**：`scripts/build.sh` 根本不传这个选项，所以每一次本地构建吃的都是 `ON` 默认值。
+  这个默认是**有意的**——开发机就该为自己编译。
+- **出货**：`.github/workflows/release.yml:135` 与 `.github/workflows/ci.yml` 里全部 7 处
+  configure 步骤都显式传 `-DLUMICE_NATIVE_ARCH=OFF`。出货的、以及 CI 测的，都是基线 ISA。
+- **MSVC**：这个选项只在 `if(NOT MSVC)` 分支里被读取，所以 Windows/MSVC 构建**结构上**就没有
+  等价物可开，永远待在这条缝的另一侧。
+
+**后果。** 从本地非 MSVC 构建取的吞吐数字，相对出货二进制系统性偏乐观（本仓库实测，
+Zen 5 / GCC 13.3：1.9–2.3×）。更糟的是：拿两个默认设置的本地构建做 Windows vs 非 Windows 的
+A/B，比的是 native-ISA 二进制对基线-ISA 二进制，而**任何地方都不会给你任何警告**——两边都构建
+成功、都打印出看起来合理的数字，而两者之比里有一部分只是编译开关的产物，与你想量的东西无关。
+
+**规则。**
+
+1. **任何要离开你这台机器的数字**——跨平台对照、写进 issue / 文档 / 评审里的数字——
+   **必须用 `-DLUMICE_NATIVE_ARCH=OFF` 取**。那才是 release 与 CI 用的配置，也是唯一跨平台
+   可比的那一档。
+2. **日常本机迭代可以继续吃 `ON` 默认值。** 这不是在禁止 `-march=native`，而是在划清「这个数字
+   能走多远」这条线。自己改动的前后 A/B，只要两臂在同一台机器、同一档设置上取，不受影响。
+3. **读 `isa` 键，别指望记得住。** 每一行 `[BENCHMARK]` 都带 `"isa": "native"` 或
+   `"isa": "baseline"`（`src/main.cpp` 的 `RunBenchmarkPass`，由 `LUMICE_NATIVE_ARCH_ACTIVE` 宏
+   门控；该宏与 `-march=native` 标志本身共用 `CMakeLists.txt` 里同一个
+   `LUMICE_NATIVE_ARCH_ACTIVE_COND` 条件）。于是一份旧 log 自己就能回答「这是哪个构建取的」，
+   不需要还留着当时的 configure 输出。`baseline` 是可比的那一档；两行数字只有在 `isa` 相同时
+   才允许互相比较。
+4. **留意 configure 那一行。** 每次 `cmake` configure 都会打印一行 `-- LUMICE_NATIVE_ARCH=...`
+   状态，说明这棵构建树在哪一档。
+
+
 ## 1. CLI 管线基准测试
 
 不含 GUI、VSync 或显示开销的纯管线吞吐量测试。
@@ -81,8 +118,8 @@ CLI 基准测试和 GUI 性能测试均支持日志级别选项。
 并行吞吐量。输出两行 JSON：
 
 ```
-[BENCHMARK] {"mode": "single", "workers": 1, "cores": 8, "rays": 2000000, "wall_sec": 8.51, "setup_sec": 0.01, "active_sec": 8.5, "rays_per_sec": 235294.1, "rate_basis": "steady"}
-[BENCHMARK] {"mode": "multi", "workers": 8, "cores": 8, "rays": 10000000, "wall_sec": 0.6, "setup_sec": 0.02, "active_sec": 0.58, "rays_per_sec": 17241379.3, "rate_basis": "steady"}
+[BENCHMARK] {"mode": "single", "workers": 1, "cores": 8, "rays": 2000000, "wall_sec": 8.51, "setup_sec": 0.01, "active_sec": 8.5, "rays_per_sec": 235294.1, "rate_basis": "steady", "isa": "native"}
+[BENCHMARK] {"mode": "multi", "workers": 8, "cores": 8, "rays": 10000000, "wall_sec": 0.6, "setup_sec": 0.02, "active_sec": 0.58, "rays_per_sec": 17241379.3, "rate_basis": "steady", "isa": "native"}
 ```
 
 `rays_per_sec` 是 `active_sec`（从首条光线追踪到 IDLE 的窗口）上的**稳态追踪率**，

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -531,6 +531,19 @@ void RunBenchmarkPass(const std::string& config_str, int num_workers, const char
       result["active_sec"] = std::round(active_sec * 1000.0) / 1000.0;
       result["rays_per_sec"] = std::round(rays_per_sec * 10.0) / 10.0;
       result["rate_basis"] = rate_basis;
+      // ISA tier this binary was actually compiled for, so a recorded [BENCHMARK] line
+      // answers "which build was this measured on?" without anyone having to still have
+      // the configure log. "native" means -march=native was compiled in (local default);
+      // "baseline" is what release and CI ship, and is the only tier comparable across
+      // platforms — MSVC has no equivalent flag, so a Windows-vs-other A/B taken on
+      // "native" numbers is not measuring what it looks like it is measuring. The macro
+      // is defined by CMakeLists.txt's LUMICE_NATIVE_ARCH_ACTIVE_COND, which gates the
+      // -march=native flag itself; see doc/performance-testing.md.
+#if defined(LUMICE_NATIVE_ARCH_ACTIVE)
+      result["isa"] = "native";
+#else
+      result["isa"] = "baseline";
+#endif
       if (drain_count_mode) {
         result["n_drains_in_window"] = n_drains_in_window;
         result["window_sec"] = std::round(window_sec * 1000.0) / 1000.0;

--- a/test/e2e-correctness/test_cli.py
+++ b/test/e2e-correctness/test_cli.py
@@ -353,3 +353,134 @@ class TestAxisSlotTypeRequired(LumiceTestCase):
         self.assertIn("crystal[id=1]", combined, "must name the offending crystal" + context)
         self.assertIn("zenith", combined, "must name the missing slot" + context)
         self.assertIn("omit `axis`", combined, "must say how to opt out of `axis`" + context)
+
+
+class TestBenchmarkIsaField(LumiceTestCase):
+    """`--benchmark`'s JSON must say which ISA tier the binary was compiled for.
+
+    Why the key exists at all: a Release build takes `-march=native` unless
+    `-DLUMICE_NATIVE_ARCH=OFF` is passed, local `scripts/build.sh` does not pass it,
+    every release and CI job does, and MSVC has no equivalent flag wired up. So a
+    throughput number recorded off a local build is not the shipped binary's number,
+    and a Windows-vs-other comparison of two local builds is ISA-asymmetric by
+    default. The `isa` key makes an already-recorded number answer that on its own.
+
+    Why this test is not "run it and read the output": the cross-check below reads
+    `CMakeCache.txt`, which CMake writes at configure time. That is a different
+    producer from the `LUMICE_NATIVE_ARCH_ACTIVE` macro → `#if` → JSON path being
+    checked, so the two do not share a failure mode: if the generator expression
+    gating the macro were written wrong (inverted, or missing one of its two
+    conjuncts), the cache would still hold what CMake actually consumed and this
+    would go red.
+    """
+
+    _ISA_VALUES = {"native", "baseline"}
+
+    def _run_benchmark(self):
+        """Run `--benchmark` on the shared bench config with a ray budget small
+        enough for the fast leg, and return the parsed `[BENCHMARK]` lines."""
+        cfg = json.loads((CONFIGS_DIR / "bench_light_single_ms.json").read_text())
+        cfg["scene"]["ray_num"] = 200000
+        tmp_cfg = Path(self.output_dir) / "bench_isa.json"
+        tmp_cfg.write_text(json.dumps(cfg))
+
+        result = self.run_lumice(["--benchmark", "-f", str(tmp_cfg), "-o", self.output_dir])
+        context = f"\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+        self.assertEqual(result.returncode, 0, "benchmark run failed" + context)
+
+        rows = [
+            json.loads(line.split("[BENCHMARK]", 1)[1].strip())
+            for line in result.stdout.splitlines()
+            if "[BENCHMARK]" in line
+        ]
+        self.assertTrue(rows, "no [BENCHMARK] line was emitted" + context)
+        return rows
+
+    def _find_cmake_cache(self) -> Path | None:
+        """Locate the CMakeCache.txt belonging to the binary under test.
+
+        Two layouts exist in this repo and both are covered: `scripts/build.sh`
+        installs to `build/cmake_install/<flavor>/` and configures in
+        `build/cmake_build/<flavor>/`; CI configures with `cmake -S . -B build` and
+        (for the shared-lib leg) points $LUMICE_BIN into the build tree. The
+        flavor-derived candidate is tried FIRST on purpose — walking up from an
+        installed binary would otherwise reach a `build/CMakeCache.txt` left behind
+        by an unrelated plain-cmake configure and cross-check against the wrong one.
+        """
+        binary = Path(self.lumice_bin).resolve()
+        root = get_project_root().resolve()
+
+        candidates = []
+        parts = binary.parts
+        if "cmake_install" in parts:
+            flavor = parts[parts.index("cmake_install") + 1]
+            candidates.append(root / "build" / "cmake_build" / flavor / "CMakeCache.txt")
+        candidates.extend(parent / "CMakeCache.txt" for parent in binary.parents)
+        candidates.append(root / "build" / "CMakeCache.txt")
+
+        for candidate in candidates:
+            if candidate.is_file():
+                return candidate
+        return None
+
+    @staticmethod
+    def _read_cache_entry(cache_text: str, key: str) -> str | None:
+        """Read one `KEY:TYPE=VALUE` line out of CMakeCache.txt's flat text format."""
+        for line in cache_text.splitlines():
+            name, sep, value = line.partition("=")
+            if sep and name.split(":", 1)[0] == key:
+                return value.strip()
+        return None
+
+    def test_isa_key_is_present_and_well_formed(self):
+        """Schema layer — runs unconditionally, independent of any build layout."""
+        for row in self._run_benchmark():
+            self.assertIn("isa", row, f"[BENCHMARK] row lacks the isa key: {row}")
+            self.assertIn(
+                row["isa"],
+                self._ISA_VALUES,
+                f"isa={row['isa']!r} is outside {sorted(self._ISA_VALUES)}: {row}",
+            )
+
+    def test_isa_key_matches_the_configure_time_record(self):
+        """Cross-check layer — the `isa` value against CMake's own configure record."""
+        cache_path = self._find_cmake_cache()
+        if cache_path is None:
+            self.skipTest(
+                "no CMakeCache.txt found for this binary — cross-check skipped, "
+                "schema assertions still cover the key (see the other test here)"
+            )
+        cache_text = cache_path.read_text()
+
+        native_arch = self._read_cache_entry(cache_text, "LUMICE_NATIVE_ARCH")
+        build_type = self._read_cache_entry(cache_text, "CMAKE_BUILD_TYPE")
+        compiler_id = self._read_cache_entry(cache_text, "LUMICE_COMPILER_ID_SNAPSHOT")
+        missing = [
+            name
+            for name, value in (
+                ("LUMICE_NATIVE_ARCH", native_arch),
+                ("CMAKE_BUILD_TYPE", build_type),
+                ("LUMICE_COMPILER_ID_SNAPSHOT", compiler_id),
+            )
+            if value is None
+        ]
+        if missing:
+            # A build tree configured before LUMICE_COMPILER_ID_SNAPSHOT existed, or a
+            # multi-config generator with no single CMAKE_BUILD_TYPE. Say so rather
+            # than raising KeyError or inventing an expectation.
+            self.skipTest(f"{cache_path} lacks {', '.join(missing)} — cross-check skipped")
+
+        native_on = native_arch.upper() in ("ON", "1", "TRUE", "YES", "Y")
+        expected = (
+            "native"
+            if (native_on and build_type == "Release" and compiler_id != "MSVC")
+            else "baseline"
+        )
+        for row in self._run_benchmark():
+            self.assertEqual(
+                row["isa"],
+                expected,
+                f"isa={row['isa']!r} but {cache_path} records "
+                f"LUMICE_NATIVE_ARCH={native_arch}, CMAKE_BUILD_TYPE={build_type}, "
+                f"LUMICE_COMPILER_ID_SNAPSHOT={compiler_id} (expected {expected!r})",
+            )

--- a/test/e2e-correctness/test_cli.py
+++ b/test/e2e-correctness/test_cli.py
@@ -443,7 +443,17 @@ class TestBenchmarkIsaField(LumiceTestCase):
             )
 
     def test_isa_key_matches_the_configure_time_record(self):
-        """Cross-check layer — the `isa` value against CMake's own configure record."""
+        """Cross-check layer — the `isa` value against CMake's own configure record.
+
+        Stated assumption: the oracle below treats `compiler_id == "MSVC"` as
+        equivalent to CMake's `MSVC` boolean, which is what CMakeLists.txt actually
+        gates the macro on. Those two decouple under clang-cl (`MSVC` is true, but
+        the compiler id is "Clang"), which would make this oracle expect "native"
+        against a binary correctly reporting "baseline". No clang-cl build exists in
+        this repo's toolchain matrix today; if one is introduced, persist the `MSVC`
+        boolean itself as a second cache snapshot rather than inferring it from the
+        compiler id.
+        """
         cache_path = self._find_cmake_cache()
         if cache_path is None:
             self.skipTest(


### PR DESCRIPTION
> ⚠️ **本 PR 叠在 #307 之上**（base = `fix/gui-test-harness-gates`，不是 main）。
> 请在 #307 合入之后再合；#307 合入时 GitHub 会自动把 base 改回 main。
>
> 📌 **另有一条顺序约束**：`task-benchmark-steady-window-outlier`（499）会动同一段
> `[BENCHMARK]` 输出。两者根因不同、不合并；**本 PR 先合，499 后做**，且 499 必须
> **重新**做一遍消费者清点，不得复用本 PR 的清单。

## 问题：偏差方向固定、幅度接近一个量级的一半，而且完全不可见

- `CMakeLists.txt` 的 `option(LUMICE_NATIVE_ARCH ... ON)` 在 `if(NOT MSVC)` 分支展开 `-march=native`
- `release.yml` 与 `ci.yml` 的 **8 处全部显式 OFF**；本地 `scripts/build.sh` **不传，吃默认 ON**

⇒ 这个仓库里每一个在非 MSVC 开发机上取的本地性能数字，跑的都不是出货的那个二进制，
偏差方向固定（本地偏乐观），实测 **1.9–2.3×**。更糟的是跨平台：Linux/macOS 吃默认 ON，
**Windows 结构上拿不到**（MSVC 分支不读它）⇒ **任何 Windows vs 非 Windows 的本地 A/B，
默认就是不对称的，且不会有任何警告。**

**伤害已经发生过**：一整条跨平台结论因此出错，还据此往待办里写了一条「Windows 还剩 54% 未解释」
的中优先条目，后被重测证伪（ISA 混淆解释了那 54% 的 74.8%）。代价不是「数字不准」，
是**一条错误结论被写成待办并流传了一段时间**。

## 三个检索点各补一处出处

1. **`doc/performance-testing{,_zh}.md` 新增一节** —— 该文档此前完全没提 ISA/`NATIVE_ARCH`。
   写明跨平台或对外引用的数字必须用 `-DLUMICE_NATIVE_ARCH=OFF` 取，以及为什么。
2. **configure 期 `message(STATUS ...)`** —— 措辞刻意是「would apply」而非断言：这条消息在
   configure 期只跑一次，而 `-march=native` 的门控带 `$<CONFIG:Release>`，要到 generate/build
   期才按配置解析，断言式措辞对「选项 ON 的 Debug 构建」是错的。本地默认 ON 是**有意的**，
   文案不吓人，要防的只是拿它的数字去做跨平台对照。
3. **`[BENCHMARK]` JSON 新增 `isa` 键**（`"native"` / `"baseline"`）—— 三条处置里唯一能让
   **已经被记录下来的**数字自证出处的：任何一份历史 log 从此都能回答「这个数字是哪个 ISA 档取的」。

### 结构上不可能漂移

新增的 `LUMICE_NATIVE_ARCH_ACTIVE_COND` 生成器表达式是**单一真源**：加不加 `-march=native` 的门控，
与报哪个 ISA 档的 `LUMICE_NATIVE_ARCH_ACTIVE` 宏，引用的是同一个变量。标志与数字的出处
因此不可能各自漂移。

## AC4 消费者清点（不得只改已知那几处）

全仓三条互补 grep 重跑（不复用计划期清单——重跑确实抓到了计划期漏掉的一处命中）。
**4 个真消费者，逐个核对后均无需适配**：

| 消费者 | 读法 | 结论 |
|---|---|---|
| `scripts/bench_throughput.py` | `json.loads` + 按字段名索引 | 无字段计数/无 schema 校验 ⇒ 安全 |
| `test/performance/test_metal_throughput.py` | 同上 | 安全 |
| `test/regression-sentinel/test_benchmark_infinite_no_hang.py` | 纯子串匹配，不解析 JSON | 安全 |
| `.github/workflows/ci.yml` | `jq '. + {…}'` 合并 + 按名取值带默认 | 安全 |

`scripts/analyze_perf_log.py` 命中但**不是**消费者：它解析的是 GUI 的 `[PERF]` 日志，
`rays_per_sec` 只是同名局部变量，全文无 `[BENCHMARK]` 字样。

## 验证

- **AC5 红态自证（负对照，只差一个变量）**：把 `CMakeCache.txt` 里 `LUMICE_NATIVE_ARCH:BOOL=ON`
  单点改成 `OFF`（**二进制不动，仍是 native**），交叉核对那条如期转红
  （`'native' != 'baseline'`），而同一次运行里 schema 那条**仍然 passed**——说明红是从交叉核对
  来的，不是整个类挂掉 ⇒ 这是活闸，不是恒真装饰。随后已还原缓存并核验。
- 两条新测试都是 PASSED 而非 SKIPPED，交叉核对分支确实执行了。
- `./scripts/test.sh pr` 全绿；五道工程门禁 rc=0。
  ⚠️ **如实记录**：第一次 `test.sh pr` 的汇总行是 FAIL，唯一红是那条 30s 墙钟哨兵超时。
  判定为并发负载假红，依据按顺序是 ①构建图论证（本次 diff 对被测二进制的 13 行改动位于
  benchmark pass **结束之后**写 JSON 处，不参与追踪循环也不参与 drain 窗口关闭判定；
  `-march=native` 门控改动取值等价）②现场证据（故障时刻 load average 18.03/26.48/41.03，
  12 核机，且另有并发构建在跑）；③隔离重跑与整层重跑复绿只作**佐证**，不作主证。

## 评审

两位独立评审 APPROVE（0 Critical / 0 Major）。Minor 3（isa 交叉核对的 oracle 用
`compiler_id == "MSVC"` 代替 CMake 的 `MSVC` 布尔量，两者在 clang-cl 下脱钩）已由第四个 commit
把该前提显式化——本仓工具链矩阵今天没有 clang-cl，按 a51 不预先加第二个快照变量。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYUQjkoHUfvHDF1xzk829e