### PR TITLE
feat(gui): "Use GPU" 可存为个人默认（覆盖文件新增 app 根键），工厂默认仍是 CPU

### DIFF
--- a/doc/gpu-single-engine-implementation.md
+++ b/doc/gpu-single-engine-implementation.md
@@ -117,6 +117,9 @@
 ## 3. 设计原则（硬约束）
 
 - **legacy = ground truth；当前 Metal 代码至多作参考，不照搬**（owner 定调：可推翻重写，别过早陷入"修当前实现"的局部陷阱）。
+  这条同时是 **GUI 工厂默认走 legacy CPU** 的第一条理由——两者是同一件事的两面。另外两条理由
+  （用途分工：GPU 适合大光线量的高质量输出、CPU 适合拖滑杆式的快速调整；以及"不隐式翻转默认链路"
+  的接口哲学）连同这条，一起落在 `src/gui/gui_state.hpp` 的 `use_gpu_backend` 字段注释里。
 - **统计等价验收**（seam-design §3.6），度量用 **raw-XYZ parity**（`GetRawXyzResults` block-mean corr，避开 sRGB tonemap 失真；**2026-08-10 注**：该 getter 已于 v4.15 净删，今天的等价读法是 `LUMICE_AcquireResultFrame` + `LUMICE_FrameGetRawXyz`，度量本身不变），覆盖单/多 MS × 有/无 filter，对 legacy。
 - **device 续传 gate 融进 kernel 逐跳 emit**（非"把 host hop 搬上 device"）：每 emit 一条离开光线（此刻 `path[]`=路径至今在寄存器）当场 device prob+filter → 续传写 continuation buffer / 输出写 exit buffer / fail 丢。三重收益：①逐位对齐 legacy `CollectData`（它就是逐跳对每条离开光线用"路径至今"判 filter，simulator.cpp:426）；②**天然修掉 §2.4 的 +16% bug**（其根因正是解耦的 host 重建；inline 用寄存器路径至今，单 MS exit 已证此 path 对 → correct-by-construction）；③E4 证融入零额外代价。
 - **frame-transit 落点（C3，2026-06-14 精化）**：emit gate 只融 **prob + filter**——它们依赖"路径至今"，必须在离开那跳、寄存器里做。**frame-transit（重采下一层晶体取向 `InitRay_rot` + `ApplyInverse` + 重采入射点/面 `InitRay_p_fid`）不依赖路径、依赖\*下一层晶体几何\*，放到\*下一层 dispatch 的 kernel 入口\***（该 dispatch 已绑定自己那块晶体）。**为什么不塞进 emit gate**：多晶体场景（Scrum 1 验收 config 即 7 晶体）下，若 frame-transit 在 emit 那跳做，gate 就需要下一层全部晶体几何池 + per-ray 选择 = 把 concern #5 几何池提前拽进 Scrum 1，与"几何池留 Scrum 2"自相矛盾。切在 ingest 则：emit gate 保持 path-local、几何池干净留 Scrum 2、per-ray 下一层晶体路由变成层间 compaction 的一步（wavefront Recombine 本就该建模）。**此边界须在 Scrum 1 设计期钉死，否则实现中途会撞"多晶体 gate 做不了 device frame-transit"。**

--- a/doc/gui-state-governance.md
+++ b/doc/gui-state-governance.md
@@ -125,12 +125,16 @@
 |---|----------|------|------|
 | ① 单例文档默认 | `FieldTier::kStructSoft` 中的单例字段（`sun` / `sim` / `renderer`） | 进覆盖文件的 GuiState 半区 |
 | ② 预设库 | 内置 axis 预设表每一行可调的 zenith std（该值不是 `GuiState` 的顶层字段，落地时机与运行时形态见 8.7） | 进覆盖文件独立的 `presets` 子树，不占用 GuiState 半区的键名空间 |
-| ③ app 偏好 | `FieldTier::kView` 中未被 `SerializeGuiStateJson` 序列化的那批（日志级别三件套 / 日志面板展开态 / 左侧面板折叠态），以及 `FieldTier::kStructSoft` 但 `auto_diff_excluded=true` 的字段（如渲染后端选择） | 一期不提供个人默认——这批字段的共同点是"不进文档"，归属清楚，故一期排除不留半拉工程；有具体诉求再评估 |
+| ③ app 偏好 | `FieldTier::kView` 中未被 `SerializeGuiStateJson` 序列化的那批（日志级别三件套 / 日志面板展开态 / 左侧面板折叠态），以及 `use_gpu_backend`（渲染后端选择） | **部分解禁**：`use_gpu_backend` 经覆盖文件独立的第三个根键 `app` 落地为个人默认（形态与 ② 同构，面板里是第二个注册式区，见 8.3），在 `kFieldTierTable` 上由自己的 `app_preference_eligible` 位登记；其余成员仍然排除——它们没有存储通道，`ResolveDefaultEligibility` 对它们仍返回 `kAppPreference`。工厂默认不变（`use_gpu_backend = false`，理由见 `gui_state.hpp` 该字段处的注释）|
 | ④ 集合区 | `FieldTier::kStructHard` 的成员，以及 `kStructSoft` 里被 `kCollectionFields`（`user_defaults.hpp:64`）标记的容器：晶体 / layer / filter / 染色规则 | 排除。这些容器在序列化后的 key path 里携带文档局部下标（如某个数组的第几项），脱离具体文档后这个下标没有意义 |
 
 ### 8.2 资格判定：从档位表派生，不手写第二份清单
 
 `ResolveDefaultEligibility()`（`user_defaults.hpp:105`）以字段名为输入，在 `kDerivedFieldsExcludeList`（`gui_state_tiers.hpp:128`）与 `kFieldTierTable`（`gui_state_tiers.hpp:48`）这一"治理并集"里查找，返回 `kEligible` / `kIneligible`（附一个具体原因）/ `kUnregistered`（后者只应在字段名打错或漏注册时出现，从不是合法结果）。判定完全由已有的、被 `scripts/check_policies.py` 强制"每个 `GuiState` 顶层字段恰好登记一处"的档位表推导，本层没有再引入任何手写字段名列表——新增一个 `GuiState` 字段时，它的默认值资格随档位表的登记自动确定，不需要在这里同步第二处。
+
+⚠️ **两个 bit 各答一个问题，不得互相借用。** `ResolveDefaultEligibility` 曾在 `kStructSoft` 分支上读 `auto_diff_excluded` 来把 `use_gpu_backend` 判为不可默认——那是**代理量**：`auto_diff_excluded` 回答的是"`ReconcileGuiEffects` 要不要从这个字段自动派生效果"，与"这个字段能不能存成个人默认"无关，两者的成员集合当时恰好重合而已（一个登记在别的档位上的 app 偏好会从它下面径直走过去）。现在两个问题分居 `FieldTierEntry` 的两个位：`auto_diff_excluded` 只管 reconciler；`app_preference_eligible` 只回答"这个字段有没有属于自己的个人默认通道（`app` 根键）"。`ResolveDefaultEligibility` 不再读前者，而后者的读者是把 `ResetIneligibleScalarFields()` 钉在档位表上的那道覆盖闸（`kIneligibleScalarResetFieldCount`）。
+
+`ResolveDefaultEligibility` 的返回值回答**能不能**存，不回答**存在文件的哪一半**——通道由字段自己那一行的 `app_preference_eligible` 决定，没有任何写入路径去消费这个返回值来选通道。
 
 ### 8.3 行的存在性是生成式，行的编辑器是注册式（分工写死，否则后人会读成 D3 被推翻）
 
@@ -140,6 +144,8 @@
 - **行的编辑器 = 注册式。** 一行画成滑条还是取色器、定义域是什么、当前是否可编辑，来自一张显式登记表（`FieldEditorEntry`，`field_editor_registry.hpp:111`），以**序列化键路径**（如 `"overlay_grid_color"`）而非 C++ 字段名（`grid_color`）为键——42 个可编辑叶子里有 18 个两者不同名。控件的形状不能从一个 JSON 叶子反推：`"0.3"` 说不出它是 `[0,1]` 里的 alpha、一个概率，还是一个角度。查表用 `FindFieldEditor()`（`field_editor_registry.hpp:126`），未注册返回 `nullptr`——这是设计好的合法答案，面板把它渲染成**只读**并在视觉上说明原因，而不是退化成一个通用输入框（后者会接受真实控件本会拒绝的值，比什么都不显示更有害）。
 
   405 的 D3（"编辑器只能注册，不能从 JSON 叶子派生"）**没有被推翻**：它一直管的是编辑器这一半，这次重构只是新增了存在性那一半的生成式做法，并第一次把两者在同一份文档里并列写清楚——不写清楚的代价，是后人看见"存在性是生成的"就顺势以为"编辑器现在也可以是生成的"。
+
+- **注册式的区域现在有两个，`presets` 与 `app`，两者对生成式 walk 都是隐形的。** 面板里除了 §2 那张生成式的设置列表，还有两块**不由 walk 产出**的区域：§1 预设库（`presets` 根键，命名空间 ②）与 §app 应用偏好（`app` 根键，命名空间 ③）。它们隐形的机制是同一条，且是结构性的而非约定：`SerializeGuiStateJson` 从不产出这两个根键，`BuildDefaultDiffRows` 遍历的正是那份序列化输出的键集合，因此这两棵子树没有机会成为一行。反过来说，**存在这两个根键下的字段，只能经它们各自的 `ReadXFromDoc` / `WriteXToDoc` / `EraseXFromDoc` 原语读写**——这也是"文档半区绝不能决定 `use_gpu_backend`"从一条纪律变成一条机制的地方。
 
   这张注册表也是主 UI 与面板收敛到"同一份权威"的落地方式：主 UI 里所有绑定到已注册字段的滑条调用点（`app_panels.cpp` 的 View / Display / Overlay 与 `panels.cpp` 的 Sun / Simulation，共 16 处）都改读同一个 `ConstraintFor()`（`field_editor_registry.hpp:137`），不再各自持有一份边界字面量——改一处，主 UI 与面板同时移动（`main-ui-constraint-registry` / 408.8 落地；其 AC3 的红态探针证明了这一点：故意改错某个约束的边界，主 UI 与表格单元格在同一次改动、同一帧一起偏移）。
 
@@ -196,6 +202,16 @@
 
 - **`schema_version` 与 `defaults_schema_version` 是两个键，不是一个。** 前者是 `SerializeGuiStateJson` 的输出里本来就有的根键（因此被 `kDiffEngineExcludedRootKeys` 排除在 diff 行之外），后者是覆盖文件自己的。同名复用会让同一份合并文档里一个键承载两种含义，打开文件的人无从区分。另外，`ApplyUserDefaultsOverlay` 的 merge 是 `merge_patch`，磁盘文档里任何与工厂文档同名的根键都会覆盖合并结果里的那个（值为 `null` 时更是直接**删除**该键）——所以 `BuildMergedOverlayDocument` 在 merge 之后无条件把 `schema_version` 回写成当前构建值：喂给反序列化器的那份文档描述的是**它自己**，不是它读过的文件。今天无害（反序列化器不读它），它咬人的那天正是版本号开始被用上的那天。
 - **"只含一个版本戳"必须继续读作"没有个人默认值"。** 用户把所有默认值都改回出厂值后，文件从 `{}` 变成只剩这一个键。任何回答"这个用户有没有个人默认值"的判断都不得因此翻面——今天这样的判断只有 `ApplyUserDefaultsOverlay` 的早退一处，它按键名忽略版本戳。
+
+### 8.10 用户配置只由**显式 Save** 写入——本仓库没有任何"记住上次选择"的粘滞机制
+
+这条模型事实此前散落在三处代码注释里，从未整体写下来过，导致每次讨论"某个开关能不能记住"时都要重新推一遍。落盘为一句话：
+
+- **写入方唯一，且只在用户按下 Save 时执行。** `WriteUserDefaultsFile` 的唯一调用者是 `WriteActiveOverlayDoc`，后者的唯一生产调用点是 `Settings` 面板的 `CommitCopy()`（即 Save 按钮）。这条单点约束由 `scripts/check_policies.py` 的 `user-defaults-single-write-path` 机械守着，不是靠纪律。
+- **ImGui 自己的持久化被主动关闭。** `src/gui/main.cpp` 把 `io.IniFilename` 置空，所以窗口位置、折叠态、表格列宽这些 ImGui 默认会写进 `imgui.ini` 的东西一律不落盘。
+- ⇒ **没有任何 GUI 开关会因为"你上次是这么选的"而自己被记住。** 一个开关要变成个人默认，必须有人为它建一条显式通道（命名空间 ①/②/③ 之一），并让用户在面板里按下 Save。
+
+这不是缺陷，是有意的：粘滞会让"这台机器为什么和那台机器表现不一样"变成一个没有痕迹可查的问题——与 `doc/env-var-policy.md` 拒绝用环境变量承载用户可见行为开关，是同一条理由。新增一个"记住这个选择"的诉求时，答案永远是"给它一条显式通道 + 面板里的一行"，不是"在某处偷偷写下来"。
 
 ---
 

--- a/src/gui/defaults_panel.cpp
+++ b/src/gui/defaults_panel.cpp
@@ -361,6 +361,47 @@ bool CommitCopy(const GuiState& state) {
   return true;
 }
 
+// §app — application preferences (namespace 3), the one region of this panel that is neither a
+// generated row nor a preset.
+//
+// A fixed single line rather than a third CollapsingHeader: it holds ONE control, and a section
+// that is taller folded than unfolded is a fold nobody would use. Drawn ABOVE both collapsible
+// sections on purpose — every height budget below reads GetContentRegionAvail() after this point,
+// so the row costs the two sections what it occupies and needs no arithmetic of its own.
+//
+// The control is stateless: g_copy_doc IS the state, read fresh each frame and written on click.
+// There is deliberately no TU-local mirror of it to keep in step with the copy, to freeze at open
+// time, or to clear in ResetDefaultsPanelTestState.
+//
+// The checkbox means WHAT NEW DOCUMENTS START WITH — not "this key is in my defaults", which is
+// what every checkbox in §2 means. That is why it is labelled as a sentence about new documents,
+// sits outside the settings table, and says the current window's value beside it: a bare "Use GPU"
+// here would be the same widget shape as §2's rows carrying a different meaning.
+void RenderAppPreferences(const GuiState& state) {
+  ImGui::TextUnformatted("Application preferences");
+
+  bool checked = ReadUseGpuBackendFromDoc(g_copy_doc).value_or(GuiState{}.use_gpu_backend);
+  if (Checkbox("New documents start with the GPU backend###defaults_app_use_gpu", &checked)) {
+    // Both states are written explicitly rather than "true writes, false erases". "Stored false"
+    // and "stored nothing" resolve to the same document today only because the factory value is
+    // false; recording the user's answer means it stays their answer if that ever moves.
+    WriteUseGpuBackendToDoc(g_copy_doc, checked);
+  }
+  if (ImGui::IsItemHovered()) {
+    ImGui::SetTooltip(
+        "Whether a NEW document starts with GPU simulation selected. This is the stored preference, "
+        "not the Use GPU switch in the main window — changing it here does not touch the current "
+        "document, and it takes effect on the next new document. The GPU falls back to the CPU on a "
+        "machine that has none.");
+  }
+
+  // The main window's CURRENT value, so the user can tell what they are about to store from what
+  // they are running right now. The two are independent by design: this panel is an editor of the
+  // defaults file, not a second control over the live document.
+  ImGui::SameLine();
+  ImGui::TextDisabled("(this window: %s)", state.use_gpu_backend ? "on" : "off");
+}
+
 // Section header whose open state is forced only on the frame an entry point requested it.
 bool SectionHeader(const char* label, DefaultsPanelSection section, bool open_when_pending) {
   if (g_pending_initial_section.has_value()) {
@@ -937,6 +978,9 @@ void RenderDefaultsPanel(GuiState& state) {
   ImGui::TextWrapped(
       "These are the settings a NEW document starts from. Adopting a change writes it to your "
       "personal defaults file; opening an existing file always uses the values in that file.");
+  ImGui::Separator();
+
+  RenderAppPreferences(state);
   ImGui::Separator();
 
   RenderListControls();

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -1229,7 +1229,28 @@ struct GuiState {
   // Request a GPU trace backend (Metal on Apple, CUDA on NVIDIA). Toggling this
   // reconstructs the server on the next DoRun via MaybeReconstructServerForBackend
   // (backend is a construction-time topology property: CPU N-worker vs GPU single
-  // engine), so the accumulated image resets on toggle. UI-only, session-only.
+  // engine), so the accumulated image resets on toggle. UI-only: not serialized into a
+  // document (.lmc) and not in the Revert baseline (ConfigSnapshot).
+  //
+  // WHY THE FACTORY VALUE IS false, i.e. why a fresh install simulates on the legacy CPU path
+  // even on a machine with a perfectly good GPU. This is a settled decision, recorded here
+  // because it had been re-argued from scratch more than once with nothing written down:
+  //   1. Correctness baseline. This program traced on the CPU for eight years before a GPU
+  //      backend existed (first commit 473ef759, 2018-02-23; the TraceBackend seam and the first
+  //      device backend arrived in 6b10ba43 / 6cb5857e, 2026-06-04), so every correctness
+  //      standard the project has is stated against that path. doc/gpu-single-engine-
+  //      implementation.md §3 says the same thing from the GPU side: legacy is ground truth.
+  //   2. Division of labour, and the one a user feels. The GPU path is for high-quality output
+  //      at large ray counts; the CPU path is for ADJUSTING — dragging a slider, retrying a sun
+  //      elevation. A GPU batch is enormous, so its response to a parameter change lags; on the
+  //      CPU it does not. Whichever path a first-run user is dropped into is the one they form
+  //      their impression of the program's responsiveness from.
+  //   3. Interface philosophy. The default trace path is not flipped implicitly.
+  // Reason 3 is what this field's PERSONAL DEFAULT does not violate: a user who ticks the box in
+  // the Settings panel and saves has made exactly the explicit choice reason 3 asks for, and
+  // storing it is honouring that choice rather than the program making one for them. The stored
+  // value lives under the override file's `app` root key — never the document half — see
+  // user_defaults.hpp's app-preferences block and doc/gui-state-governance.md §8.
   bool use_gpu_backend = false;
 
   // Edit modal mode (UI-only, session-only, not in ConfigSnapshot).

--- a/src/gui/gui_state_tiers.hpp
+++ b/src/gui/gui_state_tiers.hpp
@@ -55,6 +55,14 @@ struct FieldTierEntry {
   bool auto_diff_excluded;
   // Trailing + default-initialized so every existing row keeps its three-element aggregate
   // initializer; only a row that answers "yes" spells the fourth value out.
+  //
+  // Setting this to true REGISTERS a field and turns on the coverage assertion; it does not wire
+  // one up. Nothing walks this table to drive behaviour — ResetIneligibleScalarFields() and
+  // ApplyAppPreferencesOverride() (user_defaults.cpp) each name their field by hand. So adding the
+  // second member of this namespace means three edits, not one: this bit, a line in each of those
+  // two functions. That is the deliberate cost of not building a general registry for a
+  // single-member set; the coverage test is what makes forgetting the other two edits go red
+  // rather than silent.
   bool app_preference_eligible = false;
 };
 

--- a/src/gui/gui_state_tiers.hpp
+++ b/src/gui/gui_state_tiers.hpp
@@ -19,6 +19,17 @@
 // scrum's later task (raypath_color migration) splits ColorClassConfig into structural + display
 // sub-structs. Until then the field keeps its existing MarkStructHardDirty call sites.
 //
+// The `app_preference_eligible` bit answers a DIFFERENT question, and the two are kept in separate
+// bits precisely because they were once read off the same one: "does this field have a legitimate
+// personal-default channel of its own, outside the document half of the override file?" An entry
+// with this bit set is stored under the override file's `app` root key — a sibling of `presets`
+// that neither SerializeGuiStateJson nor DeserializeGuiStateJson ever touches — and must therefore
+// be reset out of anything the document half applied (ResetIneligibleScalarFields,
+// user_defaults.cpp) before that channel is read. Currently the sole use is `use_gpu_backend`.
+// Reading `auto_diff_excluded` for this instead is a proxy quantity: the two populations coincide
+// today by accident, and the reconciler's question has nothing to do with where a default is
+// stored.
+//
 // `kDerivedFieldsExcludeList` is a separate registry for fields that are outputs / runtime-derived
 // state (sim_state, epoch bookkeeping, stats readbacks, auto-EV runtime, etc.) — they are NOT
 // governed by a tier because the reconciler must not touch them.
@@ -42,6 +53,9 @@ struct FieldTierEntry {
   const char* name;
   FieldTier tier;
   bool auto_diff_excluded;
+  // Trailing + default-initialized so every existing row keeps its three-element aggregate
+  // initializer; only a row that answers "yes" spells the fourth value out.
+  bool app_preference_eligible = false;
 };
 
 // clang-format off
@@ -60,11 +74,16 @@ inline constexpr FieldTierEntry kFieldTierTable[] = {
     // third one is the signal to stop and give sub-field tiers a registry of their own rather than
     // adding a third prose entry — and to notice that the gate below cannot see any of them.
     { "renderer",                   FieldTier::kStructSoft, false },
-    // use_gpu_backend: registered kStructSoft for governance coverage, but NOT in ConfigSnapshot's
-    // From/ApplyTo (view/session field intentionally excluded from Revert baseline). No baseline →
-    // no diff possible; legacy DIRTY_IF wrapper (panels.cpp:1067) drives dirty. See SUMMARY.md AC1
-    // for the second predicted exception found during M2 implementation (per plan §7 risk 5 门槛).
-    { "use_gpu_backend",            FieldTier::kStructSoft, true  },
+    // use_gpu_backend. Two independent bits, for two unrelated reasons:
+    //   auto_diff_excluded=true      — it is NOT in ConfigSnapshot's From/ApplyTo (a view/session
+    //                                  field deliberately outside the Revert baseline), so there is
+    //                                  no baseline to diff against; the legacy DIRTY_IF wrapper in
+    //                                  panels.cpp drives dirty for it instead.
+    //   app_preference_eligible=true — the user CAN store this one as a personal default, but only
+    //                                  through the override file's `app` root key, never through
+    //                                  the document half. See user_defaults.hpp's app-preferences
+    //                                  block and doc/gui-state-governance.md §8.
+    { "use_gpu_backend",            FieldTier::kStructSoft, true, true },
 
     // ==== T-struct·hard: re-sim + display clear + epoch floor bump ==============================
     { "filters",                    FieldTier::kStructHard, false },

--- a/src/gui/user_defaults.cpp
+++ b/src/gui/user_defaults.cpp
@@ -102,17 +102,32 @@ std::string DescribeAxisPresetClamp(AxisPreset preset, float requested, float st
          " — that boundary is where the neighbouring preset's criterion begins, not a physical limit.";
 }
 
-// Reset the ineligible fields that a hand-edited override file could otherwise smuggle in.
+// Re-assert that the DOCUMENT half of an override file did not decide an app-preference field.
 //
-// Most ineligible fields are structurally unreachable from the override file: kDisplay and the
-// `kView \ serialized` set have no JSON key at all, and the collections are cleared wholesale
-// by the caller. The exception is a field that is registered kStructSoft with
-// auto_diff_excluded — an ordinary serializable scalar that DeserializeGuiStateJson will
-// happily read. Today that is exactly `use_gpu_backend`.
+// It is the boundary between namespace 1 (the GuiState half, applied by ApplyUserDefaultsOverlay)
+// and namespace 3 (the `app` root key), pinned in code. Most fields namespace 1 may not decide are
+// structurally unreachable from it anyway — kDisplay and the `kView \ serialized` set have no JSON
+// key at all, and the collections are cleared wholesale by the caller. This handles the ones that
+// are ordinary serializable scalars, where the file's top level has a well-formed place to put
+// them. Today that is exactly `use_gpu_backend`, registered app_preference_eligible.
+//
+// It does NOT rest on the claim that the deserializer would read such a key today: for
+// use_gpu_backend it would not — the GuiState serializer is written key by key (file_io.cpp) and
+// has no entry for this field, so a top-level `use_gpu_backend` is inert on the way in. The reason
+// to keep the reset anyway is that this is the one line where "namespace 1 cannot decide this
+// field" is stated as code, its cost is one assignment, and the alternative is that the boundary
+// holds only for as long as nobody adds the field to the serializer. An earlier version of this
+// comment asserted the deserializer WOULD read it; that was checked and is false, which is the
+// second reason the justification is stated as a boundary rather than as a defence against a
+// specific reader.
+//
+// ORDER: this must run BEFORE ApplyAppPreferencesOverride, never after — reversed, it would wipe
+// the personal default namespace 3 had just legitimately applied. Both calls are welded into
+// ResetIneligibleScalarsThenApplyAppOverride below so no call site has to know that.
 //
 // Keep kIneligibleScalarResetFieldCount (user_defaults.hpp) in step with this body; the AC1
-// test asserts the constant equals the population of the predicate above, so adding another
-// such field turns that test red rather than leaving a silent hole here.
+// test asserts the constant equals the population of the app_preference_eligible predicate, so
+// adding another such field turns that test red rather than leaving a silent hole here.
 void ResetIneligibleScalarFields(GuiState& state) {
   const GuiState factory{};
   state.use_gpu_backend = factory.use_gpu_backend;
@@ -548,6 +563,72 @@ void EraseAxisPresetZenithStdFromDoc(nlohmann::json& doc, AxisPreset preset) {
   }
 }
 
+// ------------------------------------------------------------------------------------------------
+// The `app` root key (namespace 3). See user_defaults.hpp for why it is a third root key rather
+// than another GuiState field in the document half.
+// ------------------------------------------------------------------------------------------------
+
+namespace {
+constexpr const char* kAppRootKey = "app";
+constexpr const char* kUseGpuBackendKey = "use_gpu_backend";
+}  // namespace
+
+std::optional<bool> ReadUseGpuBackendFromDoc(const nlohmann::json& doc) {
+  if (!doc.is_object()) {
+    return std::nullopt;
+  }
+  // find() rather than the operator[] chain, for the same reason as ReadAxisPresetZenithStdFromDoc:
+  // the document is user-editable and operator[] on a non-object throws.
+  const auto app = doc.find(kAppRootKey);
+  if (app == doc.end() || !app->is_object()) {
+    return std::nullopt;
+  }
+  const auto value = app->find(kUseGpuBackendKey);
+  if (value == app->end() || !value->is_boolean()) {
+    return std::nullopt;
+  }
+  return value->get<bool>();
+}
+
+void WriteUseGpuBackendToDoc(nlohmann::json& doc, bool value) {
+  if (!doc.is_object()) {
+    doc = nlohmann::json::object();
+  }
+  // Surgical: ONE key is touched, so the GuiState half and `presets` survive by construction.
+  // operator[] is fine on the write path — it starts from a document this process controls, not
+  // from whatever a user may have typed into the file.
+  doc[kAppRootKey][kUseGpuBackendKey] = value;
+}
+
+void EraseUseGpuBackendFromDoc(nlohmann::json& doc) {
+  if (!doc.is_object()) {
+    doc = nlohmann::json::object();
+  }
+  const auto app_it = doc.find(kAppRootKey);
+  if (app_it == doc.end() || !app_it->is_object()) {
+    return;
+  }
+  app_it->erase(kUseGpuBackendKey);
+  if (app_it->empty()) {
+    doc.erase(kAppRootKey);
+  }
+}
+
+void ApplyAppPreferencesOverride(GuiState& state, const nlohmann::json& doc) {
+  if (const std::optional<bool> use_gpu = ReadUseGpuBackendFromDoc(doc); use_gpu.has_value()) {
+    state.use_gpu_backend = *use_gpu;
+  }
+}
+
+void ResetIneligibleScalarsThenApplyAppOverride(GuiState& state, const nlohmann::json& doc, bool has_dir) {
+  // Order is the invariant; see this function's declaration in user_defaults.hpp for why the two
+  // calls live in one body and why the reset half is not gated on has_dir.
+  ResetIneligibleScalarFields(state);
+  if (has_dir) {
+    ApplyAppPreferencesOverride(state, doc);
+  }
+}
+
 void AdoptAxisPresetZenithStdOverrideInMemory(AxisPreset preset, std::optional<float> stored_value) {
   const auto slot = static_cast<std::size_t>(preset);
   if (slot >= kAxisPresetSlotCount) {
@@ -635,8 +716,10 @@ GuiState MakeNewDocumentState(std::optional<std::filesystem::path> override_dir)
 
   // The override file is user-editable, so the read path — not just the write path — has to
   // enforce eligibility. Otherwise "which fields may be defaults" would be advisory metadata
-  // that anyone can step around with a text editor.
-  ResetIneligibleScalarFields(state);
+  // that anyone can step around with a text editor. The same call also applies the `app` root
+  // key, which is the ONLY channel that may decide those fields — the two are one function
+  // because their order is what makes both halves true (see its declaration).
+  ResetIneligibleScalarsThenApplyAppOverride(state, doc, dir.has_value());
 
   // Namespace 4 (collections): a key path into these carries a document-local index, so they
   // are never written as defaults — but clear them anyway so a hand-edited file cannot make a

--- a/src/gui/user_defaults.cpp
+++ b/src/gui/user_defaults.cpp
@@ -544,6 +544,13 @@ void EraseAxisPresetZenithStdFromDoc(nlohmann::json& doc, AxisPreset preset) {
   // Same normalization as WriteAxisPresetZenithStdToDoc: a malformed top-level document (hand-edited,
   // truncated, or a bare null/array) must become a valid empty object rather than being written back
   // to disk unchanged by the caller.
+  //
+  // Reachability, stated rather than implied: no production caller gets here. Every one of them
+  // passes the panel's working copy, which is either a document read from the override file or a
+  // fresh object, so it is an object by construction. The branch is reached only by the unit test
+  // that hands it a json::array() on purpose. It is kept because the normalization is the same
+  // shape the axis-preset writer already owes its callers, not because a real path was observed
+  // producing a non-object root.
   if (!doc.is_object()) {
     doc = nlohmann::json::object();
   }

--- a/src/gui/user_defaults.hpp
+++ b/src/gui/user_defaults.hpp
@@ -560,6 +560,12 @@ std::optional<bool> ReadUseGpuBackendFromDoc(const nlohmann::json& doc);
 void WriteUseGpuBackendToDoc(nlohmann::json& doc, bool value);
 // Prunes the parents it empties, like EraseAxisPresetZenithStdFromDoc, so a file opened by hand
 // does not accumulate an empty `"app": {}` skeleton.
+//
+// No production caller today — the panel writes both states explicitly rather than erasing, so
+// "saved false" and "never saved" stay distinguishable in the file. This is kept for symmetry with
+// the read/write/erase trio the presets namespace already has, and as the channel a second member
+// of this namespace would need. It is neither dead code to delete on sight nor a call site someone
+// forgot to add.
 void EraseUseGpuBackendFromDoc(nlohmann::json& doc);
 
 // Apply the app-preferences half of `doc` to `state`: each stored field is assigned, each absent

--- a/src/gui/user_defaults.hpp
+++ b/src/gui/user_defaults.hpp
@@ -55,9 +55,12 @@ enum class IneligibleReason {
   kCollection,      // namespace 4: crystals / layers / filters / raypath_color — a key path into
                     // these contains a document-local index, which is meaningless as a default
   kNotSerialized,   // in no persisted schema at all (FieldTier::kDisplay)
-  kAppPreference,   // an application preference (log levels, backend choice) rather than
-                    // anything the document expresses; a defaults system for these is a
-                    // separate feature and none is offered yet
+  kAppPreference,   // an application preference (the log-level trio, the log panel's open state,
+                    // the left panel's collapsed state) rather than anything the document
+                    // expresses, and with no storage channel of its own yet. NOT the verdict for
+                    // an app preference that HAS one: use_gpu_backend is stored under the `app`
+                    // root key and is therefore kEligible — see kFieldTierTable's
+                    // app_preference_eligible bit.
 };
 
 // Fields the user override file must never be able to fill in, keyed by the mechanism that
@@ -121,12 +124,13 @@ inline EligibilityVerdict ResolveDefaultEligibility(std::string_view field_name)
         if (user_defaults_detail::Contains(kCollectionFields, field_name)) {
           return { DefaultEligibility::kIneligible, IneligibleReason::kCollection };
         }
-        if (entry.auto_diff_excluded) {
-          // Currently only use_gpu_backend: registered kStructSoft for governance coverage but
-          // deliberately outside the Revert baseline. It is an app preference (namespace 3).
-          return { DefaultEligibility::kIneligible, IneligibleReason::kAppPreference };
-        }
-        // sun / sim / renderer — the singleton document config (namespace 1).
+        // sun / sim / renderer — the singleton document config (namespace 1) — and
+        // use_gpu_backend, whose channel is the `app` root key (namespace 3) instead. This
+        // verdict says WHETHER the field may be a personal default, not THROUGH WHICH half of
+        // the override file: nothing consumes it to route a write, and a field's channel is
+        // registered on its kFieldTierTable row (app_preference_eligible). It used to read
+        // `auto_diff_excluded` here to hold use_gpu_backend back, which was a proxy for a
+        // question that bit does not answer — that is the coupling this branch no longer has.
         return { DefaultEligibility::kEligible, IneligibleReason::kNone };
       case FieldTier::kDisplay:
         // Currently only raypath_color_mode. Neither SerializeGuiStateJson nor
@@ -163,11 +167,16 @@ inline const char* IneligibleReasonLabel(IneligibleReason reason) {
 }
 
 // Number of fields ResetIneligibleScalarFields() (user_defaults.cpp) explicitly restores to
-// their factory value after an overlay is applied. Those are the ineligible fields that are
-// nonetheless structurally ordinary serializable scalars, i.e. a hand-edited override file
-// COULD smuggle them in. Predicate: tier == kStructSoft && auto_diff_excluded.
+// their factory value after the DOCUMENT half of an overlay is applied. Those are the fields the
+// document half must never decide, but which are nonetheless structurally ordinary serializable
+// scalars — i.e. a hand-edited override file could put one at the top level and have the
+// deserializer read it. Predicate: app_preference_eligible, the bit that says a field's only
+// legitimate default channel is the `app` root key.
 // A coverage assertion in the AC1 test ties this constant to that predicate's population, so
 // adding another such field turns the test red instead of silently leaving a hole.
+// The predicate used to be `tier == kStructSoft && auto_diff_excluded`, which named the same one
+// field for a reason unrelated to defaults; a second app preference registered under any other
+// tier would have slipped straight past it.
 inline constexpr std::size_t kIneligibleScalarResetFieldCount = 1;
 
 // --------------------------------------------------------------------------------------------------
@@ -526,6 +535,55 @@ std::vector<std::string> TakeUserDefaultsDowngradeNotices();
 // THE way another translation unit contributes to this channel — defaults_diff.cpp writes here
 // rather than reaching for a counter of its own, so a user sees one list, not two.
 void NoteUserDefaultsDowngrade(std::string notice);
+
+// --------------------------------------------------------------------------------------------------
+// The app-preferences half of an override DOCUMENT (namespace 3), with no IO.
+//
+// A THIRD root key, `app`, beside the GuiState half and `presets`. Structurally a sibling of the
+// preset library and for the same reason: SerializeGuiStateJson / DeserializeGuiStateJson never
+// emit or read this key, BuildMergedOverlayDocument's merge_patch is inert on it, and
+// BuildDefaultDiffRows' generative walk — which enumerates the keys SerializeGuiStateJson produces
+// — cannot see it. So a field stored here is reachable ONLY through the functions below, which is
+// what makes "the document half must never decide use_gpu_backend" a structural fact rather than a
+// rule someone has to keep.
+//
+// One field today, deliberately: `use_gpu_backend`. The other namespace-3 members
+// (kUnserializedViewFields) stay excluded, and this is not a general per-field registry — the shape
+// leaves room for a second member without pre-building a mechanism for one that does not exist.
+//
+// The read is tolerant because the file is user-editable: a missing key, a non-object `app`, or a
+// non-bool value all read as nullopt, i.e. "nothing stored", and NO downgrade is counted. That is
+// the one place this half deliberately diverges from the document half's "one field-level type
+// error discards the whole overlay": `app` is independent of the document half, so a typo in it
+// must not cost the user their document defaults, nor vice versa.
+std::optional<bool> ReadUseGpuBackendFromDoc(const nlohmann::json& doc);
+void WriteUseGpuBackendToDoc(nlohmann::json& doc, bool value);
+// Prunes the parents it empties, like EraseAxisPresetZenithStdFromDoc, so a file opened by hand
+// does not accumulate an empty `"app": {}` skeleton.
+void EraseUseGpuBackendFromDoc(nlohmann::json& doc);
+
+// Apply the app-preferences half of `doc` to `state`: each stored field is assigned, each absent
+// one leaves `state` untouched (so an overlay with no `app` key yields the factory value).
+void ApplyAppPreferencesOverride(GuiState& state, const nlohmann::json& doc);
+
+// The two steps that decide this field, in the one order that is correct, in one function body.
+//
+// It exists so the order is enforced by control flow instead of by two call sites agreeing to
+// remember it: ResetIneligibleScalarFields re-asserts unconditionally that namespace 1 (the
+// document half) may not decide these fields, and ApplyAppPreferencesOverride then lets namespace
+// 3 — their only legitimate source — override the just-reset factory value. Reversed, the reset
+// would wipe the personal default that had just been applied, and the feature would be silently
+// dead while every other assertion about the file stayed green.
+//
+// `has_dir` false means there is no readable config directory: the reset still runs (it is not
+// optional), and the app half is left alone — `state` keeps its factory value.
+//
+// This is the ONLY call site of ResetIneligibleScalarFields, verified rather than assumed
+// (`grep -rn ResetIneligibleScalarFields src/ test/`; every other hit is prose, not a call). A new
+// caller that needs the reset must go through this function rather than reaching for it directly,
+// even one that has no interest in the app-preferences half — that is what keeps "namespace 1
+// cannot decide this field" a property of the code rather than of the current call graph.
+void ResetIneligibleScalarsThenApplyAppOverride(GuiState& state, const nlohmann::json& doc, bool has_dir);
 
 // Build the GuiState for a NEW document: factory defaults, plus the user's personal defaults,
 // plus the standard seed contents. This is the ONLY place personal defaults enter a GuiState

--- a/test/composition-correctness/gui/test_user_defaults_chain.cpp
+++ b/test/composition-correctness/gui/test_user_defaults_chain.cpp
@@ -427,5 +427,61 @@ TEST_F(UserDefaultsChain, EveryLensTypeSurvivesTheUserDefaultsRoundTrip) {
   }
 }
 
+// ---------------------------------------------------------------------------------------------
+// The GPU-backend preference: stored, then read back by the next launch.
+//
+// The closed loop this feature IS. MakeNewDocumentState is what startup, DoNew() and DoOpen()'s
+// import all call, so calling it after writing the file is "restart the process and make a new
+// document" as far as this chain is concerned — there is no other path a new document arrives by.
+//
+// Both values are exercised, not just `true`: "stored false" and "stored nothing" are different
+// states of the file that happen to produce the same GuiState today, and a reader that collapsed
+// them would pass a true-only test.
+TEST_F(UserDefaultsChain, TheGpuBackendPreferenceSurvivesIntoTheNextNewDocument) {
+  const std::filesystem::path& dir = UseFreshConfigDir("app_use_gpu");
+
+  EXPECT_FALSE(MakeNewDocumentState(dir).use_gpu_backend) << "nothing stored means the factory value";
+
+  nlohmann::json doc = nlohmann::json::object();
+  WriteUseGpuBackendToDoc(doc, true);
+  ASSERT_TRUE(WriteUserDefaultsFile(dir, doc));
+
+  // The ORDER assertion. ResetIneligibleScalarFields runs unconditionally on this path and puts
+  // the field back to `false`; only if the app-preferences read runs AFTER it does the stored
+  // value survive. Reversed, this is the one assertion in the suite that goes red — everything
+  // else about the file would still be true.
+  EXPECT_TRUE(MakeNewDocumentState(dir).use_gpu_backend) << "the stored preference did not reach a new document";
+
+  WriteUseGpuBackendToDoc(doc, false);
+  ASSERT_TRUE(WriteUserDefaultsFile(dir, doc));
+  EXPECT_FALSE(MakeNewDocumentState(dir).use_gpu_backend);
+
+  EraseUseGpuBackendFromDoc(doc);
+  ASSERT_TRUE(WriteUserDefaultsFile(dir, doc));
+  EXPECT_FALSE(MakeNewDocumentState(dir).use_gpu_backend) << "erasing it returns the field to the factory value";
+
+  EXPECT_EQ(TakeUserDefaultsDowngradeCount(), 0) << "none of the above is a degradation";
+}
+
+// The same name in the file's two halves addresses two different things, and only one of them
+// decides the field. Stated from the `app` key's side; test_user_defaults.cpp's
+// ac3_ineligible_keys_cannot_be_smuggled_in states the other half. Together they are what stops an
+// implementation that reads the wrong location from passing: each alone is satisfied by one.
+TEST_F(UserDefaultsChain, OnlyTheAppRootKeyDecidesTheGpuBackendPreference) {
+  const std::filesystem::path& dir = UseFreshConfigDir("app_use_gpu_top_level");
+
+  nlohmann::json doc = nlohmann::json::object();
+  doc["use_gpu_backend"] = true;  // the document half — inert by construction
+  ASSERT_TRUE(WriteUserDefaultsFile(dir, doc));
+  EXPECT_FALSE(MakeNewDocumentState(dir).use_gpu_backend) << "the document half must not decide this field";
+
+  // Both present and DISAGREEING: the app key wins, which is the only reading under which the
+  // top-level key is genuinely inert rather than merely redundant.
+  doc["use_gpu_backend"] = false;
+  WriteUseGpuBackendToDoc(doc, true);
+  ASSERT_TRUE(WriteUserDefaultsFile(dir, doc));
+  EXPECT_TRUE(MakeNewDocumentState(dir).use_gpu_backend);
+}
+
 }  // namespace
 }  // namespace lumice::gui

--- a/test/gui/functional/test_defaults_panel.cpp
+++ b/test/gui/functional/test_defaults_panel.cpp
@@ -1162,6 +1162,91 @@ void RegisterDefaultsPanelTests(ImGuiTestEngine* engine) {
   }
 
   {
+    // §app: the GPU-backend preference, from the click to the file to the next new document. The
+    // one place the whole feature is observable end to end through the UI a user actually has.
+    //
+    // The section folds are driven FIRST, and that is the point of doing it rather than clicking
+    // the checkbox straight away: this row is drawn above two CollapsingHeaders, each of which
+    // spans the full window width and takes hover before anything drawn near it. A row that had
+    // ended up inside either header's reach would still look right in a screenshot and would still
+    // pass a case that only ever clicked it on an untouched panel.
+    ImGuiTest* t =
+        IM_REGISTER_TEST(engine, "defaults_panel", "the_gpu_backend_preference_is_stored_and_reaches_the_next_new");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ScopedPanel panel(ctx, "panel_app_use_gpu");
+      panel.OpenOn(gui::DefaultsPanelSection::kSettings);
+
+      const char* kAppCheckbox = "**/###defaults_app_use_gpu";
+      IM_CHECK(ctx->ItemExists(kAppCheckbox));
+      IM_CHECK(!ctx->ItemIsChecked(kAppCheckbox));
+
+      // Both neighbouring headers, both ways round, and the row survives each: neither state of
+      // either fold may swallow it.
+      ctx->ItemClick("**/###defaults_presets");
+      ctx->Yield(3);
+      IM_CHECK(ctx->ItemExists(kAppCheckbox));
+      ctx->ItemClick("**/###defaults_settings");
+      ctx->Yield(3);
+      IM_CHECK(ctx->ItemExists(kAppCheckbox));
+
+      ctx->ItemClick(kAppCheckbox);
+      ctx->Yield(2);
+      IM_CHECK(ctx->ItemIsChecked(kAppCheckbox));
+      // Still an editor: nothing has reached disk yet, and the live document is untouched.
+      IM_CHECK(!ReadOverlayFile(panel.dir()).contains("app"));
+      IM_CHECK(!gui::g_state.use_gpu_backend);
+
+      SaveDefaultsPanel(ctx);
+      const json saved = ReadOverlayFile(panel.dir());
+      IM_CHECK(saved.contains("app"));
+      IM_CHECK(saved["app"].contains("use_gpu_backend"));
+      IM_CHECK_EQ(saved["app"]["use_gpu_backend"].get<bool>(), true);
+      // The document half is NOT where it landed — the two halves of that proposition are asserted
+      // together because either alone is satisfied by writing to the wrong one.
+      IM_CHECK(!saved.contains("use_gpu_backend"));
+      // Saving a default must not change the open document.
+      IM_CHECK(!gui::g_state.use_gpu_backend);
+
+      // ...and that file is what a new document actually starts from.
+      IM_CHECK(gui::MakeNewDocumentState().use_gpu_backend);
+
+      // Unchecking is an edit like any other: it is stored, and it takes a Save to land.
+      ctx->ItemClick(kAppCheckbox);
+      ctx->Yield(2);
+      IM_CHECK(ctx->ItemIsChecked("**/###defaults_app_use_gpu") == false);
+      IM_CHECK_EQ(ReadOverlayFile(panel.dir())["app"]["use_gpu_backend"].get<bool>(), true);
+      SaveDefaultsPanel(ctx);
+      IM_CHECK_EQ(ReadOverlayFile(panel.dir())["app"]["use_gpu_backend"].get<bool>(), false);
+      IM_CHECK(!gui::MakeNewDocumentState().use_gpu_backend);
+    };
+  }
+
+  {
+    // Closing without saving discards this row like every other edit. Stated for §app on its own
+    // because its control writes g_copy_doc DIRECTLY (as §1's preset cells do) instead of going
+    // through the checkbox set §2's rows use — the two paths reach the copy differently and only
+    // one of them is covered by the existing discard case.
+    ImGuiTest* t =
+        IM_REGISTER_TEST(engine, "defaults_panel", "an_app_preference_closed_without_saving_reaches_no_file");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ScopedPanel panel(ctx, "panel_app_use_gpu_discard");
+      panel.OpenOn(gui::DefaultsPanelSection::kSettings);
+
+      ctx->ItemClick("**/###defaults_app_use_gpu");
+      ctx->Yield(2);
+      IM_CHECK(ctx->ItemIsChecked("**/###defaults_app_use_gpu"));
+
+      panel.Close();
+      IM_CHECK(!ReadOverlayFile(panel.dir()).contains("app"));
+      IM_CHECK(!gui::MakeNewDocumentState().use_gpu_backend);
+
+      // Re-opening starts from the file again, not from the discarded copy.
+      panel.OpenOn(gui::DefaultsPanelSection::kSettings);
+      IM_CHECK(!ctx->ItemIsChecked("**/###defaults_app_use_gpu"));
+    };
+  }
+
+  {
     // Save writes the checked rows and REMOVES the unchecked ones, in one pass, and what it wrote
     // is what a new document actually reads. Two edited keys, exactly one of them un-checked, so
     // the case distinguishes "wrote everything" from "wrote what was asked".

--- a/test/gui/references/_thresholds.json
+++ b/test/gui/references/_thresholds.json
@@ -120,7 +120,7 @@
       }
     },
     "defaults_panel_layout": {
-      "generated_at": "2026-08-31T21:51:21",
+      "generated_at": "2026-09-05T08:04:33",
       "n_ref_runs": 10,
       "n_calib_runs": 10,
       "scenes": {

--- a/test/gui/references/defaults_panel_filtered.png
+++ b/test/gui/references/defaults_panel_filtered.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:54e48793d8dad8e8c45db8ad207a75cbb96af885c1d3ba15e247ba081cc04678
-size 97481
+oid sha256:fb8566229d3e06e54c828ab3f21da6a072a9c9e75f60c8a5854ebc2c71896dcb
+size 106740

--- a/test/gui/references/defaults_panel_no_changes.png
+++ b/test/gui/references/defaults_panel_no_changes.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bea484b61829ede349ee4fb2c787769b89202701ed0e21765cc43090d1783e25
-size 95554
+oid sha256:9f64207f70b45ff3262c2db5edb301809604ebab1c1dbca0e26733e23e258109
+size 96421

--- a/test/gui/references/defaults_panel_other_expanded.png
+++ b/test/gui/references/defaults_panel_other_expanded.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:61d1117d241abdc3e61a0edd875264d16ccbc1e43c6b50cfbbde566ed8a0f7cc
-size 95660
+oid sha256:b347aa2827da0ea78de3d20d6f5d3b9d99e6e12b0f26220712c37f766d0bce06
+size 96522

--- a/test/gui/references/defaults_panel_pending_changes.png
+++ b/test/gui/references/defaults_panel_pending_changes.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5dd12b023f6b49687d75b92df6a89eb85f8ddf80c4e6016d1d5b44e4ca3b9c08
-size 95903
+oid sha256:bf7d27906d1a048ec6a1e69657ce83b8402c323f66835d704d6ab0d63e763fb9
+size 96777

--- a/test/gui/references/defaults_panel_presets_expanded.png
+++ b/test/gui/references/defaults_panel_presets_expanded.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:78e07587f6200724b7f59209e57322dafaf73b95f55439618eded74fb53d7336
-size 87613
+oid sha256:1b7c26c786faef6bae840d2fce7f18fa8af4a42b747dd391fc5985e2142edb9c
+size 96839

--- a/test/gui/references/defaults_panel_presets_warning.png
+++ b/test/gui/references/defaults_panel_presets_warning.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c79d87971791af6425291eb576f9f7126ab9b573e927dee0d03b5b633162bb60
-size 96566
+oid sha256:9e61f69adafd175fd7c85f09f4ab4caa15f6ff70395714ef38f54c33bb65673a
+size 105747

--- a/test/unit-correctness/gui/test_user_defaults.cpp
+++ b/test/unit-correctness/gui/test_user_defaults.cpp
@@ -332,6 +332,10 @@ TEST_F(UserDefaults, ac3_ineligible_keys_cannot_be_smuggled_in) {
   EXPECT_TRUE(gui::WriteUserDefaultsFile(dir, doc));
 
   const gui::GuiState state = gui::MakeNewDocumentState(dir);
+  // The TOP-LEVEL key stays inert. This field does have a legitimate personal-default channel —
+  // the `app` root key, covered by AppPreferencesRoundTripThroughTheAppRootKey below and by the
+  // composition chain — and the two assertions are the two halves of one proposition: exactly one
+  // of the two places this name can appear in the file decides the field.
   EXPECT_EQ(state.use_gpu_backend, gui::GuiState{}.use_gpu_backend);
   // Seeded contents only: exactly one layer with one entry, one crystal, no filters, no colours.
   EXPECT_EQ(state.layers.size(), static_cast<size_t>(1));
@@ -339,6 +343,73 @@ TEST_F(UserDefaults, ac3_ineligible_keys_cannot_be_smuggled_in) {
   EXPECT_EQ(state.crystals.size(), static_cast<size_t>(1));
   EXPECT_EQ(state.filters.size(), static_cast<size_t>(0));
   EXPECT_EQ(state.raypath_color.size(), static_cast<size_t>(0));
+}
+
+// The `app` root key: read / write / erase, and — the part that is easy to get backwards — that it
+// is a DIFFERENT place in the file from the top-level key of the same name. The pair of assertions
+// about those two locations is the point of the case: an implementation that wrote the top-level
+// key would pass a naive round-trip through its own reader and fail here.
+TEST_F(UserDefaults, AppPreferencesRoundTripThroughTheAppRootKey) {
+  json doc = json::object();
+  EXPECT_FALSE(gui::ReadUseGpuBackendFromDoc(doc).has_value()) << "an empty document stores nothing";
+
+  gui::WriteUseGpuBackendToDoc(doc, true);
+  ASSERT_TRUE(gui::ReadUseGpuBackendFromDoc(doc).has_value());
+  EXPECT_TRUE(*gui::ReadUseGpuBackendFromDoc(doc));
+  EXPECT_TRUE(doc.contains("app"));
+  EXPECT_TRUE(doc["app"].contains("use_gpu_backend"));
+  EXPECT_FALSE(doc.contains("use_gpu_backend")) << "the value must NOT land at the document half's top level";
+
+  gui::WriteUseGpuBackendToDoc(doc, false);
+  ASSERT_TRUE(gui::ReadUseGpuBackendFromDoc(doc).has_value());
+  EXPECT_FALSE(*gui::ReadUseGpuBackendFromDoc(doc)) << "false is a stored value, not an absent one";
+
+  // Erase prunes the parent it empties, like the preset library's erase: a file opened by hand
+  // must not accumulate `"app": {}` skeletons.
+  gui::EraseUseGpuBackendFromDoc(doc);
+  EXPECT_FALSE(gui::ReadUseGpuBackendFromDoc(doc).has_value());
+  EXPECT_FALSE(doc.contains("app"));
+
+  // A sibling key under `app` keeps the parent alive — the prune must be conditional, not a
+  // wholesale erase of the section. (Nothing writes such a key today; this pins the shape the
+  // section is meant to grow into.)
+  doc["app"]["something_else"] = 1;
+  gui::WriteUseGpuBackendToDoc(doc, true);
+  gui::EraseUseGpuBackendFromDoc(doc);
+  EXPECT_TRUE(doc.contains("app"));
+  EXPECT_TRUE(doc["app"].contains("something_else"));
+}
+
+// The file is user-editable, so every malformed shape has to read as "nothing stored" rather than
+// throw. Each arm is a different node of the path being the wrong type, because they fail in
+// different places in the reader.
+TEST_F(UserDefaults, AMalformedAppSectionReadsAsNothingStored) {
+  json not_an_object = json::array();
+  EXPECT_FALSE(gui::ReadUseGpuBackendFromDoc(not_an_object).has_value());
+
+  json app_not_an_object = json::object();
+  app_not_an_object["app"] = "yes";
+  EXPECT_FALSE(gui::ReadUseGpuBackendFromDoc(app_not_an_object).has_value());
+
+  json value_not_a_bool = json::object();
+  value_not_a_bool["app"]["use_gpu_backend"] = "true";
+  EXPECT_FALSE(gui::ReadUseGpuBackendFromDoc(value_not_a_bool).has_value());
+
+  json value_is_a_number = json::object();
+  value_is_a_number["app"]["use_gpu_backend"] = 1;
+  EXPECT_FALSE(gui::ReadUseGpuBackendFromDoc(value_is_a_number).has_value())
+      << "JSON 1 is not JSON true; a number here is a hand-edit, not a value";
+
+  // A type error in the app half costs the app half and nothing else — no downgrade is counted
+  // and, unlike the document half, no other section is discarded over it.
+  EXPECT_EQ(gui::TakeUserDefaultsDowngradeCount(), 0);
+
+  // The write path normalizes a malformed root instead of leaving it for the caller to write back.
+  json bad_root = json::array();
+  gui::WriteUseGpuBackendToDoc(bad_root, true);
+  EXPECT_TRUE(bad_root.is_object());
+  ASSERT_TRUE(gui::ReadUseGpuBackendFromDoc(bad_root).has_value());
+  EXPECT_TRUE(*gui::ReadUseGpuBackendFromDoc(bad_root));
 }
 
 // --no-user-config and --user-config <empty dir> must be the same document. Both are "the
@@ -358,6 +429,12 @@ TEST_F(UserDefaults, switch_disabled_equals_empty_explicit_dir) {
     empty_explicit = gui::MakeNewDocumentState();
   }
   EXPECT_TRUE(SerializesIdentically(disabled, empty_explicit));
+  // Asserted separately because SerializesIdentically cannot see this field: use_gpu_backend has no
+  // key in SerializeGuiStateJson's output at all (its channel is the `app` root key), so the
+  // comparison above is blind to it and would stay green if the app-preferences path started
+  // handing out a non-factory value on a route where the user has stored nothing.
+  EXPECT_FALSE(disabled.use_gpu_backend);
+  EXPECT_FALSE(empty_explicit.use_gpu_backend);
   EXPECT_EQ(gui::TakeUserDefaultsDowngradeCount(), 0);
 
   // ...and the comparison above is not vacuous: the SAME directory holding a real override
@@ -383,6 +460,7 @@ TEST_F(UserDefaults, switch_disabled_equals_empty_explicit_dir) {
     disabled_again = gui::MakeNewDocumentState();
   }
   EXPECT_TRUE(SerializesIdentically(disabled, disabled_again));
+  EXPECT_FALSE(disabled_again.use_gpu_backend);
 
   // Last, the harness's own baseline, asserted from inside the harness with NO guard in force.
   // This binary installs kTestHarnessUserConfigDefault before any test runs (gui_unit_test_env.cpp;

--- a/test/unit-correctness/gui/test_user_defaults_eligibility.cpp
+++ b/test/unit-correctness/gui/test_user_defaults_eligibility.cpp
@@ -145,8 +145,9 @@ TEST(UserDefaultsEligibility, RepresentativeFieldsMapToTheDesignedVerdicts) {
     { "layers", DefaultEligibility::kIneligible, IneligibleReason::kCollection },
     { "filters", DefaultEligibility::kIneligible, IneligibleReason::kCollection },
     { "raypath_color", DefaultEligibility::kIneligible, IneligibleReason::kCollection },
-    // namespace 3 — app preference, out of scope for phase one.
-    { "use_gpu_backend", DefaultEligibility::kIneligible, IneligibleReason::kAppPreference },
+    // namespace 3 — app preferences. use_gpu_backend is the one member with a storage channel of
+    // its own (the `app` root key), so it is eligible; the rest still have nowhere to be stored.
+    { "use_gpu_backend", DefaultEligibility::kEligible, IneligibleReason::kNone },
     { "gui_log_level", DefaultEligibility::kIneligible, IneligibleReason::kAppPreference },
     { "core_log_level", DefaultEligibility::kIneligible, IneligibleReason::kAppPreference },
     { "log_to_file", DefaultEligibility::kIneligible, IneligibleReason::kAppPreference },
@@ -168,27 +169,34 @@ TEST(UserDefaultsEligibility, RepresentativeFieldsMapToTheDesignedVerdicts) {
   }
 }
 
-TEST(UserDefaultsEligibility, IneligibleScalarResetCoversEverySmugglableField) {
-  // Coverage gate for ResetIneligibleScalarFields (user_defaults.cpp). Most ineligible fields
-  // are structurally unreachable from the override file — no JSON key at all, or a collection
-  // the read path clears wholesale. The exception is a field registered kStructSoft with
-  // auto_diff_excluded: an ordinary serializable scalar the deserializer will happily read,
-  // which therefore needs an explicit reset. If someone adds another such field without
-  // extending that reset, this assertion fails instead of leaving a silent hole.
+TEST(UserDefaultsEligibility, IneligibleScalarResetCoversEveryAppPreferenceField) {
+  // Coverage gate for ResetIneligibleScalarFields (user_defaults.cpp). It restores the fields the
+  // DOCUMENT half of an override file must never decide but could structurally reach — an ordinary
+  // serializable scalar has a well-formed place at the file's top level. Those are exactly the
+  // fields registered app_preference_eligible: their one legitimate channel is the `app` root key,
+  // so anything the document half applied to them has to be undone before that channel is read. If
+  // someone registers another such field without extending the reset, this fails instead of
+  // leaving a silent hole.
   //
-  // Scope note (deliberate narrowing): the predicate below is exactly the shape of the current
-  // exception. A structurally DIFFERENT future category of "serializable but ineligible" would
-  // not be caught here — extending the predicate is part of introducing such a category.
-  std::size_t smugglable = 0;
+  // The predicate used to be `tier == kStructSoft && auto_diff_excluded`. It named the same single
+  // field, but for a reason that has nothing to do with where a default is stored — an app
+  // preference registered under any other tier would have walked straight past it.
+  //
+  // Scope note (deliberate narrowing): a structurally DIFFERENT future category of "reachable from
+  // the document half but not decidable by it" would not be caught here — extending the predicate
+  // is part of introducing such a category.
+  std::size_t app_preference_fields = 0;
   for (const auto& entry : kFieldTierTable) {
-    if (entry.tier == FieldTier::kStructSoft && entry.auto_diff_excluded) {
-      ++smugglable;
-      EXPECT_EQ(ResolveDefaultEligibility(entry.name).eligibility, DefaultEligibility::kIneligible) << entry.name;
+    if (entry.app_preference_eligible) {
+      ++app_preference_fields;
+      // Eligible — through the `app` root key, which is what having this bit set MEANS. The
+      // reset exists to keep the OTHER channel shut, not to make the field undefaultable.
+      EXPECT_EQ(ResolveDefaultEligibility(entry.name).eligibility, DefaultEligibility::kEligible) << entry.name;
     }
   }
-  EXPECT_EQ(smugglable, kIneligibleScalarResetFieldCount)
-      << "A new kStructSoft/auto_diff_excluded field appeared. Add it to "
-         "ResetIneligibleScalarFields() in src/gui/user_defaults.cpp and bump "
+  EXPECT_EQ(app_preference_fields, kIneligibleScalarResetFieldCount)
+      << "A new app_preference_eligible field appeared. Add it to ResetIneligibleScalarFields() "
+         "and to ApplyAppPreferencesOverride() in src/gui/user_defaults.cpp, and bump "
          "kIneligibleScalarResetFieldCount.";
 }
 


### PR DESCRIPTION
> ⚠️ **本 PR 叠在 #307 之上**（base = `fix/gui-test-harness-gates`，不是 main）。
> 请在 #307 合入之后再合；#307 合入时 GitHub 会自动把 base 改回 main。

## 问题

用户每次启动都要重勾一次 "Use GPU"，**且有一段代码专门负责擦掉他想记住这个选择的尝试**
（`ResetIneligibleScalarFields`）。本 PR 部分解禁 `doc/gui-state-governance.md` §8.1 的命名空间③。

⛔ **工厂默认保持 legacy CPU，本 PR 不改变任何默认行为。**

## 实现

- **覆盖文件新增第三个根键 `app`**，自带读写器，**不进文档 schema** ⇒ `.lmc` 永远不会带上这个值。
  这是机制上的必然而非约定：`.lmc` 的内容**就是** `SerializeGuiStateJson` 的输出，字段不进那个
  函数就没有任何路径进文档。形态与既有的 `presets` 根键同构。
- **语义是「个人默认」而非「记住上次选择」**：只由显式 Save 写入，不在勾选时自动落盘。
  本仓库没有任何粘滞先例且是刻意的（`imgui.ini` 持久化被主动关闭），选粘滞等于引入本 app
  的第一条隐式写入路径。
- **资格判定不再借道 `auto_diff_excluded`**：那个 bit 回答的是「通用 diff reconciler 是否自动
  派生效果」，与「能否作为个人默认」毫无关系；两个语义骑在同一个 bit 上正是本任务要消除的形态。
  改用 `FieldTierEntry` 新增的独立位 `app_preference_eligible`（资格仍从档位表推导，不手写第二份清单）。

## 验证（编排者独立复核，非仅采信实施记录）

在分支尖端重新构建后自行跑出：`./scripts/test.sh pr` → **RESULT: PASS**（rc=0，六层全 PASS）。
重拍的 `defaults_panel_layout` 六张参考图比对 **PSNR=inf**（逐像素相同）。
五道工程门禁 rc=0。LFS 对象已确认上传（6/6，599 KB）。

**AC2（不可协商的那条）的覆盖**：顶层手工走私的 `use_gpu_backend` 被重置回工厂值；
值**不得**落到文档半区顶层（这条是 `.lmc` 永不携带它的机械保证）；`--no-user-config` 与
空的显式 `--user-config` 目录下均为 `false`（CPU）。

## 📌 三处请 owner 过目

1. **一条我替你做的形态决定，可直接推翻**：默认值面板的这一行**不跟随 GPU 探测结果**、始终可见。
   运行时勾选框（`src/gui/panels.cpp:1918`）门控在
   `LUMICE_IsBackendAvailable(METAL) || LUMICE_IsBackendAvailable(CUDA)` 上，理由是 CPU-only 主机
   上选它会在 `EnsureDevice` 失败。默认值面板**不复用**这个条件，因为两者回答的是不同问题：
   运行时问「这台机器现在能不能用 GPU」，默认值面板问「你存了什么」。若也跟随探测，一个在有 GPU
   的机器上存了 `true` 的用户换到 CPU-only 机器将**既看不到也清不掉**这条已存偏好——正是
   `doc/env-var-policy.md` 点名的「静默的逐机器漂移」。存着 `true` 本身无害：运行路径本就静默回退 CPU。

2. **一条 code-review Minor 我没有代做，留给你裁决**：progress.md 记录了「Reset all 不清这一行」
   这条**本任务新引入的行为断言**，但树内没有任何测试守它 ⇒ 后续有人改 Reset all 逻辑时没有红态防护。
   补它需要写一条真正的 GUI functional 用例（不是注释补丁），已超出我做收尾修补的范围，故不静默吞掉。

3. **落盘了一条此前只活在对话里的裁定**：`gui_state.hpp` 的字段声明处补了「为什么默认是 CPU」
   的理由。其中「早期只有 CPU 路线」这句是历史陈述，已用 `git log` 核实并给出永久锚点——
   仓库首次提交 `473ef759`（2018-02-23），最早引入 GPU 后端的是 `6b10ba43` / `6cb5857e`
   （2026-06-04），相隔八年余。

## 评审

两位独立评审 APPROVE（0 Critical / 0 Major）。plan-review 走了 5 轮（前 4 轮 REQUEST_CHANGES，
每轮的 Major 都能用一条 grep / 一次 `git log` 判定，架构师角色 5/5 APPROVE，方向从未被质疑）。
Minor 2 与两条 Suggestion 已由最后一个 commit 采纳，均为注释层——把三处隐含前提写成显式提示，
其中最值得看的一条是：`app_preference_eligible` **置 true 只完成登记、不完成接线**，
本命名空间加第二个成员需要三处改动而非一处，而覆盖率测试是让「忘掉另外两处」变红而不是变静默的东西。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYUQjkoHUfvHDF1xzk829e