### PR TITLE
fix(bench): active_short 不得拿 IDLE 检测延迟当分母（14-29x 野值的根因）

### DIFF
--- a/doc/geometry-randomization-perf.md
+++ b/doc/geometry-randomization-perf.md
@@ -198,7 +198,12 @@ C should not be re-attempted on the current representation.
 - **Warm the CUDA context** before timing (a throwaway iteration), or the first-call init pollutes the number.
 - **Interleave** the two arms; never compare back-to-back grouped runs on a shared machine.
 - **Use a large enough `ray_num`** that trace dominates fixed overhead.
-- **Trust only `rate_basis` = `steady`/`active`; treat `wall_fallback` as setup-polluted and discard it.**
+- **Trust only `rate_basis` = `steady`.** `active_short` and `wall_fallback` are both a
+  conservative wall-clock lower bound (`rays / wall_sec`), not a steady-state rate — see
+  `performance-testing.md` §C rule 4/5 for the mechanism (a too-short `ray_num` degrades
+  `active_short` to dividing by IDLE-detection latency instead of trace duration, which used
+  to produce 14–29x phantom rates before that branch was fixed to use `wall_sec`). Discard
+  both when comparing throughput; only `steady` measures what this section's numbers need.
 - Perf baseline is legacy CPU (state the denominator); the GPU throughput bar is hardware/competitor class, not merely "beats legacy".
 
 See also: `seam-design.md` (§3.2 per-ray shape pool, §5 single-engine three-clock target),

--- a/doc/performance-testing.md
+++ b/doc/performance-testing.md
@@ -143,7 +143,7 @@ a "warm" run (init already paid by an earlier process) can measure a many-x cold
 is a **process-order artifact, not a property of the trace**. This mechanism was the source of
 the "stoch vs det 15.7×" cold/warm measurement artifact.
 
-Four defensive rules — the first is now enforced by the tool, the other three remain usage
+Five defensive rules — the first is now enforced by the tool, the rest remain usage
 discipline:
 
 1. **`--benchmark` runs one silent warm-up pass on the GPU route before the timed steady pass**
@@ -164,13 +164,33 @@ discipline:
    the reported pass falls through to `wall_fallback` or `active_short` (`src/main.cpp`
    `RunBenchmarkPass`, next to the `[BENCHMARK]` JSON emit) so neither can be missed silently.
    `active_short` fires when the whole run's rays land inside the single poll that first
-   observes `sim_ray_num > 0` — at that point `active_sec` is measuring IDLE-detection
-   latency after that poll, not real trace duration, and the resulting rate can be off by
-   orders of magnitude in either direction (measured on CUDA/RTX4060Ti: a 10M-ray config
-   reported `active_short` at 1.97 billion rays/s, ~30x the same hardware's real `steady`
-   rate). There is no cheap way to recover a trustworthy number from an `active_short` sample
-   after the fact — the fix is rule 3's `ray_num` floor, large enough that the run reliably
-   spans multiple poll intervals and lands on `steady` instead.
+   observes `sim_ray_num > 0`, so `active_sec` is measuring IDLE-detection latency after
+   that poll, not real trace duration. Its `rays_per_sec` therefore falls back to the
+   wall-clock denominator, the same one `wall_fallback` uses: setup-polluted and hence a
+   conservative **lower** bound, but bounded. It did not always: the branch used to divide
+   by `active_sec` itself, which made the published rate `ray_num / (k · poll_interval)` —
+   unbounded above as k → 1, and *only* ever biased upward, the direction a floor-style
+   gate cannot catch. Two measured instances: CUDA/RTX4060Ti reported 1.97 billion rays/s
+   on a 10M-ray config (~30× the same hardware's real `steady` rate), and mac/Metal
+   reported 266–390 M rays/s against a true 13.9 M rays/s on 4% of runs of the same
+   config (below). Rule 3's `ray_num` floor is still the remedy that gets you a *usable*
+   number; the change only stops the estimator from inventing one.
+
+5. **On a GPU backend, `ray_num` must exceed one drain quantum or the window has zero
+   interior samples.** `sim_ray_num` is published in whole drains of
+   `kDefaultXyzDrainBatches * dispatch_size` rays — **2,097,152** with the Metal default
+   dispatch of 32768 (`simulator.hpp` `kDefaultXyzDrainBatches` = 64). A config whose entire
+   `ray_num` is below that reads 0 at every poll and then publishes once, at the end: there
+   is no window to measure, and which basis you get is decided by a race between that publish
+   and the IDLE transition — same poll → `wall_fallback`, one poll apart → `active_short`.
+   Measured on mac/Metal with `ms_multi_crystal_complex_filter` at `ray_num=2,000,000`
+   (below the quantum): 240 black-box runs produced `steady` **zero** times. Raising
+   `ray_num` past the quantum restores interior samples and `steady` becomes reachable, but
+   is not yet trustworthy — at 2.5M/3M/4.5M rays (2–3 samples in the window) the same scene
+   measured up to +40%/+33%/+18% above its own median, decaying to the flat 13.9–14.0 M
+   rays/s that 20M and 200M report. This is rule 3's floor seen from the sampling side.
+   ⚠️ Measured on mac + Metal only; CUDA's default dispatch differs, so the quantum there is
+   a different number, not this one.
 
 ## ⚠️ A local build is not the shipped binary: `-march=native` is on by default here and off everywhere else
 
@@ -236,8 +256,12 @@ output:
 ```
 
 `rays_per_sec` is the **steady trace rate** over `active_sec` (the window from
-first traced ray to IDLE), NOT `rays / wall_sec`. `setup_sec` (server alloc +
-scene gen + first-dispatch latency) is excluded from the denominator;
+first traced ray to IDLE), NOT `rays / wall_sec` — but only on `rate_basis`
+`steady`, which is exactly what `rate_basis` is there to tell you. The
+degenerate bases (`wall_fallback`, `active_short`) both fall back to
+`rays / wall_sec`, so on those the field is a setup-polluted lower bound and
+`active_sec` is not its denominator. `setup_sec` (server alloc + scene gen +
+first-dispatch latency) is excluded from the denominator on `steady`;
 `rate_basis` records which path produced the rate. This setup-exclusion fix
 (task-fix-throughput-bench-honesty) matters for fast backends whose whole run is
 ~0.2s — folding setup in deflated their rays_per_sec by >30%.

--- a/doc/performance-testing_zh.md
+++ b/doc/performance-testing_zh.md
@@ -67,6 +67,13 @@ CLI 基准测试和 GUI 性能测试均支持日志级别选项。
 | `texture FPS` | GUI 性能测试 steady_state | 稳态纹理刷新率 |
 | `Consume profile` | CLI -v / GUI --log-level debug | 每批次 filter/proj/accum 分解 |
 
+> ⚠️ 英文版这里还有一整节**尚未翻译**的内容（`## ⚠️ Two ways \`--benchmark\` silently reports
+> a number that answers a different question`，含 §A 单线程/多线程口径混淆、§B GPU 短窗测的是
+> 时钟升频瞬态、§C GPU 冷启动初始化被折进分母，以及五条防御性规则——含本任务新测得的
+> "GPU 上 `ray_num` 必须超过 drain 量子" 这条机制）。这不是本次改动引入的缺口——该节在中文版
+> 里从一开始就不存在（不是"被删掉的规则 4/5"，是整节从未译过）；需要时请直接读英文版
+> `performance-testing.md` 对应小节。补齐翻译不在本任务范围内。
+
 ## ⚠️ 本地构建不是出货的那个二进制：`-march=native` 在这里默认开、在别处一律关
 
 这一条讲的不是 `--benchmark` 报的是*哪个*数字，而是这个数字出自*哪个二进制*。它已经害过一次

--- a/doc/performance-testing_zh.md
+++ b/doc/performance-testing_zh.md
@@ -123,8 +123,11 @@ A/B，比的是 native-ISA 二进制对基线-ISA 二进制，而**任何地方�
 ```
 
 `rays_per_sec` 是 `active_sec`（从首条光线追踪到 IDLE 的窗口）上的**稳态追踪率**，
-**不是** `rays / wall_sec`。`setup_sec`（server alloc + 场景生成 + 首 dispatch 延迟）从分母
-剔除；`rate_basis` 记录产出该率的路径。这个 setup-剔除修复（task-fix-throughput-bench-honesty）
+**不是** `rays / wall_sec`——但这只在 `rate_basis` 为 `steady` 时成立，而这正是
+`rate_basis` 这个字段存在的意义。两个退化档（`wall_fallback` / `active_short`）都退回
+`rays / wall_sec`，此时该字段是含 setup 的**下界**，分母也不是 `active_sec`。
+`setup_sec`（server alloc + 场景生成 + 首 dispatch 延迟）只在 `steady` 档从分母剔除；
+`rate_basis` 记录产出该率的路径。这条 setup-剔除规则
 对整个 run 只 ~0.2s 的快后端很重要——折进 setup 会把它们的 rays_per_sec 压低 >30%。
 
 **两套独立的 `rate_basis` 阶梯**（消费者/gate 按走的哪条路径判定，不按全集字符串相等判）：

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -518,17 +518,24 @@ void RunBenchmarkPass(const std::string& config_str, int num_workers, const char
         rays_per_sec = static_cast<double>(r_end - rays_at_active_start) / active_sec;
         rate_basis = "steady";
       } else if (active_started && active_sec > 1e-4) {
-        // Degenerate window: sim_ray_num was observed exactly ONCE, so there is no
-        // interior sample and `active_sec` measures IDLE-detection latency, not trace
-        // duration. Dividing by it is what produced the 14-29x phantom rates this branch
-        // used to report (see the warning below for the measured mechanism). Use the
-        // wall-clock denominator instead — it is a real duration that provably contains
+        // Degenerate window: sim_ray_num was observed exactly ONCE (r_end ==
+        // rays_at_active_start), so there is no interior sample and `active_sec` measures
+        // IDLE-detection latency, not trace duration. On a GPU backend this is not
+        // hypothetical: sim_ray_num advances in whole drain quanta
+        // (kDefaultXyzDrainBatches * dispatch_size = 64 * 32768 = 2,097,152 rays with the
+        // Metal default), so a config whose entire ray_num is below one quantum publishes
+        // its counter exactly once, at the end — whether that publish shares a poll with
+        // the IDLE transition or precedes it by one is a race, which is why the same
+        // binary/config/machine alternated between `wall_fallback` and a measured 14-29x
+        // phantom rate at ~4% of runs when this branch divided by `active_sec` itself. Use
+        // the wall-clock denominator instead — it is a real duration that provably contains
         // the whole trace, so the number is a conservative LOWER bound on the true rate
         // rather than an unbounded upward fantasy. Same formula as `wall_fallback`, but
         // the basis label is deliberately kept distinct: the two say different things
         // (`active_short` = exactly one counter publish observed; `wall_fallback` = no
         // usable active window at all), and merging them would change the rate_basis
-        // value set for no gain.
+        // value set for no gain. See doc/performance-testing.md §C rule 5 for the full
+        // derivation (quantum value, 240-run measurement, short-window bias decay curve).
         rays_per_sec = wall_bounded_rate;
         rate_basis = "active_short";
       } else {
@@ -579,19 +586,9 @@ void RunBenchmarkPass(const std::string& config_str, int num_workers, const char
                     << " rate_basis=wall_fallback — rays_per_sec includes one-time setup/context-init "
                     << "and is not a steady trace rate; do not use for perf comparison.\n";
         } else if (std::string_view(rate_basis) == "active_short") {
-          // active_short means the run's rays all landed in the single poll that first
-          // observed cur_rays > 0 (r_end == rays_at_active_start): active_sec is measuring
-          // IDLE-detection latency after that poll, not trace duration. The dominant cause
-          // on a GPU backend is measured, not hypothetical: sim_ray_num advances in drain
-          // quanta (kDefaultXyzDrainBatches * dispatch_size = 64 * 32768 = 2,097,152 rays
-          // with the Metal default), so a config whose whole ray_num is smaller than one
-          // quantum publishes its counter exactly once, at the end. Whether that publish
-          // shares a poll with the IDLE transition or precedes it by one is a race, which
-          // is why the same binary/config/machine alternated between `wall_fallback` and a
-          // 14-29x phantom rate at ~4% of runs. rays_per_sec now uses the wall denominator
-          // (a real duration containing the trace), so it is a conservative LOWER bound —
-          // but it still includes setup, so it is not a steady trace rate. Same remedy as
-          // wall_fallback: a ray_num spanning several drain quanta / poll intervals.
+          // Mechanism: see the `active_short` branch comment above (where rate_basis is
+          // assigned) and doc/performance-testing.md §C rule 5. Not re-derived here so the
+          // two sites can't drift apart.
           std::cerr << "Warning: [BENCHMARK] mode=" << mode
                     << " rate_basis=active_short — the run produced only a single "
                     << "sim_ray_num observation (ray_num below one drain quantum), so no "

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -500,6 +500,10 @@ void RunBenchmarkPass(const std::string& config_str, int num_workers, const char
       const char* rate_basis = "wall_fallback";
       double window_sec = 0.0;
       LUMICE_RayCount window_rays = 0;
+      // Shared by `active_short` and `wall_fallback`: both degrade to a wall-clock
+      // lower bound (see the `active_short` branch comment below for why). Computed
+      // once so the two branches cannot silently diverge if only one is edited later.
+      const double wall_bounded_rate = wall_sec > 0 ? static_cast<double>(r_end) / wall_sec : 0.0;
       if (drain_count_mode) {
         if (window_closed && t_final_drain > t_first_drain && rays_at_final_drain > rays_at_first_drain) {
           window_sec = std::chrono::duration<double>(t_final_drain - t_first_drain).count();
@@ -525,10 +529,10 @@ void RunBenchmarkPass(const std::string& config_str, int num_workers, const char
         // (`active_short` = exactly one counter publish observed; `wall_fallback` = no
         // usable active window at all), and merging them would change the rate_basis
         // value set for no gain.
-        rays_per_sec = wall_sec > 0 ? static_cast<double>(r_end) / wall_sec : 0.0;
+        rays_per_sec = wall_bounded_rate;
         rate_basis = "active_short";
       } else {
-        rays_per_sec = wall_sec > 0 ? static_cast<double>(r_end) / wall_sec : 0.0;
+        rays_per_sec = wall_bounded_rate;
         rate_basis = "wall_fallback";
       }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -514,7 +514,18 @@ void RunBenchmarkPass(const std::string& config_str, int num_workers, const char
         rays_per_sec = static_cast<double>(r_end - rays_at_active_start) / active_sec;
         rate_basis = "steady";
       } else if (active_started && active_sec > 1e-4) {
-        rays_per_sec = static_cast<double>(r_end) / active_sec;
+        // Degenerate window: sim_ray_num was observed exactly ONCE, so there is no
+        // interior sample and `active_sec` measures IDLE-detection latency, not trace
+        // duration. Dividing by it is what produced the 14-29x phantom rates this branch
+        // used to report (see the warning below for the measured mechanism). Use the
+        // wall-clock denominator instead — it is a real duration that provably contains
+        // the whole trace, so the number is a conservative LOWER bound on the true rate
+        // rather than an unbounded upward fantasy. Same formula as `wall_fallback`, but
+        // the basis label is deliberately kept distinct: the two say different things
+        // (`active_short` = exactly one counter publish observed; `wall_fallback` = no
+        // usable active window at all), and merging them would change the rate_basis
+        // value set for no gain.
+        rays_per_sec = wall_sec > 0 ? static_cast<double>(r_end) / wall_sec : 0.0;
         rate_basis = "active_short";
       } else {
         rays_per_sec = wall_sec > 0 ? static_cast<double>(r_end) / wall_sec : 0.0;
@@ -566,14 +577,23 @@ void RunBenchmarkPass(const std::string& config_str, int num_workers, const char
         } else if (std::string_view(rate_basis) == "active_short") {
           // active_short means the run's rays all landed in the single poll that first
           // observed cur_rays > 0 (r_end == rays_at_active_start): active_sec is measuring
-          // IDLE-detection latency after that poll, not trace duration, so rays_per_sec can
-          // be off by orders of magnitude in either direction (measured on CUDA: a 10M-ray
-          // config reported 1.97 billion rays/s this way). Symmetric to the wall_fallback
-          // warning above — same remedy (a larger ray_num spanning multiple poll intervals).
+          // IDLE-detection latency after that poll, not trace duration. The dominant cause
+          // on a GPU backend is measured, not hypothetical: sim_ray_num advances in drain
+          // quanta (kDefaultXyzDrainBatches * dispatch_size = 64 * 32768 = 2,097,152 rays
+          // with the Metal default), so a config whose whole ray_num is smaller than one
+          // quantum publishes its counter exactly once, at the end. Whether that publish
+          // shares a poll with the IDLE transition or precedes it by one is a race, which
+          // is why the same binary/config/machine alternated between `wall_fallback` and a
+          // 14-29x phantom rate at ~4% of runs. rays_per_sec now uses the wall denominator
+          // (a real duration containing the trace), so it is a conservative LOWER bound —
+          // but it still includes setup, so it is not a steady trace rate. Same remedy as
+          // wall_fallback: a ray_num spanning several drain quanta / poll intervals.
           std::cerr << "Warning: [BENCHMARK] mode=" << mode
-                    << " rate_basis=active_short — the run completed within a single poll "
-                    << "interval; active_sec is not a real trace duration and rays_per_sec "
-                    << "can be wildly wrong; do not use for perf comparison.\n";
+                    << " rate_basis=active_short — the run produced only a single "
+                    << "sim_ray_num observation (ray_num below one drain quantum), so no "
+                    << "steady window exists; rays_per_sec falls back to the wall-clock "
+                    << "denominator and includes setup — a lower bound, not a steady trace "
+                    << "rate; do not use for perf comparison.\n";
         }
         std::cout << "[BENCHMARK] " << result.dump() << "\n";
       }

--- a/test/performance/test_metal_throughput.py
+++ b/test/performance/test_metal_throughput.py
@@ -137,6 +137,10 @@ def _run_benchmark(config_name: str, metal: bool) -> dict:
                 multi_basis = str(data.get("rate_basis", "?"))
             elif data.get("mode") == "single":
                 single_rps = float(data["rays_per_sec"])
+                # No `single_basis` counterpart: nothing here consumes it (the C2
+                # sentinel below only ratios `multi_rps`), so it is omitted rather
+                # than added speculatively. Add it the same way if a future gate
+                # needs the single-pass basis too.
     return {
         "multi_rps": multi_rps,
         "single_rps": single_rps,

--- a/test/performance/test_metal_throughput.py
+++ b/test/performance/test_metal_throughput.py
@@ -54,10 +54,22 @@ _HEAVY_CONFIGS = [
 ]
 
 # C2 sentinel floor: ratio below this = catastrophic regression / near-hang.
-# `rays_per_sec` is a SINGLE sample per run (no warm-up/median). Since
-# task-fix-throughput-bench-honesty the [BENCHMARK] rate is the steady trace
-# rate (setup excluded, 5ms poll), so it no longer deflates the fast Metal
-# backend.
+# `rays_per_sec` is a SINGLE sample per run (no warm-up/median).
+#
+# WHICH `rate_basis` THIS GATE ACTUALLY CONSUMES, measured rather than assumed:
+# the legacy arm reports `steady` on both configs, but the **Metal arm never
+# does**. `_HEAVY_CONFIGS` carry ray_num=2,000,000, which is below the Metal
+# drain quantum (2,097,152 = 64 batches * 32768 dispatch), so sim_ray_num is
+# published exactly once and no steady window exists — 240 runs gave
+# `wall_fallback` 96% / `active_short` 4%, `steady` zero times. The numerator is
+# therefore a wall-clock rate that still contains whatever setup the warm-up pass
+# did not absorb; measured ~13.0-13.5M vs the same scene's true steady rate of
+# ~13.9M at ray_num=20M, i.e. ~5% conservative. That is a ratio DEflation, so it
+# cannot manufacture a false green here — but the earlier `active_short` defect
+# could and did: that basis used to divide by IDLE-detection latency and reported
+# 266-390M rays/s on 4% of Metal runs, multiplying this ratio by ~20x with nothing
+# wrong. Fixed in `RunBenchmarkPass` (main.cpp), guarded by
+# test/regression-sentinel/test_benchmark_rate_not_impossible.py.
 #
 # THIS RATIO HAS A MOVING DENOMINATOR, and that has now bitten once. The floor
 # was 3.0, derived from a measured nominal of ~8-10x (bench_throughput.py
@@ -111,14 +123,26 @@ def _run_benchmark(config_name: str, metal: bool) -> dict:
     )
     fell_back = bool(_RE_FALLBACK.search(proc.stderr) or _RE_FALLBACK.search(proc.stdout))
     multi_rps = single_rps = 0.0
+    multi_basis = "?"
     for line in proc.stdout.splitlines():
         if "[BENCHMARK]" in line:
             data = json.loads(line.split("[BENCHMARK]", 1)[1].strip())
             if data.get("mode") == "multi":
                 multi_rps = float(data["rays_per_sec"])
+                # Reported, not asserted on: which basis each arm lands on is a
+                # property of the config's ray_num vs the backend's drain quantum
+                # (see the _SANITY_FLOOR comment), so pinning it would be pinning
+                # the gate's inputs. Printing it makes a future drift visible in
+                # the CI log instead of silent.
+                multi_basis = str(data.get("rate_basis", "?"))
             elif data.get("mode") == "single":
                 single_rps = float(data["rays_per_sec"])
-    return {"multi_rps": multi_rps, "single_rps": single_rps, "fell_back": fell_back}
+    return {
+        "multi_rps": multi_rps,
+        "single_rps": single_rps,
+        "fell_back": fell_back,
+        "multi_basis": multi_basis,
+    }
 
 
 @pytest.mark.slow
@@ -138,7 +162,8 @@ def test_metal_throughput_gate(config_name):
     print(
         f"[throughput] {config_name}: legacy_multi={legacy['multi_rps']:.0f} "
         f"metal_multi={metal['multi_rps']:.0f} ratio={ratio:.3f} "
-        f"(sanity>={_SANITY_FLOOR}, gate>={_GATE})"
+        f"(legacy_basis={legacy['multi_basis']}, metal_basis={metal['multi_basis']}; "
+        f"sanity>={_SANITY_FLOOR}, gate>={_GATE})"
     )
 
     # --- C2 sentinel: active gate, must pass on the landed engine today --------

--- a/test/regression-sentinel/test_benchmark_rate_not_impossible.py
+++ b/test/regression-sentinel/test_benchmark_rate_not_impossible.py
@@ -1,0 +1,139 @@
+"""Regression guard: `--benchmark` must never report a rate the run had no time for.
+
+Fix: `RunBenchmarkPass` (`src/main.cpp`) — the `rate_basis=active_short` branch
+used to compute `rays_per_sec = r_end / active_sec`.
+
+Root cause (diagnosed white-box by tracing `(t, sim_ray_num, server_state)` at
+every poll): on a GPU backend `sim_ray_num` advances in whole drain quanta
+(`kDefaultXyzDrainBatches` * dispatch_size = 64 * 32768 = 2,097,152 rays with the
+Metal default). A config whose entire `ray_num` is below one quantum reads 0 at
+every poll and then publishes once, at the very end, so the run yields exactly ONE
+observation and there is no window to measure. `active_short` is precisely the
+branch that detects this (`r_end == rays_at_active_start`), yet it divided by
+`active_sec` — which in that state is the gap between the poll that saw the
+publish and the poll that saw IDLE, i.e. IDLE-detection latency. The published
+rate was therefore `ray_num / (k * poll_interval)`, unbounded above as k -> 1:
+measured 266-390 M rays/s against the same scene's true 13.9 M rays/s.
+
+Why it needed a guard rather than just a fix: the error is one-directional
+(always upward) and the only single-sample consumer, `test_metal_throughput.py`,
+compares the Metal rate against a FLOOR. A noise source that can only turn a red
+green produces no complaints, so nothing else in the tree would report it.
+
+The invariant asserted here is deliberately basis-agnostic and physical rather
+than a re-statement of the formula: **the rays the estimator claims per second,
+multiplied by the whole run's wall clock, cannot exceed the rays the run actually
+traced by more than a small factor.** Every honest basis lands near 1.0 (measured:
+`steady` 0.99-1.0 on legacy CPU and on Metal at 20M/200M rays; `wall_fallback`
+and `active_short` are exactly 1.0 by construction), while the defect scored ~20.
+`_MAX_WORK_RATIO` sits between them with room on both sides.
+
+Scope, stated rather than implied: this is macOS + Metal only, because the defect
+needs a drain quantum coarse enough to swallow a whole run — legacy CPU publishes
+per batch, and at ray_num=200,000 it still reports `steady`, so it cannot reach
+the branch. CUDA is untested here (no local device); its quantum differs.
+
+Detection is probabilistic in REACHING the branch, not in judging it: which basis
+a run lands on is a race, measured at 4-8% `active_short` over 220 runs, so
+`_RUNS` is sized to make a miss unlikely rather than impossible. The assertion
+itself is evaluated on every sample and cannot false-red — the test prints how
+many `active_short` samples it actually saw so a vacuous pass is visible.
+
+@pytest.mark.slow — needs the release binary and ~25 repeated benchmark runs;
+sits beside the other perf-measurement gate (test/performance/) rather than in
+the fast leg.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import subprocess
+
+import pytest
+
+from test.e2e.runner import find_lumice_binary, get_project_root
+
+pytestmark = pytest.mark.skipif(
+    platform.system() != "Darwin", reason="the coarse-drain-quantum path needs Metal (macOS)"
+)
+
+_CONFIGS_DIR = get_project_root() / "test" / "e2e" / "configs"
+
+# Below the 2,097,152-ray Metal drain quantum, which is what makes the window
+# degenerate. Same two scenes the throughput gate uses, so the two agree on what
+# they are measuring.
+_CONFIGS = ["ms_multi_crystal_complex_filter", "ms_multi_crystal_filtered_bd"]
+
+# P(no active_short sample in _RUNS) = 0.96**25 ~ 36% at the low end of the
+# measured 4-8% rate, per config; with two configs a total miss is ~13%. Each run
+# is ~0.25s, so the whole test is ~13s.
+_RUNS = 25
+
+# Honest bases score ~1.0; the defect scored ~20. See the module docstring.
+_MAX_WORK_RATIO = 3.0
+
+_TIMEOUT = 120
+
+
+def _benchmark_rows(config_name: str) -> list[dict]:
+    """One `--benchmark` invocation on Metal; return its parsed [BENCHMARK] rows."""
+    env = dict(os.environ)
+    env["LUMICE_TRACE_BACKEND"] = "metal"
+    proc = subprocess.run(
+        [
+            str(find_lumice_binary()),
+            "--benchmark",
+            "-f",
+            str(_CONFIGS_DIR / f"{config_name}.json"),
+            "-o",
+            "/tmp",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT,
+        env=env,
+    )
+    assert proc.returncode == 0, f"{config_name}: benchmark exited {proc.returncode}\n{proc.stderr}"
+    return [
+        json.loads(line.split("[BENCHMARK]", 1)[1].strip())
+        for line in proc.stdout.splitlines()
+        if "[BENCHMARK]" in line
+    ]
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("config_name", _CONFIGS)
+def test_reported_rate_is_physically_possible(config_name: str) -> None:
+    seen_basis: dict[str, int] = {}
+    worst = None  # (work_ratio, row) over every sample, reported either way.
+
+    for _ in range(_RUNS):
+        for row in _benchmark_rows(config_name):
+            basis = str(row.get("rate_basis", "?"))
+            seen_basis[basis] = seen_basis.get(basis, 0) + 1
+            wall_sec = float(row["wall_sec"])
+            if wall_sec <= 0.0:
+                continue  # rounded-away wall clock carries no bound; not a failure
+            work_ratio = float(row["rays_per_sec"]) * wall_sec / float(row["rays"])
+            if worst is None or work_ratio > worst[0]:
+                worst = (work_ratio, row)
+            # Reported inside the loop so the failing SAMPLE is in the message,
+            # and so a red stops here instead of driving 24 more runs against an
+            # already-established failure.
+            assert work_ratio <= _MAX_WORK_RATIO, (
+                f"{config_name}: [BENCHMARK] claims {row['rays_per_sec']:,.0f} rays/s over a "
+                f"{wall_sec}s run that traced only {row['rays']:,} rays — that is "
+                f"{work_ratio:.1f}x more work than the run had time for "
+                f"(limit {_MAX_WORK_RATIO}). rate_basis={basis}, active_sec={row.get('active_sec')}. "
+                f"The estimator is dividing by something that is not a trace duration."
+            )
+
+    assert worst is not None, f"{config_name}: no usable [BENCHMARK] sample in {_RUNS} runs"
+    # Vacuity is visible rather than silent: if `active_short` never came up, the
+    # branch the guard exists for was not exercised this time.
+    print(
+        f"[rate-sanity] {config_name}: {_RUNS} runs, bases={seen_basis}, "
+        f"worst work_ratio={worst[0]:.2f} (limit {_MAX_WORK_RATIO})"
+    )

--- a/test/regression-sentinel/test_benchmark_rate_not_impossible.py
+++ b/test/regression-sentinel/test_benchmark_rate_not_impossible.py
@@ -24,9 +24,11 @@ The invariant asserted here is deliberately basis-agnostic and physical rather
 than a re-statement of the formula: **the rays the estimator claims per second,
 multiplied by the whole run's wall clock, cannot exceed the rays the run actually
 traced by more than a small factor.** Every honest basis lands near 1.0 (measured:
-`steady` 0.99-1.0 on legacy CPU and on Metal at 20M/200M rays; `wall_fallback`
-and `active_short` are exactly 1.0 by construction), while the defect scored ~20.
-`_MAX_WORK_RATIO` sits between them with room on both sides.
+`wall_fallback` and `active_short` are exactly 1.0 by construction — the only two
+bases `_HEAVY_CONFIGS` can reach, since their fixed ray_num stays below the drain
+quantum; `steady` measured 0.99-1.0 during the diagnosis with `ray_num` temporarily
+overridden to 20M/200M, a case THIS test's fixed configs never exercise), while the
+defect scored ~20. `_MAX_WORK_RATIO` sits between them with room on both sides.
 
 Scope, stated rather than implied: this is macOS + Metal only, because the defect
 needs a drain quantum coarse enough to swallow a whole run — legacy CPU publishes

--- a/test/regression-sentinel/test_benchmark_rate_not_impossible.py
+++ b/test/regression-sentinel/test_benchmark_rate_not_impossible.py
@@ -54,6 +54,7 @@ import subprocess
 import pytest
 
 from test.e2e.runner import find_lumice_binary, get_project_root
+from test.performance.test_metal_throughput import _HEAVY_CONFIGS
 
 pytestmark = pytest.mark.skipif(
     platform.system() != "Darwin", reason="the coarse-drain-quantum path needs Metal (macOS)"
@@ -62,9 +63,10 @@ pytestmark = pytest.mark.skipif(
 _CONFIGS_DIR = get_project_root() / "test" / "e2e" / "configs"
 
 # Below the 2,097,152-ray Metal drain quantum, which is what makes the window
-# degenerate. Same two scenes the throughput gate uses, so the two agree on what
+# degenerate. Reuses the throughput gate's own `_HEAVY_CONFIGS` (rather than a
+# second hardcoded list) so the two tests cannot silently drift apart on what
 # they are measuring.
-_CONFIGS = ["ms_multi_crystal_complex_filter", "ms_multi_crystal_filtered_bd"]
+_CONFIGS = _HEAVY_CONFIGS
 
 # P(no active_short sample in _RUNS) = 0.96**25 ~ 36% at the low end of the
 # measured 4-8% rate, per config; with two configs a total miss is ~13%. Each run
@@ -77,7 +79,7 @@ _MAX_WORK_RATIO = 3.0
 _TIMEOUT = 120
 
 
-def _benchmark_rows(config_name: str) -> list[dict]:
+def _benchmark_rows(config_name: str, out_dir: str) -> list[dict]:
     """One `--benchmark` invocation on Metal; return its parsed [BENCHMARK] rows."""
     env = dict(os.environ)
     env["LUMICE_TRACE_BACKEND"] = "metal"
@@ -88,7 +90,7 @@ def _benchmark_rows(config_name: str) -> list[dict]:
             "-f",
             str(_CONFIGS_DIR / f"{config_name}.json"),
             "-o",
-            "/tmp",
+            out_dir,
         ],
         capture_output=True,
         text=True,
@@ -105,12 +107,12 @@ def _benchmark_rows(config_name: str) -> list[dict]:
 
 @pytest.mark.slow
 @pytest.mark.parametrize("config_name", _CONFIGS)
-def test_reported_rate_is_physically_possible(config_name: str) -> None:
+def test_reported_rate_is_physically_possible(config_name: str, tmp_path) -> None:
     seen_basis: dict[str, int] = {}
     worst = None  # (work_ratio, row) over every sample, reported either way.
 
     for _ in range(_RUNS):
-        for row in _benchmark_rows(config_name):
+        for row in _benchmark_rows(config_name, str(tmp_path)):
             basis = str(row.get("rate_basis", "?"))
             seen_basis[basis] = seen_basis.get(basis, 0) + 1
             wall_sec = float(row["wall_sec"])


### PR DESCRIPTION
> ⚠️ **本 PR 叠在 #309 之上**（base = `chore/native-arch-measurement-hygiene`）。
> 合入顺序：**#307 → #309 → 本 PR**。两者动同一段 `[BENCHMARK]` 输出但根因不同，
> 故不合并；本 PR 的消费者清点是在含 #309 新 `isa` 键的树上**重新**做的，未复用 #309 的清单。

## ⚠️ 先说一条：issue 的前提是错的，已由白盒推翻

issue 写「野值以 `rate_basis="steady"` 报出（不是 `wall_fallback`）」。**实测不成立**：
`steady` 在这条路径上**结构性不可达**，240 次黑盒 + 100 次插桩里出现 **0 次**。
野值实际报的是 **`active_short`**。

## 根因（机制层，量级闭合，不是「疑似」）

逐 poll 插桩抓到的两条轨迹（`ms_multi_crystal_complex_filter`，`ray_num=2,000,000`，Metal）：

```
正常样本：  t=142.5ms rays=0        state=RUNNING
           t=150.0ms rays=2000000  state=IDLE      <- 计数器发布与 IDLE 同一次 poll
野值样本：  t=148.8ms rays=2000000  state=RUNNING   <- 计数器在这一 poll 发布
           t=156.3ms rays=2000000  state=IDLE      <- IDLE 晚一个 poll 才被观察到
```

1. **`sim_ray_num` 按 drain 量子前进**，量子 = **2,097,152 rays**
   （64 batches × 32768 dispatch）。config 的 `ray_num = 2,000,000 < 2,097,152`
   ⇒ **整个 run 装不满一个量子**，窗口内**零个**内部采样点 ⇒ 根本不存在"稳定窗口"。
2. `r_end == rays_at_active_start` 恒成立 ⇒ `steady` 分支条件永远为假（这就是 `steady` 不可达的原因）。
3. **决定报 `wall_fallback` 还是报野值的唯一变量，是「IDLE 被哪一次 poll 观察到」**：
   同一次 poll ⇒ `active_sec = 0` ⇒ `wall_fallback`；晚一次 poll（~5–8ms）⇒ `active_sec`
   等于那个 poll 间隔，而它量的是 **IDLE 检测延迟**，与追迹耗时毫无关系
   ⇒ `r_end / active_sec` = 2e6 / 6ms ≈ 3e8 rays/s。**与观察到的 266–390M 量级闭合。**

**观察者效应已核对**：插桩版复现率 4/100，与黑盒版 4/100 完全一致 ⇒ 打点没有改变时序特征。

## 修法

`active_short` 分支的分母从 `active_sec` 换成 `wall_sec`——一个**可证明包含整条追迹**的真实时长，
于是这个数变成真实速率的**保守下界**，而不是无界的向上幻觉。

`rate_basis` 的**取值集合不变**（解析契约不破）：`active_short` 与 `wall_fallback` 刻意保持区分，
因为二者陈述不同的事实（前者＝只观察到一次计数器发布；后者＝根本没有可用的 active 窗口），
合并它们会改变取值集合却换不到任何东西。

## AC5：没有靠放宽判据收场

`test/performance/test_metal_throughput.py` 的 `_SANITY_FLOOR` 与 `_GATE` **数值一个都没动**。
那个文件的改动是把「这道闸实际消费哪个 `rate_basis`」实测下来写进注释（240 次：
`wall_fallback` 96% / `active_short` 4% / `steady` **0 次**），并把 basis 打进 CI 日志，
**且刻意不断言它**——断言 basis 等于把闸的输入钉死。

⭐ 顺带纠正了那个文件里一条错误的既有断言：它原本写着自己消费的是 steady 率。

## 新增常驻哨兵

`test/regression-sentinel/test_benchmark_rate_not_impossible.py`：物理不变量判据
（速率不得超过物理上可能的上界），红绿双态自证。

## 验证（编排者独立复核）

**⚠️ 一次红态与它的定性，如实记录**：我第一次独立跑 `test.sh pr` 时
`test_benchmark_infinite_terminates_cpu`（30s 墙钟哨兵）超时变红，而 runner 自报全绿。定性依据按权重排序：

1. **构建图论证（主证）**：本 PR 对 `src/main.cpp` 的改动**不触及**这条测试走的
   `drain_count_mode` 路径；该路径上唯一新增的工作是 run 结束时算一次 `double` 除法。
   机制上不可能造成 30s 挂起。
2. 隔离重跑 ×8：8/8 通过，每次 ~3.6s（对 30s 预算 **8× 余量**）。
3. **只差一个变量的负对照**：同一条 `pytest -n auto` 命令，基线（#309 尖端，不含本 PR 改动）
   2/2 通过，本 PR 2/2 通过。⚠️ **0/2 vs 0/2 对偶发事件功效近乎为零，这条只作佐证，
   不构成「不会发生」的证据。**
4. 完整 `test.sh pr` 复跑：**RESULT: PASS**（rc=0，六层全 PASS/SKIP）。

⇒ 判定为**偶发的、对并发负载敏感的 30s 墙钟哨兵**，非本 PR 的回归。
📌 **同一条测试在本批的另一个任务（#309）验证时也红过一次**（当时实测 load average 18–41）。
**一个批次内两次**，隔离余量却有 8× ⇒ 这条哨兵的预算在 `pytest -n auto` 下偏紧，
值得单独立项，但那是 owner 的裁决，本 PR 不擅自扩范围。

其余：五道工程门禁 rc=0。

## AC6 覆盖面（据实，⛔ 不外推）

- **已验证**：macOS + **Metal** + release static。复现 240 次黑盒 + 100 次插桩；修后 120 次黑盒。
- **顺带验证**：**legacy CPU** 同机对照全部报 `steady`（CoV < 1.5%）⇒ 其逐 batch 计数粒度
  **结构上到不了** `active_short` 分支。
- ⛔ **未测**：CUDA / Linux / Windows。
  ⚠️ 但树内原本就有一条注释记着同一缺陷在 **CUDA** 上出现过（10M config 报出 1.97 billion rays/s）
  ——机制是后端无关的（drain 量子 × poll 时序），所以修法**应当**同样覆盖它，但这是推断不是实测。

## 评审

code-review 三轮 APPROVE。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYUQjkoHUfvHDF1xzk829e