### PR TITLE
fix(gui): keep the edit modal bound to its entry across a delete

### DIFF
--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -1120,6 +1120,17 @@ EditModalTarget GetEditModalTarget() {
   return { g_modal_layer_idx, g_modal_entry_idx };
 }
 
+void NotifyEntryDeleted(int layer_idx, int deleted_entry_idx) {
+  // TEMPORARY NO-OP (red-state probe): reproduces today's behaviour exactly.
+  (void)layer_idx;
+  (void)deleted_entry_idx;
+}
+
+void NotifyLayerDeleted(int deleted_layer_idx) {
+  // TEMPORARY NO-OP (red-state probe): reproduces today's behaviour exactly.
+  (void)deleted_layer_idx;
+}
+
 namespace {
 // Defined further down, in the same anonymous namespace as the modal edit buffers it applies.
 void CommitAllBuffersImmediate(GuiState& state);

--- a/src/gui/edit_modals.cpp
+++ b/src/gui/edit_modals.cpp
@@ -1121,14 +1121,28 @@ EditModalTarget GetEditModalTarget() {
 }
 
 void NotifyEntryDeleted(int layer_idx, int deleted_entry_idx) {
-  // TEMPORARY NO-OP (red-state probe): reproduces today's behaviour exactly.
-  (void)layer_idx;
-  (void)deleted_entry_idx;
+  if (g_active_modal != ActiveModal::kOpen || layer_idx != g_modal_layer_idx) {
+    return;
+  }
+  if (deleted_entry_idx == g_modal_entry_idx) {
+    // Same close as the bounds guard in RenderEditModals performs — one behaviour, reached from the
+    // two directions a delete can come from.
+    g_active_modal = ActiveModal::kNone;
+  } else if (deleted_entry_idx < g_modal_entry_idx) {
+    --g_modal_entry_idx;
+  }
 }
 
 void NotifyLayerDeleted(int deleted_layer_idx) {
-  // TEMPORARY NO-OP (red-state probe): reproduces today's behaviour exactly.
-  (void)deleted_layer_idx;
+  if (g_active_modal != ActiveModal::kOpen) {
+    return;
+  }
+  if (deleted_layer_idx == g_modal_layer_idx) {
+    // Every entry the modal could have been editing went with the layer.
+    g_active_modal = ActiveModal::kNone;
+  } else if (deleted_layer_idx < g_modal_layer_idx) {
+    --g_modal_layer_idx;
+  }
 }
 
 namespace {

--- a/src/gui/edit_modals.hpp
+++ b/src/gui/edit_modals.hpp
@@ -39,6 +39,25 @@ struct EditModalTarget {
 };
 EditModalTarget GetEditModalTarget();
 
+// Keep the open modal's (layer_idx, entry_idx) binding meaning the same ENTRY across a delete.
+//
+// The binding names a position, so the one operation that can change what it means is an erase:
+// every later element shifts up one and the same numbers now denote a different entry. Call the
+// matching function immediately after erasing, from the delete site itself — that is the only place
+// that knows which index went away, and routing it through here keeps the rule in one function
+// instead of a bounds check at each of the places that read the binding.
+//
+// Three outcomes, in both flavours: the deleted item IS the bound one (close the modal — it has
+// nothing left to edit), the deleted item sat BEFORE it (decrement, so the binding follows its
+// entry down), or after it (nothing to do). A no-op when no modal is open: the stale indices left
+// behind are overwritten wholesale by the next OpenEditModal.
+//
+// Only the modal's own bounds guard in RenderEditModals catches the remaining case, the binding
+// falling off the end of the vector; everything short of that is in range and silently wrong,
+// because Immediate mode writes the edit buffers into the bound entry's pool slots every frame.
+void NotifyEntryDeleted(int layer_idx, int deleted_entry_idx);
+void NotifyLayerDeleted(int deleted_layer_idx);
+
 // Returns the EditTarget corresponding to the currently active tab. Returns
 // EditTarget::kCrystal when no modal is open because ResetModalState() resets
 // g_active_tab to kCrystal on close. Intended solely for resolving the tab in

--- a/src/gui/panels.cpp
+++ b/src/gui/panels.cpp
@@ -1692,6 +1692,7 @@ void RenderLayer(GuiState& state, int layer_idx) {
   }
   if (layer_delete_clicked && can_delete_layer) {
     state.layers.erase(state.layers.begin() + layer_idx);
+    NotifyLayerDeleted(layer_idx);
     g_thumbnail_cache.OnLayerStructureChanged();
     ImGui::PopID();
     return;  // Skip rendering the rest; layer has been erased.
@@ -1767,6 +1768,7 @@ void RenderLayer(GuiState& state, int layer_idx) {
     // Deferred delete
     if (pending_delete_entry >= 0 && layer.entries.size() > 1) {
       layer.entries.erase(layer.entries.begin() + pending_delete_entry);
+      NotifyEntryDeleted(layer_idx, pending_delete_entry);
       g_thumbnail_cache.OnLayerStructureChanged();
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -293,6 +293,7 @@ if(BUILD_GUI)
     "${PROJ_TEST_DIR}/unit-correctness/gui/test_color_window_logic.cpp"
     "${PROJ_TEST_DIR}/unit-correctness/gui/test_gui_identity_formatting.cpp"
     "${PROJ_TEST_DIR}/unit-correctness/gui/test_semantic_colors.cpp"
+    "${PROJ_TEST_DIR}/unit-correctness/gui/test_edit_modal_delete_binding.cpp"
     "${PROJ_TEST_DIR}/unit-correctness/gui/test_view_look_at.cpp")
   target_include_directories(gui_unit_test
     PRIVATE ${PROJ_TEST_DIR})

--- a/test/gui/functional/test_entry_management.cpp
+++ b/test/gui/functional/test_entry_management.cpp
@@ -102,9 +102,9 @@ void MakeThreeIndependentEntries(ImGuiTestContext* ctx) {
 // Driven through OpenEditModal rather than by clicking the card, because a click on the card is
 // itself one of the things the editor's presence changes; what these cases are about starts once it
 // is open.
-void OpenImmediateEditorOnEntry(ImGuiTestContext* ctx, int entry_idx) {
+void OpenImmediateEditorOnEntry(ImGuiTestContext* ctx, int entry_idx, int layer_idx = 0) {
   gui::g_state.modal_immediate_mode = true;
-  gui::EditRequest req{ gui::EditTarget::kCrystal, /*layer_idx=*/0, /*entry_idx=*/entry_idx };
+  gui::EditRequest req{ gui::EditTarget::kCrystal, layer_idx, entry_idx };
   gui::OpenEditModal(req, gui::g_state);
   ctx->Yield(4);
   IM_CHECK_SILENT(gui::IsEditModalOpen());
@@ -1395,6 +1395,46 @@ void RegisterEntryManagementTests(ImGuiTestEngine* engine) {
       // The entry below it was never the editor's business.
       IM_CHECK(gui::g_state.crystals[cid2] == crystal_before);
       IM_CHECK(gui::g_state.filters[fid2] == filter_before);
+    };
+  }
+
+  // The same NotifyLayerDeleted rule, on the LAYER axis and through the real production call site
+  // (RenderLayer's per-layer x -> state.layers.erase -> NotifyLayerDeleted at
+  // src/gui/panels.cpp:1695) rather than a direct function call — the two cases above cover the
+  // entry axis this way, and unit-correctness/gui/test_edit_modal_delete_binding.cpp already pins
+  // the index arithmetic in isolation, so what is missing without this case is proof that the
+  // wiring at the real button is correct. Deleting the layer BEFORE the bound one is the
+  // discriminator: it needs the decrement to be right, where deleting the bound layer itself would
+  // only need a close.
+  {
+    ImGuiTest* t =
+        IM_REGISTER_TEST(engine, "entry_management", "deleting_a_layer_above_the_editor_keeps_it_on_the_same_entry");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      const ScopedPopups popup_guard(ctx);
+      ctx->Yield(2);
+
+      ctx->ItemClick("**/+ Layer");
+      ctx->Yield(2);
+      IM_CHECK_EQ(static_cast<int>(gui::g_state.layers.size()), 2);
+
+      const int edited_cid = gui::g_state.layers[1].entries[0].crystal_id;
+
+      OpenImmediateEditorOnEntry(ctx, /*entry_idx=*/0, /*layer_idx=*/1);
+      if (ctx->IsError()) {
+        return;
+      }
+
+      ctx->ItemClick("**/" ICON_FA_XMARK "##layer_0");
+      ctx->Yield(6);
+
+      IM_CHECK_EQ(static_cast<int>(gui::g_state.layers.size()), 1);
+      IM_CHECK(gui::IsEditModalOpen());
+      // Same entry, new layer index — the layer that held it shifted up one when layer 0 was
+      // erased.
+      IM_CHECK_EQ(gui::GetEditModalTarget().layer_idx, 0);
+      IM_CHECK_EQ(gui::GetEditModalTarget().entry_idx, 0);
+      IM_CHECK_EQ(gui::g_state.layers[0].entries[0].crystal_id, edited_cid);
     };
   }
 }

--- a/test/gui/functional/test_entry_management.cpp
+++ b/test/gui/functional/test_entry_management.cpp
@@ -45,7 +45,7 @@
 #include <vector>
 
 #include "IconsFontAwesome6.h"
-#include "gui/edit_modals.hpp"  // IsEditModalOpen — the toggle must not also trip the card's click handler
+#include "gui/edit_modals.hpp"  // IsEditModalOpen / OpenEditModal / GetEditModalTarget — the toggle must not also trip the card's click handler, and the delete cases below read the editor's binding
 #include "gui/gui_state.hpp"
 #include "imgui_internal.h"  // ImGuiWindow — a card's widgets are not addressable by path; see CardWindow
 #include "test_gui_shared.hpp"
@@ -67,6 +67,51 @@ void AddSecondEntryOnItsOwnSlot(ImGuiTestContext* ctx) {
   gui::g_state.layers[0].entries.push_back(card);
   gui::g_thumbnail_cache.OnLayerStructureChanged();
   ctx->Yield(3);
+}
+
+// Three entries in layer 0, each on a crystal slot and a filter slot of its own, with values
+// distinct enough that a slot written with the wrong entry's buffer cannot compare equal.
+//
+// Independent slots are the point: with two cards sharing a pool slot, "the survivor's crystal was
+// overwritten" and "the survivor legitimately sees its own linked slot change" are the same pixels.
+void MakeThreeIndependentEntries(ImGuiTestContext* ctx) {
+  auto& entries = gui::g_state.layers[0].entries;
+  static const char* const kRaypaths[] = { "3-5-7", "3-1-5", "3-2-6" };
+  for (int i = 0; i < 3; ++i) {
+    if (i > 0) {
+      gui::EntryCard card;
+      card.crystal_id = static_cast<int>(gui::g_state.crystals.size());
+      gui::g_state.crystals.emplace_back();
+      entries.push_back(card);
+    }
+    gui::g_state.crystals[entries[i].crystal_id].height = 1.0f + static_cast<float>(i);
+    gui::FilterConfig f;
+    f.SetRaypath(gui::RaypathParams{ kRaypaths[i] });
+    gui::SetFilter(gui::g_state, entries[i], f);
+  }
+  gui::g_thumbnail_cache.OnLayerStructureChanged();
+  ctx->Yield(3);
+  IM_CHECK_SILENT(entries.size() == 3);
+}
+
+// Open the editor on one entry the way the production default leaves it: Immediate mode, so it is a
+// plain window and the cards behind it stay clickable, parked off to the right so the rail is not
+// covered — which is how a user who dragged it aside (or onto a second display, this window can
+// become its own OS viewport) leaves it without noticing it is still open.
+//
+// Driven through OpenEditModal rather than by clicking the card, because a click on the card is
+// itself one of the things the editor's presence changes; what these cases are about starts once it
+// is open.
+void OpenImmediateEditorOnEntry(ImGuiTestContext* ctx, int entry_idx) {
+  gui::g_state.modal_immediate_mode = true;
+  gui::EditRequest req{ gui::EditTarget::kCrystal, /*layer_idx=*/0, /*entry_idx=*/entry_idx };
+  gui::OpenEditModal(req, gui::g_state);
+  ctx->Yield(4);
+  IM_CHECK_SILENT(gui::IsEditModalOpen());
+  if (ImGuiWindow* w = ctx->GetWindowByRef("Edit Entry")) {
+    ctx->WindowMove("Edit Entry", ImVec2(ImGui::GetIO().DisplaySize.x - w->Size.x, 0.0f));
+    ctx->Yield(2);
+  }
 }
 
 // The Colors window one case parks over the cards, closed on every exit path.
@@ -1256,6 +1301,100 @@ void RegisterEntryManagementTests(ImGuiTestEngine* engine) {
                     ref.name, ref.value_left, rows[i].value_left - ref.value_left);
         }
       }
+    };
+  }
+
+  // ===================================================================================
+  // Deleting a card while the Edit Entry editor is open.
+  //
+  // The editor binds its target by INDEX (g_modal_layer_idx / g_modal_entry_idx), and a delete is
+  // the one operation that changes what an index means: erase() shifts every later element up one.
+  // In Immediate mode the editor is an ordinary window rather than a blocking popup, so the rail's
+  // x is reachable while it is open, and its per-frame CommitAllBuffersImmediate keeps writing the
+  // buffers into whatever entry now sits at the bound index. The only case the pre-existing bounds
+  // guard in RenderEditModals catches is the bound index falling off the END of the vector; delete
+  // anything before it and the index stays in range while pointing at a different entry, so the
+  // deleted card's crystal and filter get written over its neighbour's pool slots. That is what the
+  // beta report "whatever lmc I open, the card below will be closed" actually is: the card was not
+  // closed, its contents were overwritten with the deleted card's.
+  //
+  // Both cases assert on the POOL slots (crystals[...] / filters[...]), not on the cards, because
+  // the entry struct only carries ids — a card that kept its id while its slot was rewritten looks
+  // untouched from the card side and is exactly the defect.
+  // ===================================================================================
+
+  // Delete the very card the editor is bound to. The editor must close, and the entry that shifts
+  // up into the freed index must keep its own crystal and filter.
+  {
+    ImGuiTest* t =
+        IM_REGISTER_TEST(engine, "entry_management", "deleting_the_bound_card_closes_the_editor_it_belongs_to");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      const ScopedPopups popup_guard(ctx);
+      ctx->Yield(2);
+      MakeThreeIndependentEntries(ctx);
+
+      const int cid1 = gui::g_state.layers[0].entries[1].crystal_id;
+      const int fid1 = *gui::g_state.layers[0].entries[1].filter_id;
+      const gui::CrystalConfig crystal_before = gui::g_state.crystals[cid1];
+      const gui::FilterConfig filter_before = gui::g_state.filters[fid1];
+
+      OpenImmediateEditorOnEntry(ctx, 0);
+      if (ctx->IsError()) {
+        return;
+      }
+
+      ctx->ItemClick("**/" ICON_FA_XMARK "##del_0_0");
+      ctx->Yield(6);
+
+      IM_CHECK_EQ(static_cast<int>(gui::g_state.layers[0].entries.size()), 2);
+      // The survivor kept its identity...
+      IM_CHECK_EQ(gui::g_state.layers[0].entries[0].crystal_id, cid1);
+      IM_CHECK_EQ(*gui::g_state.layers[0].entries[0].filter_id, fid1);
+      // ...and both of its pool slots still hold what they held. Crystal and filter are asserted
+      // separately: they are written by two different limbs of ApplyBuffersToEntry, and a fix that
+      // only reached one of them would pass a crystal-only check.
+      IM_CHECK(gui::g_state.crystals[cid1] == crystal_before);
+      IM_CHECK(gui::g_state.filters[fid1] == filter_before);
+      // The editor has nothing left to edit, so it is closed rather than silently re-aimed.
+      IM_CHECK(!gui::IsEditModalOpen());
+    };
+  }
+
+  // Delete a card ABOVE the one being edited. The editor must follow its entry down to the new
+  // index rather than stay on the number and start writing into the entry below.
+  {
+    ImGuiTest* t =
+        IM_REGISTER_TEST(engine, "entry_management", "deleting_a_card_above_the_editor_keeps_it_on_the_same_entry");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      const ScopedPopups popup_guard(ctx);
+      ctx->Yield(2);
+      MakeThreeIndependentEntries(ctx);
+
+      const int edited_cid = gui::g_state.layers[0].entries[1].crystal_id;
+      // Entry 2 is the one the stale binding would land on once entry 0 is gone.
+      const int cid2 = gui::g_state.layers[0].entries[2].crystal_id;
+      const int fid2 = *gui::g_state.layers[0].entries[2].filter_id;
+      const gui::CrystalConfig crystal_before = gui::g_state.crystals[cid2];
+      const gui::FilterConfig filter_before = gui::g_state.filters[fid2];
+
+      OpenImmediateEditorOnEntry(ctx, 1);
+      if (ctx->IsError()) {
+        return;
+      }
+
+      ctx->ItemClick("**/" ICON_FA_XMARK "##del_0_0");
+      ctx->Yield(6);
+
+      IM_CHECK_EQ(static_cast<int>(gui::g_state.layers[0].entries.size()), 2);
+      IM_CHECK(gui::IsEditModalOpen());
+      // Same entry, new index.
+      IM_CHECK_EQ(gui::GetEditModalTarget().entry_idx, 0);
+      IM_CHECK_EQ(gui::g_state.layers[0].entries[0].crystal_id, edited_cid);
+      // The entry below it was never the editor's business.
+      IM_CHECK(gui::g_state.crystals[cid2] == crystal_before);
+      IM_CHECK(gui::g_state.filters[fid2] == filter_before);
     };
   }
 }

--- a/test/unit-correctness/gui/test_edit_modal_delete_binding.cpp
+++ b/test/unit-correctness/gui/test_edit_modal_delete_binding.cpp
@@ -1,0 +1,199 @@
+// The edit modal binds its target by INDEX, and deleting from a vector is the one operation that
+// changes what an index means.
+//
+// `g_modal_layer_idx` / `g_modal_entry_idx` name a position, not an object. `erase()` shifts every
+// later element up one, so after a delete the same pair of numbers can denote a different entry —
+// and in Immediate mode the modal is a plain window that keeps writing its edit buffers into
+// whatever now sits at those numbers, one write per frame. The bounds guard in RenderEditModals
+// only catches the index falling off the END of the vector, which is the single case where the
+// mistake is not silent.
+//
+// NotifyEntryDeleted / NotifyLayerDeleted are the whole of the repair: the delete site tells the
+// binding what just happened to the index space, and the binding either follows its entry to the
+// new index or closes because that entry is gone. What is asserted here is that arithmetic, over
+// every ordering of (deleted index, bound index) plus the two no-op cases — a proposition about one
+// unit, with no frame and no input event in it, so it belongs here rather than in gui_test. The
+// end-to-end half — that panels.cpp's delete button actually reaches these functions — needs a real
+// frame and lives in test/gui/functional/test_entry_management.cpp.
+//
+// What a user sees when this breaks: they delete one card and a DIFFERENT card's crystal and filter
+// are replaced by the deleted one's, with no error anywhere.
+
+#include <gtest/gtest.h>
+
+#include "gui/edit_modals.hpp"
+#include "gui/gui_state.hpp"
+#include "gui/panels.hpp"
+
+namespace gui = lumice::gui;
+
+namespace {
+
+// A document with `layer_count` layers of `entries_per_layer` entries, every entry on a crystal
+// slot of its own so a slot's identity names exactly one entry.
+gui::GuiState MakeDoc(int layer_count, int entries_per_layer) {
+  gui::GuiState s;
+  s.crystals.clear();
+  s.layers.clear();
+  for (int l = 0; l < layer_count; ++l) {
+    gui::Layer layer;
+    for (int e = 0; e < entries_per_layer; ++e) {
+      gui::EntryCard card;
+      card.crystal_id = static_cast<int>(s.crystals.size());
+      gui::CrystalConfig c;
+      c.height = 1.0f + static_cast<float>(s.crystals.size());
+      s.crystals.push_back(c);
+      layer.entries.push_back(card);
+    }
+    s.layers.push_back(layer);
+  }
+  return s;
+}
+
+// The modal statics are file-level in edit_modals.cpp and therefore shared by every case in this
+// binary; a case that returned early on a failed expectation would otherwise leave the next one
+// starting from an open modal.
+class EditModalDeleteBinding : public ::testing::Test {
+ protected:
+  void SetUp() override { gui::ResetModalState(); }
+  void TearDown() override { gui::ResetModalState(); }
+
+  // The crystal slot the modal is currently aimed at, or -1 if it is closed or aimed out of range.
+  static int BoundCrystalId(const gui::GuiState& s) {
+    const gui::EditModalTarget t = gui::GetEditModalTarget();
+    if (t.layer_idx < 0 || t.layer_idx >= static_cast<int>(s.layers.size())) {
+      return -1;
+    }
+    const auto& entries = s.layers[t.layer_idx].entries;
+    if (t.entry_idx < 0 || t.entry_idx >= static_cast<int>(entries.size())) {
+      return -1;
+    }
+    return entries[t.entry_idx].crystal_id;
+  }
+
+  static void Open(gui::GuiState& s, int layer_idx, int entry_idx) {
+    gui::EditRequest req{ gui::EditTarget::kCrystal, layer_idx, entry_idx };
+    gui::OpenEditModal(req, s);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Entry deletes, over the three orderings of (deleted index, bound index).
+// ---------------------------------------------------------------------------
+
+TEST_F(EditModalDeleteBinding, DeletingTheBoundEntryClosesTheModal) {
+  gui::GuiState s = MakeDoc(1, 3);
+  Open(s, 0, 1);
+  ASSERT_TRUE(gui::IsEditModalOpen());
+
+  s.layers[0].entries.erase(s.layers[0].entries.begin() + 1);
+  gui::NotifyEntryDeleted(0, 1);
+
+  EXPECT_FALSE(gui::IsEditModalOpen());
+}
+
+TEST_F(EditModalDeleteBinding, DeletingAnEntryBeforeTheBoundOneFollowsItDown) {
+  gui::GuiState s = MakeDoc(1, 3);
+  Open(s, 0, 2);
+  const int edited = BoundCrystalId(s);
+  ASSERT_EQ(edited, s.layers[0].entries[2].crystal_id);
+
+  s.layers[0].entries.erase(s.layers[0].entries.begin() + 0);
+  gui::NotifyEntryDeleted(0, 0);
+
+  EXPECT_TRUE(gui::IsEditModalOpen());
+  EXPECT_EQ(gui::GetEditModalTarget().entry_idx, 1);
+  // The index moved because the entry did; asserting the slot is what separates that from an
+  // index that merely happens to be in range.
+  EXPECT_EQ(BoundCrystalId(s), edited);
+}
+
+TEST_F(EditModalDeleteBinding, DeletingAnEntryAfterTheBoundOneLeavesItAlone) {
+  gui::GuiState s = MakeDoc(1, 3);
+  Open(s, 0, 0);
+  const int edited = BoundCrystalId(s);
+
+  s.layers[0].entries.erase(s.layers[0].entries.begin() + 2);
+  gui::NotifyEntryDeleted(0, 2);
+
+  EXPECT_TRUE(gui::IsEditModalOpen());
+  EXPECT_EQ(gui::GetEditModalTarget().entry_idx, 0);
+  EXPECT_EQ(BoundCrystalId(s), edited);
+}
+
+TEST_F(EditModalDeleteBinding, AnEntryDeleteInAnotherLayerDoesNotMoveTheBinding) {
+  gui::GuiState s = MakeDoc(2, 3);
+  Open(s, 1, 0);
+  const int edited = BoundCrystalId(s);
+
+  s.layers[0].entries.erase(s.layers[0].entries.begin() + 0);
+  gui::NotifyEntryDeleted(0, 0);
+
+  EXPECT_TRUE(gui::IsEditModalOpen());
+  EXPECT_EQ(gui::GetEditModalTarget().layer_idx, 1);
+  EXPECT_EQ(gui::GetEditModalTarget().entry_idx, 0);
+  EXPECT_EQ(BoundCrystalId(s), edited);
+}
+
+// ---------------------------------------------------------------------------
+// Layer deletes. Same defect, same index space, one level up: the layer x button is reachable
+// while the Immediate-mode editor is open, and deleting a layer above the bound one leaves
+// g_modal_layer_idx in range and pointing at the layer that shifted up into it.
+// ---------------------------------------------------------------------------
+
+TEST_F(EditModalDeleteBinding, DeletingTheBoundLayerClosesTheModal) {
+  gui::GuiState s = MakeDoc(3, 2);
+  Open(s, 1, 0);
+  ASSERT_TRUE(gui::IsEditModalOpen());
+
+  s.layers.erase(s.layers.begin() + 1);
+  gui::NotifyLayerDeleted(1);
+
+  EXPECT_FALSE(gui::IsEditModalOpen());
+}
+
+TEST_F(EditModalDeleteBinding, DeletingALayerBeforeTheBoundOneFollowsItDown) {
+  gui::GuiState s = MakeDoc(3, 2);
+  Open(s, 2, 1);
+  const int edited = BoundCrystalId(s);
+
+  s.layers.erase(s.layers.begin() + 0);
+  gui::NotifyLayerDeleted(0);
+
+  EXPECT_TRUE(gui::IsEditModalOpen());
+  EXPECT_EQ(gui::GetEditModalTarget().layer_idx, 1);
+  EXPECT_EQ(gui::GetEditModalTarget().entry_idx, 1);
+  EXPECT_EQ(BoundCrystalId(s), edited);
+}
+
+TEST_F(EditModalDeleteBinding, DeletingALayerAfterTheBoundOneLeavesItAlone) {
+  gui::GuiState s = MakeDoc(3, 2);
+  Open(s, 0, 1);
+  const int edited = BoundCrystalId(s);
+
+  s.layers.erase(s.layers.begin() + 2);
+  gui::NotifyLayerDeleted(2);
+
+  EXPECT_TRUE(gui::IsEditModalOpen());
+  EXPECT_EQ(gui::GetEditModalTarget().layer_idx, 0);
+  EXPECT_EQ(BoundCrystalId(s), edited);
+}
+
+// ---------------------------------------------------------------------------
+// With no modal open there is no binding to keep, and the stale indices left behind are overwritten
+// wholesale by the next OpenEditModal. Both notifications must be inert rather than resurrect one.
+// ---------------------------------------------------------------------------
+
+TEST_F(EditModalDeleteBinding, NotificationsAreInertWhileNoModalIsOpen) {
+  gui::GuiState s = MakeDoc(2, 3);
+  ASSERT_FALSE(gui::IsEditModalOpen());
+
+  gui::NotifyEntryDeleted(0, 0);
+  gui::NotifyLayerDeleted(0);
+
+  EXPECT_FALSE(gui::IsEditModalOpen());
+  EXPECT_EQ(gui::GetEditModalTarget().layer_idx, -1);
+  EXPECT_EQ(gui::GetEditModalTarget().entry_idx, -1);
+}
+
+}  // namespace


### PR DESCRIPTION
## What broke

The Edit Entry editor binds its target by **index** (`g_modal_layer_idx` / `g_modal_entry_idx`), and `erase()` is the one operation that changes what an index means. In Immediate mode — the shipped default — the editor is an ordinary `ImGui::Begin` window rather than a blocking popup, so the rail's `×` is reachable while it is open, and its per-frame `CommitAllBuffersImmediate → ApplyBuffersToEntry` keeps writing the edit buffers into whatever entry now sits at the bound index.

The only case the pre-existing bounds guard in `RenderEditModals` catches is the binding falling off the **end** of the vector. Delete anything before it and the index stays in range while pointing at a different entry, whose crystal *and* filter pool slots are then overwritten with the deleted entry's contents — silently, once per frame.

That is what the beta report

> The card closing problem is right now a "default". Whatever lmc I open, the card below will be closed.

actually is: the card below was not closed. Its contents were replaced with the deleted card's, and its label renumbered.

## The fix

Two notifications called from the two delete sites in `panels.cpp`, which are the only places that know which index went away:

| relation | outcome |
|---|---|
| deleted **==** bound | close the modal (nothing left to edit) |
| deleted **<** bound | decrement, so the binding follows its entry down |
| deleted **>** bound | nothing |
| no modal open / other layer | inert |

Kept as one function per flavour rather than a bounds check at each site that reads the binding — the rule lives in one place instead of being re-derived per reader.

## Scope note for the owner

The issue was written about **entry** deletion. Auditing the delete sites turned up `panels.cpp`'s **layer** delete (`state.layers.erase(...)`, the layer header's `×`) as a literally isomorphic instance of the same root cause: same binding, same shared bounds guard, same Immediate-mode write loop. With three layers and the editor bound to layer 1, deleting layer 0 leaves `g_modal_layer_idx == 1` in range and pointing at the old layer 2. It is fixed here too, in the same shape (`NotifyLayerDeleted`).

If you would rather that half be its own change, dropping `NotifyLayerDeleted`, its call site and its four unit cases leaves the entry half untouched.

None of AC7's three named out-of-scope areas were touched: Immediate/Staged mode is unchanged, `ApplyBuffersToEntry`'s semantics are unchanged, and the click-the-card-to-open-the-editor interaction is unchanged.

## Red state

The first commit wires both notifications in as **no-ops**, so it is behaviourally identical to today's code, and the new cases are red against it:

- `gui_test`, 0/2 — case 1 on `crystals[cid1] == crystal_before` (the pool slot was overwritten), case 2 on `GetEditModalTarget().entry_idx [1] == 0 [0]` (the binding did not follow).
- `gui_unit_test`, 4 of 8 red — the `==` and `<` relations on both flavours. The other four assert that nothing changes, so passing under a no-op is correct.

The second commit fills the bodies in; all 10 go green.

## Verification

- `./scripts/test.sh quick` → `RESULT: PASS` (ctest 36s / fast-e2e 72s / gui-correctness 49s; `gui_test` 356/356)
- `ctest -R LumiceGuiUnitTest` → 230 passed, `EditModalDeleteBinding` 8/8
- `check_policies.py`, `check_new_refs.py --range`, `check_new_gui_tests.py`, `check_loop_fatal_asserts.py`, `format.sh --check` → all exit 0

## Test placement

`test/gui/functional/test_entry_management.cpp` takes the two cases that need a real frame and a real click on the rail's `×` — they are what proves the delete sites actually reach the notifications. `test/unit-correctness/gui/test_edit_modal_delete_binding.cpp` (new, `gui_unit_test`) takes the index arithmetic itself: one unit, no frame, no input event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019AbQUG8KwvV5EN2uUahauH