### PR TITLE
fix(cli): overlay label 视口 clamp 收敛为 GUI/CLI 共享的单一实现

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,16 @@ CMake build tree is `build/cmake_build/<flavor>/` and compiler output lands in
 - Public API boundary: `src/gui/` code must only access core/config functionality
   through the C API (`src/include/lumice.h`). Direct `#include` of `core/` or `config/`
   headers from `src/gui/` is prohibited.
+  `src/util/` is deliberately outside that prohibition, and the exemption has a shape:
+  what may live there and be included from both sides is a **pure, stateless helper that
+  carries no simulation or configuration semantics** — `bit_utils.hpp`, `color_space.hpp`,
+  `label_viewport_clamp.hpp`. The gate exists so the GUI cannot reach into the engine's
+  data model and pin its layout by including it; a geometry function with no state does
+  not offer that reach, and forcing one through the C API would only mean the rule gets
+  written twice, once per side, which is the divergence the boundary is there to prevent.
+  So: a rule BOTH renderers must obey, expressible without a core or config type, belongs
+  in `src/util/`. Anything that needs to see a `RenderConfig`, a `SimData` or a crystal
+  does not, and still goes through the C API.
 - Environment variables: before adding any new `std::getenv`, apply the decision gate in
   `doc/env-var-policy.md`. User-facing behavior switches must go through CLI/config/API,
   not env vars (env causes silent per-machine drift). Env is fine for dev/experiment knobs

--- a/src/gui/overlay_labels.cpp
+++ b/src/gui/overlay_labels.cpp
@@ -6,6 +6,7 @@
 
 #include "gui/gui_constants.hpp"
 #include "gui/preview_renderer.hpp"
+#include "util/label_viewport_clamp.hpp"
 
 namespace lumice::gui {
 namespace {
@@ -473,27 +474,15 @@ void WorldDirToPixelForTesting(float wx, float wy, float wz, float res_x, float 
   }
 }
 
+// The GUI's ImVec2-shaped entry to the shared clamp. The rule itself — the inset and the
+// degenerate-viewport fallback — lives in util/label_viewport_clamp.hpp, which the CLI compositor
+// calls too; core cannot see ImVec2, which is the whole reason this unpacking layer exists rather
+// than a second copy of the arithmetic. Same operation as lumice::ClampLabelPosToViewport, only in
+// the types a draw list speaks.
 ImVec2 ClampLabelPosToViewport(ImVec2 pos, ImVec2 text_size, float vp_x, float vp_y, float vp_w, float vp_h) {
-  // kViewportInsetPx is a small visual padding (in screen-space pixels) keeping the
-  // text glyph rect away from the absolute viewport edge — guards against the
-  // half-pixel anti-aliasing fringe and the panel border 1 px line. 2 px is a
-  // visual-padding heuristic, not a precise geometric boundary; revisit if a
-  // future HiDPI-aware UI pass requires resolution-scaled padding.
-  constexpr float kViewportInsetPx = 2.0f;
-
-  // Only clamp if the viewport actually has room for the text + 2×inset. If
-  // the viewport is narrower / shorter than that (extreme corner case for
-  // panel collapse / tiny export targets), fall back to the original pos so
-  // the legacy "centered on label anchor" behaviour is preserved.
-  if (vp_w > text_size.x + 2.0f * kViewportInsetPx) {
-    pos.x = std::max(pos.x, vp_x + kViewportInsetPx);
-    pos.x = std::min(pos.x, vp_x + vp_w - text_size.x - kViewportInsetPx);
-  }
-  if (vp_h > text_size.y + 2.0f * kViewportInsetPx) {
-    pos.y = std::max(pos.y, vp_y + kViewportInsetPx);
-    pos.y = std::min(pos.y, vp_y + vp_h - text_size.y - kViewportInsetPx);
-  }
-  return pos;
+  const LabelPos clamped = lumice::ClampLabelPosToViewport(
+      LabelPos{ pos.x, pos.y }, LabelSize{ text_size.x, text_size.y }, LabelViewport{ vp_x, vp_y, vp_w, vp_h });
+  return ImVec2(clamped.x, clamped.y);
 }
 
 }  // namespace detail

--- a/src/gui/overlay_labels.cpp
+++ b/src/gui/overlay_labels.cpp
@@ -479,6 +479,14 @@ void WorldDirToPixelForTesting(float wx, float wy, float wz, float res_x, float 
 // calls too; core cannot see ImVec2, which is the whole reason this unpacking layer exists rather
 // than a second copy of the arithmetic. Same operation as lumice::ClampLabelPosToViewport, only in
 // the types a draw list speaks.
+//
+// The shared name is deliberate, not an oversight: the two are meant to read as one rule and its
+// type adapter, so the paired tests can assert "the wrapper is only a wrapper" without the reader
+// having to hold two names in their head. The cost is that a bare symbol search finds both, so a
+// call site must be read with its namespace qualifier — every one of them writes `lumice::` or
+// `detail::` explicitly for that reason. If a third caller ever appears, re-weigh that trade:
+// paired readability was worth more than symbol uniqueness at two call sites, not necessarily at
+// more.
 ImVec2 ClampLabelPosToViewport(ImVec2 pos, ImVec2 text_size, float vp_x, float vp_y, float vp_w, float vp_h) {
   const LabelPos clamped = lumice::ClampLabelPosToViewport(
       LabelPos{ pos.x, pos.y }, LabelSize{ text_size.x, text_size.y }, LabelViewport{ vp_x, vp_y, vp_w, vp_h });

--- a/src/gui/overlay_labels.hpp
+++ b/src/gui/overlay_labels.hpp
@@ -77,13 +77,14 @@ void AppendCurveLabels(const CurveLabelSet& set, float vp_screen_x, float vp_scr
 // `vp_screen_*` is the viewport rect the anchors live in: FBO-local, starting at (0, 0), in LOGICAL
 // POINTS (the space a draw list works in; the DPI is applied once by the backend, see
 // RenderOverlayToFbo). Each label's rendered text bounding box is clamped at least 2 px inside each
-// viewport edge (`kViewportInsetPx` in detail::ClampLabelPosToViewport) so labels never straddle the
-// viewport edge.
+// viewport edge (`kLabelViewportInsetPx`, util/label_viewport_clamp.hpp) so labels never straddle
+// the viewport edge.
 //
-// This clamp is unconditional (all lens types, all visible modes) and is the GUI's alone: the CLI
-// renderer draws core's raw anchors with no clamp and no collision pass, so a label near the rim
-// can sit a few pixels differently in the two. Where the two agree is WHICH labels appear and
-// where the curve puts them, which is what moving the walk into core bought.
+// This clamp is unconditional (all lens types, all visible modes) and is NOT the GUI's alone: the
+// CLI compositor (RenderConsumer::PaintLabels, src/server/render.cpp) calls the same shared
+// function on the same anchors, so a label at the rim lands in the same place in both. What is
+// still the GUI's alone is the COLLISION pass below — the CLI draws every label core hands it, so
+// two labels that crowd each other are dropped in the preview and overlap in a CLI render.
 void AppendOverlayToDrawList(ImDrawList* dl, const std::vector<OverlayLabel>& labels, float vp_screen_x,
                              float vp_screen_y, float vp_screen_w, float vp_screen_h);
 
@@ -138,7 +139,7 @@ void WorldDirToPixelForTesting(float wx, float wy, float wz, float res_x, float 
                                const float view_matrix[9], float* out_px, float* out_py, bool* out_valid);
 
 // Clamp a label's anchor position so the rendered text bounding box stays
-// inside the viewport rect with at least 2 px (`kViewportInsetPx`) margin
+// inside the viewport rect with at least 2 px (`kLabelViewportInsetPx`) margin
 // on each side.
 // `pos` is the desktop-relative top-left of the text glyph rect (caller has
 // already subtracted half of `text_size` from the label's center). The returned
@@ -146,6 +147,11 @@ void WorldDirToPixelForTesting(float wx, float wy, float wz, float res_x, float 
 // (and similarly for y), unless the viewport is too narrow to fit the text +
 // 2×inset — in that case the original pos is returned unchanged (rendering
 // degrades to "centered on label anchor", matching legacy behaviour).
+//
+// THE RULE ITSELF IS NOT HERE. This is the ImVec2-shaped entry to
+// `lumice::ClampLabelPosToViewport` (util/label_viewport_clamp.hpp), which the CLI
+// compositor calls too; core cannot see ImGui types, so unpacking is all this
+// layer does. Change the inset or the fallback there, not here.
 //
 // Pure function — exposed in detail:: for unit testing
 // (`overlay_labels/clamp_label_pos_*` tests).

--- a/src/server/render.cpp
+++ b/src/server/render.cpp
@@ -24,6 +24,7 @@
 #include "core/shared/projection_shared.h"
 #include "util/color_data.hpp"
 #include "util/color_space.hpp"
+#include "util/label_viewport_clamp.hpp"
 
 
 namespace lumice {
@@ -1001,8 +1002,20 @@ void RenderConsumer::PaintLabels() {
     }
     // The anchor is core's canvas pixel, rounded to the grid the glyphs were rasterized on; the
     // bitmap's offsets carry the centring (annotation_font.hpp).
-    const int left = static_cast<int>(std::lround(draw.label->px)) + ink.offset_x;
-    const int top = static_cast<int>(std::lround(draw.label->py)) + ink.offset_y;
+    const int left_raw = static_cast<int>(std::lround(draw.label->px)) + ink.offset_x;
+    const int top_raw = static_cast<int>(std::lround(draw.label->py)) + ink.offset_y;
+    // Then push that rect inside the canvas, by the same rule and the same code the GUI's drawer
+    // uses (util/label_viewport_clamp.hpp). An anchor is placed where its curve ENTERS the visible
+    // region, which on a narrow field of view is the frame edge — so without this the glyph run
+    // straddles the edge and the loop below silently drops the half that fell off. A label that
+    // was already clear of the edges is returned unchanged, which is why this affects only the
+    // rim: `left == left_raw` and `top == top_raw` everywhere else.
+    const LabelPos placed = ClampLabelPosToViewport(
+        LabelPos{ static_cast<float>(left_raw), static_cast<float>(top_raw) },
+        LabelSize{ static_cast<float>(ink.width), static_cast<float>(ink.height) },
+        LabelViewport{ 0.0f, 0.0f, static_cast<float>(width_px), static_cast<float>(height_px) });
+    const int left = static_cast<int>(std::lround(placed.x));
+    const int top = static_cast<int>(std::lround(placed.y));
     for (int row = 0; row < ink.height; ++row) {
       const int y = top + row;
       if (y < 0 || y >= height_px) {

--- a/src/util/label_viewport_clamp.hpp
+++ b/src/util/label_viewport_clamp.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <algorithm>
+
+namespace lumice {
+
+// =================================================================================================
+// The ONE viewport clamp for overlay text labels, shared by both renderers.
+//
+// Two renderers draw the same overlay labels onto the same anchors: the GUI's draw-list pass
+// (src/gui/overlay_labels.cpp, AppendOverlayToDrawList) and the CLI/server compositor
+// (src/server/render.cpp, RenderConsumer::PaintLabels). An anchor is placed where the curve ENTERS
+// the visible region (core's annotation_overlay.cpp), which on a narrow field of view is the frame
+// edge itself — so a label centred on its anchor straddles that edge routinely, not rarely.
+//
+// This file is that rule's SINGLE OWNER. It lives in src/util/ rather than in either renderer for
+// the one reason that matters: src/gui/ may not include core/ or config/ (the C API boundary,
+// enforced by scripts/check_policies.py), and core may not depend on the GUI at all, so a rule
+// written on either side could only be shared by copying it. util/ is includable from both — the
+// GUI already includes several util/ headers directly, and so does src/server/render.cpp — and a
+// pure, stateless geometry function is exactly what may travel that way without weakening the
+// boundary the gate draws around core/ and config/.
+//
+// Both call sites are thin: the GUI's detail::ClampLabelPosToViewport unpacks ImVec2 (core cannot
+// see ImGui types), the server's PaintLabels unpacks ints. Neither repeats any of the decisions
+// below. Change the inset or the degenerate-viewport rule here and both renderers move together.
+// =================================================================================================
+
+// A small visual padding, in the pixels of whichever canvas is being drawn to, keeping the text
+// glyph rect away from the absolute viewport edge — it guards against the half-pixel anti-aliasing
+// fringe and, in the GUI, the panel border's own 1 px line. 2 px is a visual-padding heuristic, not
+// a precise geometric boundary; revisit if a future HiDPI-aware UI pass requires resolution-scaled
+// padding. Deliberately NOT scaled by resolution today: both renderers have always treated it as an
+// absolute pixel count, and giving one side a scaled inset would put a GUI/CLI divergence back.
+inline constexpr float kLabelViewportInsetPx = 2.0f;
+
+// The three geometric quantities, each in its own type. They are all "two or four floats", and a
+// flat parameter list of them invites exactly the transposition bug this clamp's two call sites are
+// most exposed to (pos vs size, width vs height), so the types carry the meaning instead.
+struct LabelPos {
+  float x = 0.0f;
+  float y = 0.0f;
+};
+
+struct LabelSize {
+  float w = 0.0f;
+  float h = 0.0f;
+};
+
+struct LabelViewport {
+  float x = 0.0f;
+  float y = 0.0f;
+  float w = 0.0f;
+  float h = 0.0f;
+};
+
+// Push the text glyph rect `[pos, pos + size]` inside `vp`, leaving `kLabelViewportInsetPx` of
+// margin against each edge, and return its new top-left. `pos` is the rect's top-left, i.e. the
+// caller has already applied whatever centring turns an anchor into a corner.
+//
+// The axes are independent: a label past the left edge and comfortably inside vertically moves in x
+// only. When the viewport cannot hold the text plus two insets on an axis, that axis is left
+// UNTOUCHED rather than clamped to a nonsense position — clamping there would move the label to a
+// corner for no benefit, whereas leaving it alone keeps the legacy "centred on its anchor, possibly
+// cropped" look for degenerate targets (a collapsed panel, a tiny export).
+inline LabelPos ClampLabelPosToViewport(LabelPos pos, LabelSize size, LabelViewport vp) {
+  if (vp.w > size.w + 2.0f * kLabelViewportInsetPx) {
+    pos.x = std::max(pos.x, vp.x + kLabelViewportInsetPx);
+    pos.x = std::min(pos.x, vp.x + vp.w - size.w - kLabelViewportInsetPx);
+  }
+  if (vp.h > size.h + 2.0f * kLabelViewportInsetPx) {
+    pos.y = std::max(pos.y, vp.y + kLabelViewportInsetPx);
+    pos.y = std::min(pos.y, vp.y + vp.h - size.h - kLabelViewportInsetPx);
+  }
+  return pos;
+}
+
+}  // namespace lumice

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -107,6 +107,7 @@ add_executable(unit_correctness_test
   "${PROJ_TEST_DIR}/unit-correctness/util/test_cpu_info.cpp"
   "${PROJ_TEST_DIR}/unit-correctness/util/test_bit_utils.cpp"
   "${PROJ_TEST_DIR}/unit-correctness/util/test_illuminant.cpp"
+  "${PROJ_TEST_DIR}/unit-correctness/util/test_label_viewport_clamp.cpp"
   # gui/
   "${PROJ_TEST_DIR}/unit-correctness/gui/test_axis_presets.cpp"
   "${PROJ_TEST_DIR}/unit-correctness/gui/test_filter_sop_grammar.cpp"

--- a/test/unit-correctness/server/test_render_consumer_label.cpp
+++ b/test/unit-correctness/server/test_render_consumer_label.cpp
@@ -422,6 +422,11 @@ TEST(RenderConsumerLabel, ARimLabelIsPaintedWholeRatherThanCroppedAtTheCanvasEdg
                                      "exercises the clamp, so the assertion below would hold either way";
   ASSERT_GT(expected_ink, 0) << "the labels rasterized to nothing";
 
+  // Precondition of comparing a SUM against a UNION: no two labels' glyph bounding boxes may
+  // overlap in this scene. `expected_ink` adds each label's ink count, while DifferingPixels
+  // counts changed pixels once. The current MakeRimLabelConfig() angular spacing keeps them
+  // apart; tightening that spacing until two glyph runs touch would make this assertion fail on
+  // a correct renderer, so re-check this line before changing the config's label density.
   EXPECT_EQ(DifferingPixels(img_off, img_on), expected_ink)
       << "the glyphs' " << expected_ink << " covered pixels did not all reach the image: a rim label was composited "
       << "from its raw anchor and cropped by the canvas bounds instead of being pushed inside them";

--- a/test/unit-correctness/server/test_render_consumer_label.cpp
+++ b/test/unit-correctness/server/test_render_consumer_label.cpp
@@ -21,12 +21,15 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
 #include <cstdint>
 #include <vector>
 
 #include "config/color_class_table.hpp"
 #include "config/render_config.hpp"
 #include "config/sim_data.hpp"
+#include "core/annotation_font.hpp"
+#include "core/annotation_overlay.hpp"
 #include "server/render.hpp"
 #include "support/render_anchor.hpp"
 
@@ -320,6 +323,108 @@ TEST(RenderConsumerLabel, FlippingASwitchMidRunReachesTheImage) {
   EXPECT_FALSE(rc.ElevationLabelsForTest().empty());
   EXPECT_FALSE(rc.AngularDistLabelsForTest().empty());
   EXPECT_GT(DifferingPixels(img_off, img_on), 0) << "the switch flipped but the image did not change";
+}
+
+
+// ---- The viewport clamp, at the layer that has to be wired to it -------------------------------
+//
+// An anchor is placed where its curve ENTERS the visible region (core's annotation_overlay.cpp),
+// which on a bounded canvas is the frame edge itself — so a glyph run centred on one straddles that
+// edge as a matter of course, and the compositing loop above would drop whatever fell outside.
+// util/label_viewport_clamp.hpp is the rule that prevents it, shared with the GUI's drawer; what is
+// asserted here is that THIS renderer calls it, which the shared function's own unit test cannot
+// say.
+//
+// The judge is a pixel count rather than an eyeball: every pixel the rasterized glyph covers must
+// reach the image. Two things make the count exact — the scene paints nothing else where the labels
+// land (no grid lines at all, and the one ray goes to the zenith while the horizon sits at the
+// bottom of the frame), and sRGB's toe is steep enough that even a coverage of 1/255 moves the byte,
+// so "covered" and "differs from the no-label frame" are the same set.
+
+// The label config stripped to the horizon family alone: no grid lines to paint over the numbers,
+// and the horizon's own line switched off (which it may be while its labels are on — see the case
+// above). `el` chooses how far down the frame the horizon crosses, and with it whether its labels
+// land at the rim.
+RenderConfig MakeRimLabelConfig(float el_deg, bool labels_on = true) {
+  RenderConfig cfg;
+  cfg.id_ = 0;
+  cfg.lens_.type_ = LensParam::kLinear;
+  cfg.lens_.fov_ = 120.0f;
+  cfg.resolution_[0] = kW;
+  cfg.resolution_[1] = kH;
+  cfg.view_.el_ = el_deg;
+  cfg.visible_ = RenderConfig::kFull;
+  cfg.horizon_ = false;
+  cfg.horizon_label_ = labels_on;
+  return cfg;
+}
+
+// What render.cpp's compositing loop computes before the clamp: the glyph rect the raw anchor asks
+// for. Mirrors the two lines there (`lround(anchor) + ink.offset`) so this file can ask whether that
+// rect would have fallen off the canvas.
+struct RawGlyphRect {
+  int left = 0;
+  int top = 0;
+  int width = 0;
+  int height = 0;
+  int ink_pixels = 0;  // non-zero coverage cells, i.e. how many pixels the run must light
+
+  bool InsideCanvas() const { return left >= 0 && top >= 0 && left + width <= kW && top + height <= kH; }
+};
+
+RawGlyphRect RawRectOf(const annotation::Label& label) {
+  const annotation::TextBitmap ink = annotation::RasterizeLabel(label.text);
+  RawGlyphRect r;
+  r.left = static_cast<int>(std::lround(label.px)) + ink.offset_x;
+  r.top = static_cast<int>(std::lround(label.py)) + ink.offset_y;
+  r.width = ink.width;
+  r.height = ink.height;
+  for (const uint8_t c : ink.coverage) {
+    if (c != 0) {
+      ++r.ink_pixels;
+    }
+  }
+  return r;
+}
+
+TEST(RenderConsumerLabel, ARimLabelIsPaintedWholeRatherThanCroppedAtTheCanvasEdge) {
+  // 55 deg up puts the horizon low in a 120 deg frame, where its label anchors sit against the
+  // bottom edge. Asserted below rather than assumed: a view that drifted away from the rim would
+  // leave this case passing without the clamp, which is the one way it could go quietly useless.
+  const RenderConfig cfg = MakeRimLabelConfig(55.0f);
+
+  RenderConsumer off(MakeRimLabelConfig(55.0f, /*labels_on=*/false), ColorClassTable{}, MakeSun());
+  const std::vector<uint8_t> img_off = SnapshotOnce(&off);
+  ASSERT_EQ(img_off.size(), static_cast<size_t>(kTotalPix) * 3);
+  ASSERT_TRUE(HasAnyNonBlackPixel(img_off)) << "the reference frame is entirely black — see MakeRimLabelConfig";
+  ASSERT_TRUE(off.HorizonLabelsForTest().empty());
+
+  RenderConsumer on(cfg, ColorClassTable{}, MakeSun());
+  const std::vector<uint8_t> img_on = SnapshotOnce(&on);
+  ASSERT_EQ(img_on.size(), static_cast<size_t>(kTotalPix) * 3);
+
+  const std::vector<annotation::Label>& labels = on.HorizonLabelsForTest();
+  ASSERT_FALSE(labels.empty()) << "no horizon anchor was computed; there is nothing to clamp";
+
+  int expected_ink = 0;
+  int off_canvas_labels = 0;
+  for (const annotation::Label& label : labels) {
+    const RawGlyphRect raw = RawRectOf(label);
+    expected_ink += raw.ink_pixels;
+    if (!raw.InsideCanvas()) {
+      ++off_canvas_labels;
+    }
+  }
+  // The non-vacuity guard, and the mechanised form of this task's red state: at least one label's
+  // UNCLAMPED rect really does leave the canvas, so the count below can only come out right if the
+  // clamp ran. Without it this case would pass on a scene with no rim label in it at all.
+  ASSERT_GT(off_canvas_labels, 0) << "every anchor is already comfortably inside the canvas — this view no longer "
+                                     "exercises the clamp, so the assertion below would hold either way";
+  ASSERT_GT(expected_ink, 0) << "the labels rasterized to nothing";
+
+  EXPECT_EQ(DifferingPixels(img_off, img_on), expected_ink)
+      << "the glyphs' " << expected_ink << " covered pixels did not all reach the image: a rim label was composited "
+      << "from its raw anchor and cropped by the canvas bounds instead of being pushed inside them";
 }
 
 }  // namespace

--- a/test/unit-correctness/util/test_label_viewport_clamp.cpp
+++ b/test/unit-correctness/util/test_label_viewport_clamp.cpp
@@ -1,0 +1,132 @@
+// The shared overlay-label viewport clamp, asserted on the function itself.
+//
+// This file exists because the rule now has TWO call sites — the GUI's draw-list pass and the
+// CLI/server compositor — and neither of them is a good place to pin the arithmetic: one needs an
+// ImGui font atlas to produce a text size, the other needs a rendered frame. What is left when
+// both are stripped away is eight numbers in and two out, which is what is asserted here.
+//
+// The case table is deliberately the same one as
+// test/unit-correctness/gui/test_overlay_labels.cpp's ALabelIsPulledBackInsideTheViewportOnEveryEdge,
+// numbers included. That is not duplication for its own sake: the GUI case goes through
+// gui::detail::ClampLabelPosToViewport (the ImVec2 wrapper) and this one through
+// lumice::ClampLabelPosToViewport (the shared rule), so the pair says the wrapper is a wrapper. If
+// the two ever disagree, the unpacking layer has grown a decision of its own — which is exactly the
+// GUI/CLI divergence this shared header was written to make impossible.
+
+#include <gtest/gtest.h>
+
+#include "util/label_viewport_clamp.hpp"
+
+namespace lumice {
+namespace {
+
+// A 30x14 glyph run in a 200x100 viewport pinned at (10, 20) — an offset origin rather than (0, 0)
+// so a rule that confused "viewport coordinate" with "distance from the left edge" fails here
+// instead of passing on a canvas that happens to start at zero. The CLI's own viewport does start
+// at (0, 0), so this is the axis its call site cannot test.
+constexpr float kTextW = 30.0f;
+constexpr float kTextH = 14.0f;
+constexpr LabelViewport kVp{ 10.0f, 20.0f, 200.0f, 100.0f };
+
+TEST(LabelViewportClamp, ALabelIsPulledBackInsideTheViewportOnEveryEdge) {
+  struct Case {
+    const char* name;
+    LabelPos pos;
+    float vp_w;
+    LabelPos expected;
+  };
+  const Case kCases[] = {
+    // x=5 would start left of the viewport at x=10; the inset puts it at 12.
+    { "past the left edge", { 5.0f, 50.0f }, kVp.w, { 12.0f, 50.0f } },
+    // x=195 plus 30 of text ends at 225, past the right edge at 210; 210 - 30 - 2 = 178.
+    { "past the right edge", { 195.0f, 50.0f }, kVp.w, { 178.0f, 50.0f } },
+    { "above the top edge", { 50.0f, 15.0f }, kVp.w, { 50.0f, 22.0f } },
+    // 20 + 100 - 14 - 2 = 104.
+    { "below the bottom edge", { 50.0f, 110.0f }, kVp.w, { 50.0f, 104.0f } },
+    { "already inside", { 50.0f, 50.0f }, kVp.w, { 50.0f, 50.0f } },
+    // 20 wide cannot hold 30 of text plus two insets, so x is left alone; y is processed normally
+    // and happens to need no adjustment.
+    { "a viewport too narrow for the text", { 5.0f, 50.0f }, 20.0f, { 5.0f, 50.0f } },
+  };
+
+  for (const Case& c : kCases) {
+    const LabelViewport vp{ kVp.x, kVp.y, c.vp_w, kVp.h };
+    const LabelPos clamped = ClampLabelPosToViewport(c.pos, LabelSize{ kTextW, kTextH }, vp);
+    // Non-fatal: this loop is a table of independent propositions, and one bad edge must not hide
+    // the state of the other five (doc/testing-architecture.md §4.9).
+    EXPECT_EQ(clamped.x, c.expected.x) << c.name;
+    EXPECT_EQ(clamped.y, c.expected.y) << c.name;
+  }
+}
+
+// The two axes are independent. A label past the left edge AND below the bottom moves on both; the
+// cases above only ever needed one axis at a time, so a rule that returned early after the first
+// adjustment would pass every one of them.
+TEST(LabelViewportClamp, BothAxesMoveWhenBothAreOutside) {
+  const LabelPos clamped = ClampLabelPosToViewport(LabelPos{ 5.0f, 110.0f }, LabelSize{ kTextW, kTextH }, kVp);
+  EXPECT_EQ(clamped.x, 12.0f);
+  EXPECT_EQ(clamped.y, 104.0f);
+}
+
+// The property the CLI compositor actually depends on: after clamping, the whole glyph rect is
+// inside the canvas, so no row or column of it can fall off the edge and be dropped. Asserted over
+// a sweep rather than at hand-picked points, because the call site's anchors come from a curve walk
+// and land anywhere.
+TEST(LabelViewportClamp, TheWholeRectEndsUpInsideACanvasThatCanHoldIt) {
+  constexpr LabelViewport kCanvas{ 0.0f, 0.0f, 128.0f, 96.0f };
+  const LabelSize size{ 21.0f, 15.0f };  // about what a two-glyph label rasterizes to at 15 px
+
+  // The sweep reports its FIRST offending anchor and nothing else: tens of thousands of rows would
+  // all fail for one reason, and a single located counterexample is the whole diagnostic. Recorded
+  // here and asserted after the loop, so no report is made from inside it.
+  int offenders = 0;
+  LabelPos first_in{ 0.0f, 0.0f };
+  LabelPos first_out{ 0.0f, 0.0f };
+  for (float y = -30.0f; y <= 130.0f; y += 1.0f) {
+    for (float x = -30.0f; x <= 160.0f; x += 1.0f) {
+      const LabelPos p = ClampLabelPosToViewport(LabelPos{ x, y }, size, kCanvas);
+      const bool inside = p.x >= kCanvas.x && p.y >= kCanvas.y && p.x + size.w <= kCanvas.x + kCanvas.w &&
+                          p.y + size.h <= kCanvas.y + kCanvas.h;
+      if (inside) {
+        continue;
+      }
+      if (offenders == 0) {
+        first_in = LabelPos{ x, y };
+        first_out = p;
+      }
+      ++offenders;
+    }
+  }
+  EXPECT_EQ(offenders, 0) << "first of " << offenders << ": anchor (" << first_in.x << ", " << first_in.y
+                          << ") clamped to (" << first_out.x << ", " << first_out.y << "), whose " << size.w << "x"
+                          << size.h << " rect leaves the " << kCanvas.w << "x" << kCanvas.h << " canvas";
+}
+
+// A label already comfortably inside is returned bit-identical. This is what makes the CLI change
+// affect the rim and nothing else — every existing render whose labels were clear of the edges must
+// composite the same bytes it did before the clamp existed.
+TEST(LabelViewportClamp, AnInteriorLabelIsUntouched) {
+  // Same shape as the sweep above, and for the same reason: locate the first anchor the clamp moved
+  // and report that one, rather than every anchor in the interior.
+  int moved = 0;
+  LabelPos first_in{ 0.0f, 0.0f };
+  LabelPos first_out{ 0.0f, 0.0f };
+  for (float y = 40.0f; y <= 60.0f; y += 0.5f) {
+    for (float x = 40.0f; x <= 60.0f; x += 0.5f) {
+      const LabelPos p = ClampLabelPosToViewport(LabelPos{ x, y }, LabelSize{ kTextW, kTextH }, kVp);
+      if (p.x == x && p.y == y) {
+        continue;
+      }
+      if (moved == 0) {
+        first_in = LabelPos{ x, y };
+        first_out = p;
+      }
+      ++moved;
+    }
+  }
+  EXPECT_EQ(moved, 0) << "first of " << moved << ": an interior anchor (" << first_in.x << ", " << first_in.y
+                      << ") was moved to (" << first_out.x << ", " << first_out.y << ")";
+}
+
+}  // namespace
+}  // namespace lumice


### PR DESCRIPTION
> ⚠️ **本 PR 叠在 #307 之上**（base = `fix/gui-test-harness-gates`，不是 main）。
> 请在 #307 合入之后再合；#307 合入时 GitHub 会自动把 base 改回 main。

## 问题

GUI 侧 `AppendOverlayToDrawList` 早就有 `ClampLabelPosToViewport`（把文字框推进视口内 2px），
CLI 渲染路径**刻意没有实现等价机制**（当时明示 out-of-scope），直接按 core 返回的原始锚点画。
后果：锚点落在画幅边缘时文字被硬裁一半——窄视场（`fov 40`）里那条 30° 等高线的 label 只剩右半边。

机制上必然：**锚点被放在曲线「进入可见区域」的位置**，窄视场下那就是画幅边缘，于是字形串跨在
边界上，合成循环把落在外面的那一半静默丢掉。

## 修法：不是在 CLI 再写一份，而是把规则收敛成一个 owner

新增 `src/util/label_viewport_clamp.hpp`，规则本体（inset 常量 + 退化视口的回退行为）只此一份：

- **CLI**（`src/server/render.cpp::PaintLabels`）接入它
- **GUI**（`src/gui/overlay_labels.cpp`）改成薄包装——只做 `ImVec2` ↔ 结构体的类型适配，
  因为 core 看不到 `ImVec2`，这层拆包正是为了不产生第二份算术

⭐ 这条不是形式要求：这批注解层工作的**全部立项理由**就是消灭 core↔GUI 的分歧族，
在它的遗留项上重新制造一处分歧等于把任务做成负收益。

**退化视口的行为**值得单独看一眼：当视口装不下「文字 + 两个 inset」时，该轴**保持不动**而不是
钳到一个无意义的位置——钳过去只会把 label 推到角落且毫无收益，保持不动则维持既有的
「以锚点为中心、可能被裁」的观感（塌陷的面板、极小的导出）。

## 关于 `src/util/` 与 GUI API 边界

把共享规则放进 `src/util/` 不是新开的口子：`src/gui/` **今天已经 include 了 12 个** `util/` 头
（`spdlog_levels` / `result_frame` / `color_space` / `path_utils` / `fatal` …）。边界规则的原文只
禁止 `src/gui/` 直接 include `core/` 或 `config/`。

本 PR 顺手给这个既有豁免**补上形状**（`AGENTS.md`，是收紧不是放宽）：可以住在那里并被两侧
include 的，是**不携带仿真/配置语义的纯无状态 helper**；需要看见 `RenderConfig` / `SimData` /
晶体的东西仍然走 C API。⚠️ **这是对项目治理文档的改动，请 owner 过目**——判据「不带 core/config
类型」对现有 12 个 include 逐个成立（含 `result_frame.hpp`，它只 include `<memory>` 与
`lumice.h` 这个 C API 本身）。

## 验证

- **AC1 红态锚点先行**：先做出稳定复现「label 被裁一半」的 config + 输出图，再动手
- **两层回归测试，各自红态自证**：`test/unit-correctness/util/test_label_viewport_clamp.cpp`
  钉公式本身；`test/unit-correctness/server/test_render_consumer_label.cpp` 钉「CLI 真的接了它」
  ——两层缺一不可：只测公式无法发现 CLI 没接线
- **GUI 侧逐像素零变化**，三组 on-screen 参考图零重拍
- **e2e 参考图零影响**（逐张核实，不是「没红就算过」）
- `./scripts/test.sh pr` 全绿；五道工程门禁 rc=0
- ⛔ 按 issue 边界**不做碰撞避让**（那需要先决定 GUI 的分组规则要不要一起搬，异根因）

## 评审

两位独立评审 APPROVE（0 Critical / 0 Major）。三条 Minor（其中两条是同一发现的两次表述）
已由第四个 commit 采纳：

1. 共享函数与 GUI 包装函数**同名**是有意选择，但理由此前只在工作笔记里 ⇒ 已连同它的代价
   （裸符号搜索会同时命中两者）与重新权衡的触发条件（出现第三个调用点）写进代码注释。
2. 集成回归的判据拿 **SUM 比 UNION**，隐含前提是「各 label 字形包围盒互不重叠」；改动 config 的
   label 密度会让它**在渲染正确的情况下假红** ⇒ 已显式写出。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYUQjkoHUfvHDF1xzk829e