### PR TITLE
fix(gui,ci): 拆开超 MSVC 上限的 shader 字面量 + 立静态门禁 + CI 触发去重

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,13 @@ on:
   # `github.event_name == 'push'` now means "main only", which is a legitimate
   # thing to want (see benchmark-summary) but a silent loss of coverage if it
   # was meant to mean "always".
+  #
+  # A branch filter also drops tag pushes, which the unfiltered `push:` used to
+  # catch: `v*` tags no longer run this workflow. That is intended, not lost
+  # coverage. A release tag is cut from a commit already on main, so this
+  # workflow has already run on that exact commit — a tag-push run was a third
+  # copy of the same result. Release artifacts are gated by release.yml, which
+  # keeps its own `push: tags: ['v*']` trigger and is unaffected by this filter.
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,21 @@
 name: CI
 
 on:
+  # `push` is filtered to main on purpose. Without a branch filter, a push to a
+  # PR branch fires BOTH `push` and `pull_request`, so every job without a
+  # job-level `if:` ran twice on the same commit — measured at ~18.4 minutes of
+  # duplicated machine time and 4 concurrency slots per PR. Filtering here fixes
+  # that at the source, for every job at once, instead of per-job guards that
+  # each have to be kept in sync.
+  #
+  # The consequence to keep in mind when adding a job: on a PR branch there is
+  # now NO push event. A job that wants to run on PRs must therefore have either
+  # no job-level `if:` at all, or one that admits `pull_request` — a guard of
+  # `github.event_name == 'push'` now means "main only", which is a legitimate
+  # thing to want (see benchmark-summary) but a silent loss of coverage if it
+  # was meant to mean "always".
   push:
+    branches: [main]
   pull_request:
 
 concurrency:
@@ -12,10 +26,14 @@ env:
   CPM_SOURCE_CACHE: ${{ github.workspace }}/cpm_cache
 
 jobs:
-  # Build + unit tests run on every push (all branches).
+  # Build + unit tests run once per PR and once per push to main.
   # E2E tests run separately on pull_request and push to main (see e2e-test job).
+  #
+  # No job-level `if:` — the workflow-level `on: push: branches: [main]` /
+  # `pull_request` pair already yields exactly one run per commit. The guard that
+  # used to sit here (`github.event_name == 'push'`) predates that filter and now
+  # would mean "never run on a PR".
   build:
-    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
@@ -252,7 +270,7 @@ jobs:
           retention-days: 7
 
   # CUDA compile-only: nvcc actually compiles the .cu translation units on every
-  # push/PR. No GPU is required (nvcc emits PTX/object from CPU). Runtime and
+  # PR and every push to main. No GPU is required (nvcc emits PTX/object from CPU). Runtime and
   # parity validation still need a GPU runner and are intentionally
   # out of scope here — see issue.md AC6: this job must not be read as
   # "CUDA all green". The job exists to catch nvcc-only compile/syntax bugs
@@ -349,8 +367,9 @@ jobs:
   # without it, the scrum-309 Windows-gated build fixes (spdlog/fmt/nvcc)
   # would have zero automated regression protection on main.
   #
-  # No job-level `if:` — relies on the workflow-level `on: push / pull_request`
-  # triggers so both PRs and branch pushes run this gate.
+  # No job-level `if:` — relies on the workflow-level `on: push: branches: [main]`
+  # / `pull_request` triggers, so this gate runs once per PR and once per push to
+  # main.
   windows-cuda-compile:
     runs-on: windows-2022
     timeout-minutes: 30
@@ -455,8 +474,9 @@ jobs:
   # break surfaced only when someone tried -b by hand. Fixing the file without
   # adding this gate would just restart that clock.
   #
-  # No job-level `if:` — relies on the workflow-level `on: push / pull_request`
-  # triggers so both PRs and branch pushes run this gate.
+  # No job-level `if:` — relies on the workflow-level `on: push: branches: [main]`
+  # / `pull_request` triggers, so this gate runs once per PR and once per push to
+  # main.
   bench-compile:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
@@ -506,8 +526,9 @@ jobs:
   # correctness, which is exactly the defect class above. Runtime behavior under the
   # shared flavor is verified locally, not here.
   #
-  # No job-level `if:` — relies on the workflow-level `on: push / pull_request`
-  # triggers so both PRs and branch pushes run this gate.
+  # No job-level `if:` — relies on the workflow-level `on: push: branches: [main]`
+  # / `pull_request` triggers, so this gate runs once per PR and once per push to
+  # main.
   shared-gui-test-build:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
@@ -788,6 +809,9 @@ jobs:
           esac
         timeout-minutes: 15
 
+  # The `push` guard STAYS here, and now reads as "main only" — which is the
+  # intent: this job publishes the benchmark history to gh-pages, and a PR must
+  # not write to it.
   benchmark-summary:
     if: always() && github.event_name == 'push'
     needs: [build]
@@ -987,8 +1011,9 @@ jobs:
           summary-always: true
           max-items-in-chart: 100
 
+  # No job-level `if:` — see the note on the `build` job: the workflow-level
+  # trigger pair already gives one run per PR and one per push to main.
   format-check:
-    if: github.event_name == 'push'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
@@ -1001,8 +1026,8 @@ jobs:
   # Engineering-policy gate (separate from format-check above): env-knob
   # centralization + registration, GUI/core API boundary, no `using namespace`.
   # Version-independent — the executable half of doc/env-var-policy.md + AGENTS.md.
+  # No job-level `if:` — see the note on the `build` job.
   policy:
-    if: github.event_name == 'push'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -495,6 +495,10 @@ script prints the path for whichever group it ran.
   there is no `push` event at all, so a guard of `github.event_name == 'push'` means "`main` only"
   (which `benchmark-summary` genuinely wants, since it writes the gh-pages benchmark history) and
   is a silent loss of PR coverage anywhere it was meant to mean "always".
+  The `on:` block's own comment in `ci.yml` is the authority on this — it is the thing that has to
+  be right for the workflow to behave, and it carries the details this summary leaves out (what the
+  duplication cost, and why tag pushes no longer run this workflow). Change the triggers and that
+  comment is what you edit; this paragraph is a summary that has to be re-checked against it.
 
 ## Documentation Index (`doc/`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -488,7 +488,13 @@ script prints the path for whichever group it ran.
 - `config.json`, `test.json`, `scratchpad/`, remote test output files, and most generated artifacts are intentionally git-ignored.
 - Do not use `git add -f` to force-track ignored files. If a file is ignored and you are unsure, stop and ask first.
 - Reference images under `test/e2e-correctness/references/*.jpg` and `test/gui/references/*.jpg` are explicitly unignored and may be tracked normally.
-- CI runs build and unit tests on branch pushes; E2E tests run on PRs and `main`.
+- CI (`.github/workflows/ci.yml`) triggers on `pull_request` and on `push` **filtered to `main`**.
+  Every job therefore runs exactly once per commit: once while the change is a PR, once again when
+  it lands on `main`. The filter is what makes that true — without it a push to a PR branch fires
+  both events and every unguarded job runs twice. The consequence when adding a job: on a PR branch
+  there is no `push` event at all, so a guard of `github.event_name == 'push'` means "`main` only"
+  (which `benchmark-summary` genuinely wants, since it writes the gh-pages benchmark history) and
+  is a silent loss of PR coverage anywhere it was meant to mean "always".
 
 ## Documentation Index (`doc/`)
 

--- a/scripts/check_policies.py
+++ b/scripts/check_policies.py
@@ -160,6 +160,11 @@ CXX_SUFFIXES = {".cpp", ".cc", ".hpp", ".h", ".mm", ".inl"}
 # pay it: a THIRD consumer. At that point a name that describes only the first
 # one has stopped being a historical accident and started being misleading, and
 # the rename should be done then rather than re-argued.
+#
+# That same trigger covers a second debt, so the two get settled in one pass
+# rather than being rediscovered separately: the two consumers also carry a
+# duplicated `sorted(SRC.rglob("*"))` + suffix-filter walk. Two inlined copies
+# are cheaper to read than a helper; a third is the point where the helper wins.
 PRINT_SCAN_SUFFIXES = CXX_SUFFIXES | {".cu", ".cuh", ".metal"}
 
 # The only two translation units under src/ allowed to write to a stdio stream.
@@ -1265,6 +1270,13 @@ MSVC_STRING_LITERAL_LIMIT = 16384
 #   - `R"` appearing inside a line comment or inside another string is read as a
 #     literal opener. That direction fails toward a false positive, which someone
 #     investigates; the misses above fail toward green, which nobody does.
+#   - the body is measured after the file has been decoded with
+#     errors="replace", the reading style every scanning check in this file uses.
+#     A byte sequence that is not valid UTF-8 becomes U+FFFD and re-encodes to
+#     three bytes, so a file carrying one would be measured against a count that
+#     is not its size on disk. Left as is rather than special-cased here: the
+#     divergence is shared with the other checks, and pinning it in one of them
+#     would leave the others reading differently from their sibling.
 RAW_STRING_LITERAL = re.compile(r'R"([A-Za-z0-9_]{0,16})\((.*?)\)\1"', re.DOTALL)
 
 

--- a/scripts/check_policies.py
+++ b/scripts/check_policies.py
@@ -1319,7 +1319,7 @@ def check_msvc_string_literal_limit() -> list[Violation]:
                     "(C2026: string too big, trailing characters truncated). Split it "
                     'into adjacent literals — `)delim"` on one line, `R"delim(` on the '
                     "next — which the compiler concatenates back into the identical "
-                    "bytes. See AGENTS.md.",
+                    "bytes. src/gui/preview_renderer.cpp carries a worked example.",
                 )
             )
     return out

--- a/scripts/check_policies.py
+++ b/scripts/check_policies.py
@@ -107,6 +107,17 @@ Checks:
      the rule" are different facts and get different exits. The next rule's
      author should reuse that channel rather than invent a second one — said by
      position, because a rule number written here rots the moment one is added.
+  15. msvc-string-literal-limit — no raw string literal under src/ may exceed
+     16384 bytes of body. MSVC caps a single string literal at that size and
+     reports C2026 ("string too big, trailing characters truncated"); GCC,
+     Clang and VS 2026 do not, so the failure is invisible on every leg of CI
+     except the one that publishes Windows binaries. It has happened once: the
+     GLSL fragment-shader sources embedded in src/gui/preview_renderer.cpp grew
+     past the cap across many small shader edits and broke the release build
+     with nothing red beforehand. The fix is free — adjacent string literals
+     concatenate at compile time, so splitting one literal into two changes not
+     a single byte of the program — which is exactly why the cap is worth
+     pinning mechanically instead of remembering.
 
 Add a new check as a function returning a list of Violation and append it to
 CHECKS, and add a numbered entry above. Keep each check deterministic and
@@ -140,6 +151,15 @@ CXX_SUFFIXES = {".cpp", ".cc", ".hpp", ".h", ".mm", ".inl"}
 # file were written and validated against host C++ only, and sweeping .cu/.metal
 # into all of them at once would change ten rules' scope as a side effect of
 # adding one. Widen CXX_SUFFIXES itself only after auditing each check.
+#
+# TWO checks share this set today — no-bare-print and msvc-string-literal-limit —
+# so a change here moves both, and both must be re-audited before it lands. The
+# name still says "print" because it was written for one consumer; renaming it to
+# something scope-neutral is a real debt, deliberately deferred rather than paid
+# on the release-unblocking change that added the second consumer. The trigger to
+# pay it: a THIRD consumer. At that point a name that describes only the first
+# one has stopped being a historical accident and started being misleading, and
+# the rename should be done then rather than re-argued.
 PRINT_SCAN_SUFFIXES = CXX_SUFFIXES | {".cu", ".cuh", ".metal"}
 
 # The only two translation units under src/ allowed to write to a stdio stream.
@@ -185,8 +205,16 @@ def strip_comments(text: str) -> str:
 
     Known limitation: C++11 raw string literals (R"delim(...)delim") are not
     parsed specially — a raw string containing `//`, `/*`, or a getenv("LUMICE_…")
-    fragment could be mis-handled. The codebase currently uses none, so this is a
-    documented gap, not an active false-positive source.
+    fragment could be mis-handled. The codebase DOES use them (the embedded GLSL
+    sources in src/gui/preview_renderer.cpp and src/gui/crystal_renderer.cpp), so
+    this is an active gap, not a theoretical one. What saves it today is an
+    accident: `R"delim(` opens with a quote, so the body is read as an ordinary
+    string literal and preserved verbatim — until a body containing an odd number
+    of `"` characters desyncs the state machine, after which a `//` inside the
+    body is treated as a real comment and blanked. The msvc-string-literal-limit
+    rule therefore does NOT come through here: it needs the closing delimiter
+    intact to find a literal at all, and a blanked one makes an oversized literal
+    disappear from the scan rather than report.
     """
     out = []
     i, n = 0, len(text)
@@ -1216,6 +1244,75 @@ def check_no_bare_print() -> list[Violation]:
     return out
 
 
+# --- msvc-string-literal-limit ----------------------------------------------
+#
+# MSVC caps one string literal at 16384 bytes and reports C2026 past it. GCC,
+# Clang and VS 2026 accept more, so a literal that grows over the line compiles
+# everywhere a developer looks and fails only on the leg that ships Windows
+# binaries — where it stops a release rather than a commit. The number is the
+# observed C2026 trigger point, not a style budget.
+MSVC_STRING_LITERAL_LIMIT = 16384
+
+# R"delim( ... )delim" with the delimiter back-referenced, so the closing marker
+# must match the opening one. Non-greedy body + DOTALL: a literal spans lines,
+# and the first matching close terminator ends it.
+#
+# Known gaps, stated rather than papered over (the checker is the rule):
+#   - the delimiter charset is [A-Za-z0-9_]; C++ allows a few punctuation
+#     characters there that this pattern would not match.
+#   - a literal produced by macro expansion or by the preprocessor's # operator
+#     is not visible to a source-text scan at all.
+#   - `R"` appearing inside a line comment or inside another string is read as a
+#     literal opener. That direction fails toward a false positive, which someone
+#     investigates; the misses above fail toward green, which nobody does.
+RAW_STRING_LITERAL = re.compile(r'R"([A-Za-z0-9_]{0,16})\((.*?)\)\1"', re.DOTALL)
+
+
+def check_msvc_string_literal_limit() -> list[Violation]:
+    """No raw string literal under src/ may exceed MSVC's 16384-byte cap.
+
+    Deliberately reads the RAW file text, not code_lines()/strip_comments().
+    code_lines() is line-oriented and a literal spans hundreds of lines, so there
+    is nothing for it to measure. strip_comments() is length-preserving, so it
+    would not distort the byte count directly — the harm is one step removed and
+    worse: it does not parse raw strings, so a body carrying an odd number of `"`
+    characters desyncs its state machine, and a `//` after that point is blanked
+    as if it were a comment. Blank the closing `)delim"` and the literal is not
+    found at all, which reports as clean.
+
+    Reported at the literal's OPENING line — the line a reader has to go edit.
+    MSVC instead reports the line where its own buffer ran out, deep inside the
+    literal, which is why the two line numbers do not agree.
+    """
+    out: list[Violation] = []
+    # Same walk shape as check_no_bare_print(), for the same reason: cxx_sources()
+    # is bound to CXX_SUFFIXES and would skip .cu/.metal. Not factored into a
+    # shared helper at two call sites — see the PRINT_SCAN_SUFFIXES note.
+    for path in sorted(SRC.rglob("*")):
+        if path.suffix not in PRINT_SCAN_SUFFIXES or not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for match in RAW_STRING_LITERAL.finditer(text):
+            size = len(match.group(2).encode("utf-8"))
+            if size <= MSVC_STRING_LITERAL_LIMIT:
+                continue
+            lineno = text.count("\n", 0, match.start()) + 1
+            out.append(
+                Violation(
+                    path,
+                    lineno,
+                    "msvc-string-literal-limit",
+                    f"raw string literal body is {size} bytes, over MSVC's "
+                    f"{MSVC_STRING_LITERAL_LIMIT}-byte cap for a single literal "
+                    "(C2026: string too big, trailing characters truncated). Split it "
+                    'into adjacent literals — `)delim"` on one line, `R"delim(` on the '
+                    "next — which the compiler concatenates back into the identical "
+                    "bytes. See AGENTS.md.",
+                )
+            )
+    return out
+
+
 # --- user-defaults-single-write-path ---------------------------------------
 #
 # The personal-defaults override file has exactly one writer, and the rule exists
@@ -1649,6 +1746,7 @@ CHECKS = [
     check_no_default_constructed_crystal_slots,
     check_gui_test_suite_args_sync,
     check_no_bare_print,
+    check_msvc_string_literal_limit,
     check_user_defaults_single_write_path,
     check_pytest_invocation_marker,
 ]
@@ -1675,7 +1773,8 @@ def main() -> int:
         "reconciler-widget-include, using-namespace, struct-layout parity, no-config-by-value-copy, "
         "gui-state-field-tier-registration, no-msvc-unsafe-builtin, "
         "no-default-constructed-crystal-slots, gui-test-suite-args-sync, no-bare-print, "
-        "user-defaults-single-write-path, pytest-invocation-marker)."
+        "msvc-string-literal-limit, user-defaults-single-write-path, "
+        "pytest-invocation-marker)."
     )
     return 0
 

--- a/src/gui/preview_renderer.cpp
+++ b/src/gui/preview_renderer.cpp
@@ -210,7 +210,8 @@ vec2 dualFisheyeToUV(vec2 xy_norm, bool is_upper) {
   // every fragment onto a texel corner and turns every sample into a 2x2 bilinear average.
   return pixel / tex_res;
 }
-
+)glsl"
+R"glsl(
 // Convert world direction to dual equal-area fisheye UV (single hemisphere, no blend).
 vec2 dirToDualFisheye(vec3 d) {
   vec3 sky = -d;
@@ -580,7 +581,8 @@ vec3 overlayLensBorder(vec3 color, vec2 pos, float half_fov) {
   float t = 1.0 - smoothstep(0.0, kBorderHalfWidthPx, d);
   return mix(color, u_lens_border_color, t * u_lens_border_alpha);
 }
-
+)glsl"
+R"glsl(
 out vec4 frag_color;
 
 void main() {

--- a/test/unit-correctness/scripts/test_check_policies_string_literal_limit.py
+++ b/test/unit-correctness/scripts/test_check_policies_string_literal_limit.py
@@ -1,0 +1,186 @@
+"""Regression net for `check_msvc_string_literal_limit` in `scripts/check_policies.py`.
+
+Read the note at the top of `test_check_new_refs.py` first: this repo does not
+test symbol-matching checks, only the ones that would fail silently. This rule
+is on the tested side for two independent reasons.
+
+First, the boundary is a number nobody can see. 16384 is MSVC's cap, and the
+difference between `<=` and `<` at that comparison is one byte of a shader — not
+something a reader of the diff would catch, and not something any other leg of
+CI can report, because Clang, GCC and VS 2026 all accept the oversized literal
+happily. A regression here surfaces as a failed *release*, on the one job that
+builds Windows binaries, after the tag is already pushed.
+
+Second, the rule owns a parser. The pattern has to find a delimiter, match it
+against its own closing marker, and measure the body in bytes rather than
+characters — and it deliberately reads raw file text instead of the shared
+`strip_comments()` helper, because a shader body contains `//` runs as content.
+Every one of those decisions fails toward green if it is edited carelessly: a
+greedy body swallows two literals into one measurement, a stripped comment
+under-counts, `len()` on a str instead of on bytes under-counts again.
+
+Scope note: these cases pin *observable behaviour of the rule*, not the wording
+of the regex. A rewrite that keeps the byte-counted body and the back-referenced
+delimiter should keep this file green.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
+
+import check_policies  # noqa: E402
+
+RULE = "msvc-string-literal-limit"
+LIMIT = check_policies.MSVC_STRING_LITERAL_LIMIT
+
+
+@pytest.fixture
+def src_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    src = tmp_path / "src"
+    src.mkdir()
+    monkeypatch.setattr(check_policies, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(check_policies, "SRC", src)
+    return src
+
+
+def _violations(src_root: Path, body: str, name: str = "scratch.cpp") -> list:
+    path = src_root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return check_policies.check_msvc_string_literal_limit()
+
+
+def _raw(payload: str, delim: str = "glsl") -> str:
+    return f'R"{delim}({payload}){delim}"'
+
+
+# --- must stay red: a literal over the cap ----------------------------------
+
+
+def test_oversized_literal_is_flagged(src_root: Path) -> None:
+    out = _violations(src_root, f"const char* k =\n{_raw('x' * (LIMIT + 1))};\n")
+    assert len(out) == 1
+    assert out[0].rule == RULE
+    assert str(LIMIT + 1) in out[0].message
+
+
+def test_violation_points_at_the_opening_line(src_root: Path) -> None:
+    """The line a reader has to go edit — not where MSVC's own buffer ran out.
+
+    A multi-line body makes the two diverge: MSVC reports a line deep inside the
+    literal. Anchoring on `match.start()` is what keeps this at the opener.
+    """
+    payload = "\n".join("y" * 64 for _ in range(LIMIT // 32))
+    body = "// header\n// header\nconst char* k =\n" + _raw(payload) + ";\n"
+    out = _violations(src_root, body)
+    assert len(out) == 1
+    assert out[0].line == 4
+
+
+# --- the boundary itself ----------------------------------------------------
+
+
+def test_exactly_at_the_limit_is_clean(src_root: Path) -> None:
+    assert _violations(src_root, f"const char* k = {_raw('x' * LIMIT)};\n") == []
+
+
+def test_one_byte_over_the_limit_is_flagged(src_root: Path) -> None:
+    assert len(_violations(src_root, f"const char* k = {_raw('x' * (LIMIT + 1))};\n")) == 1
+
+
+def test_body_that_desyncs_the_comment_stripper_is_still_flagged(src_root: Path) -> None:
+    """Pins the reason this rule reads raw text instead of `strip_comments()`.
+
+    That helper does not parse raw strings: `R"delim(` reads to it as an ordinary
+    string opener, so an odd number of `"` in the body desyncs its state machine,
+    and a `//` past that point is blanked as a comment. Blanking reaches the
+    closing `)delim"`, the literal stops being findable, and an oversized shader
+    reports as clean — a miss, not a wrong number, which is why a byte-count
+    assertion alone would not catch the regression.
+
+    The body below is that exact shape: one unbalanced quote, then a trailing
+    `//` line. Routed through the stripper it yields zero violations; read raw it
+    yields one. Verified by mutating the rule to call the helper.
+    """
+    body = '// 6" wide\n' + "x" * (LIMIT + 1) + "\n// trailing note "
+    out = _violations(src_root, f"const char* k =\n{_raw(body)};\n")
+    assert len(out) == 1
+
+
+def test_limit_is_measured_in_bytes_not_characters(src_root: Path) -> None:
+    """A multi-byte body under the cap in characters can be over it in bytes.
+
+    MSVC counts the encoded bytes, so `len(str)` would let a literal through that
+    the compiler rejects. Half the cap in 3-byte characters is comfortably over.
+    """
+    payload = "あ" * (LIMIT // 2)
+    assert len(payload) < LIMIT
+    out = _violations(src_root, f"const char* k = {_raw(payload)};\n")
+    assert len(out) == 1
+
+
+# --- must stay green: shapes the rule is not about --------------------------
+
+
+def test_adjacent_literals_each_under_the_limit_are_clean(src_root: Path) -> None:
+    """The end state this task produces: one literal split into two adjacent ones.
+
+    The compiler concatenates them back into identical bytes, and MSVC applies
+    its cap per literal, so the pair must read as clean even though the combined
+    body is over. A greedy body pattern would merge them and report a false red.
+    """
+    half = "x" * (LIMIT - 1)
+    body = f"const char* k =\n{_raw(half)}\n{_raw(half)};\n"
+    assert _violations(src_root, body) == []
+
+
+def test_plain_string_literal_is_not_scanned(src_root: Path) -> None:
+    """Scope is raw literals only.
+
+    A non-raw literal that long cannot be written on one source line anyway, and
+    the rule was not asked to cover it — stated here so a later reader does not
+    read the absence as an oversight.
+    """
+    assert _violations(src_root, 'const char* k = "' + "x" * (LIMIT + 1) + '";\n') == []
+
+
+def test_distinct_delimiters_do_not_close_each_other(src_root: Path) -> None:
+    """The closing marker must match the opening delimiter.
+
+    Without the back-reference, the first `)…"` of any kind ends the literal, and
+    a body that contains one measures short.
+    """
+    payload = "x" * (LIMIT + 1)
+    body = f'const char* k = R"outer(){payload})outer";\n'
+    assert len(_violations(src_root, body)) == 1
+
+
+# --- scanned file set -------------------------------------------------------
+
+
+@pytest.mark.parametrize("suffix", [".cpp", ".hpp", ".cu", ".cuh", ".metal", ".mm", ".inl"])
+def test_every_scanned_suffix_is_covered(src_root: Path, suffix: str) -> None:
+    """A GPU backend must not be able to reopen the gap the rule closes."""
+    out = _violations(src_root, f"const char* k = {_raw('x' * (LIMIT + 1))};\n", f"s{suffix}")
+    assert len(out) == 1
+
+
+def test_unscanned_suffix_is_ignored(src_root: Path) -> None:
+    assert _violations(src_root, f"k = {_raw('x' * (LIMIT + 1))}\n", "notes.txt") == []
+
+
+def test_nested_directories_are_scanned(src_root: Path) -> None:
+    out = _violations(src_root, f"const char* k = {_raw('x' * (LIMIT + 1))};\n", "gui/deep/s.cpp")
+    assert len(out) == 1
+
+
+# --- registration -----------------------------------------------------------
+
+
+def test_check_is_registered() -> None:
+    """An unregistered check is a check that never runs."""
+    assert check_policies.check_msvc_string_literal_limit in check_policies.CHECKS

--- a/test/unit-correctness/scripts/test_check_policies_string_literal_limit.py
+++ b/test/unit-correctness/scripts/test_check_policies_string_literal_limit.py
@@ -58,6 +58,27 @@ def _raw(payload: str, delim: str = "glsl") -> str:
     return f'R"{delim}({payload}){delim}"'
 
 
+# --- the boundary value itself ----------------------------------------------
+
+
+def test_limit_constant_is_pinned_to_msvcs_observed_c2026_trigger() -> None:
+    """16384 is inside the net, not just the comparison drawn around it.
+
+    Every other case in this file builds its payload from `LIMIT`, read back out
+    of the module under test, so together they pin the *relative* behaviour of
+    that `<=` and nothing at all about the number it compares against. Change
+    `MSVC_STRING_LITERAL_LIMIT` to 8192, or add a digit to it, and all of them
+    stay green while the gate stops agreeing with MSVC — which is the exact
+    shape of the failure this rule exists to prevent: green CI, and a release
+    that still dies on the Windows leg.
+
+    The 16384 below is written out on purpose and must not be replaced by a
+    reference to the constant. It is the observed C2026 trigger point, the same
+    number recorded in this task's issue and plan.
+    """
+    assert check_policies.MSVC_STRING_LITERAL_LIMIT == 16384
+
+
 # --- must stay red: a literal over the cap ----------------------------------
 
 
@@ -151,11 +172,14 @@ def test_plain_string_literal_is_not_scanned(src_root: Path) -> None:
 def test_distinct_delimiters_do_not_close_each_other(src_root: Path) -> None:
     """The closing marker must match the opening delimiter.
 
-    Without the back-reference, the first `)…"` of any kind ends the literal, and
-    a body that contains one measures short.
+    The body opens with `)b"` — a well-formed closing marker for a *different*
+    delimiter — and only then runs past the cap before its own `)a"` arrives.
+    Drop the back-reference and the non-greedy body stops at that first `)b"`,
+    measuring an empty literal and reporting the file clean, so the oversized
+    body is missed entirely rather than mis-sized.
     """
-    payload = "x" * (LIMIT + 1)
-    body = f'const char* k = R"outer(){payload})outer";\n'
+    payload = ')b"' + "x" * (LIMIT + 1)
+    body = f'const char* k = R"a({payload})a";\n'
     assert len(_violations(src_root, body)) == 1
 
 


### PR DESCRIPTION
## 背景

v4.5.0 的 release workflow（run 34021934688）在 `Build windows-x64` 失败，`release` job 因此被跳过，没有产生任何 release：

```
FAILED: src/gui/CMakeFiles/lumice_gui_obj.dir/preview_renderer.cpp.obj
preview_renderer.cpp(351): error C2026: string too big, trailing characters truncated
preview_renderer.cpp(697): error C2026: string too big, trailing characters truncated
```

MSVC 对单个字符串字面量的上限是 16384 字节。`preview_renderer.cpp` 里两个内嵌 GLSL 的 raw string 分别是 18789 / 18440 字节。v4.4.3 发布时尚未超限——是此后 32 个 PR 的 shader 增量（lens border ring #283、背景色填充、`relIllum*`、horizon 描线）把它顶过了线。

**为什么 CI 没抓到**：三条 Windows 腿交集为空。`ci.yml` 的 `Windows MSVC x86_64` 跑 windows-2025 / VS 2026（该版本放宽了这个上限），`windows-cuda-compile` 跑 windows-2022 / VS 2022 但 `BUILD_GUI=OFF`，而发布产物是 windows-2022 / VS 2022 / GUI ON——这个组合只存在于 `release.yml`，只在推 tag 时跑。统一 CI 与发布配置是另一个 issue，本 PR 不做。

## 改动

**1. 拆字面量**（commit A）。两个超限 raw string 拆成相邻字面量，由编译器拼接回同样的字节。3 个字面量变 5 个，最大 10142 字节。**拼接后逐字节相同已机械验证**：拆前后总字节均为 37344，按序拼接的结果 `==` 比较为 True。

**2. 静态门禁 `msvc-string-literal-limit`**（commit A）。`check_policies.py` 新增第 15 条规则：任何 raw string literal 不得超过 16384 字节。红态自证：把修复前的文件放回去，门禁精确报出 `:26` 和 `:411` 两处并 exit 1；修复后 exit 0。这是编译器对源码的静态限制，所以不需要 Windows runner 就能在每个 PR 上抓到——比再加一条 Windows 构建腿便宜得多。附 210 行 pytest 覆盖。

**3. CI 触发去重**（commit B，与 1/2 文件集不相交，可独立摘除）。`ci.yml` 的 `on: push:` 没有分支过滤，加上 `on: pull_request:`，每个 PR 分支同时触发两个 run，没有 job 级 `if:` 的四个 job 各跑两遍——实测 PR #315（run 34020614950 与 34020643207）重复了 `shared-gui-test-build` 11.5m、`windows-cuda-compile` 3.4m、`cuda-compile` 2.6m、`bench-compile` 1.4m，合计 **18.4 分钟机器时间 + 4 个并发槽 / 每个 PR**。改成 `push: branches: [main]` 从源头修掉，而不是逐 job 加守卫（那需要每条都保持同步）。逐个 job 核对过触发矩阵，没有 job 落进"两个事件都不跑"。`AGENTS.md` 里"CI runs build and unit tests on branch pushes"随之失效，已同步。

## 验证

- **AC1 逐字节相同**：机械比对，见上
- **AC3 红态自证**：门禁在修复前的文件上 exit 1 并精确定位两处；修复后 exit 0
- **AC4 触发矩阵**：11 个 job 逐个求值，无覆盖丢失
- 五道门禁绿：`format.sh --check` / `check_policies.py` / `check_new_refs.py --range` / `check_new_gui_tests.py` / `check_loop_fatal_asserts.py`
- code-review APPROVE（0 Critical / 0 Major）

⚠️ **本机是 macOS/clang，复现不了 C2026**（clang 无此上限）。所以 AC1 的证据是"拼接后逐字节相同"这条构造性论证加门禁红态，**不是**"本机编译过了"。真正的跨平台确认在合并后重标 v4.5.0 时。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEQKqTCp8u5xbUNnaoALij
