### PR TITLE
feat(config): give the three grid families a line switch of their own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,21 @@ it was thinking of and false of the C struct beside it.
 
 ## [Unreleased]
 
+### Added
+- **A config can now ask for a grid family's numbers without its lines.** The parallels, the
+  meridians and the sun's angular-distance circles each gain a line switch of their own —
+  `grid.elevation_line`, `grid.longitude_line`, `grid.angular_dist_line`, all defaulting to true, so
+  every existing config renders exactly as before. Previously only the horizon could be asked for
+  text without a line; for the other three, "do not draw me" could only be said by removing their
+  angles, which removed their labels too. The GUI's exported config follows suit: turning grid or
+  circle **lines** off while leaving their **labels** on used to drop the numbers from the CLI
+  render with no warning, and now exports exactly what the preview shows.
+- **`LUMICE_RenderParam` gains `elevation_line` / `longitude_line` / `angular_dist_line`**
+  (`LUMICE_API_VERSION` 425 → 426, appended at the end of the struct — recompile against the new
+  header). Note the defaults run the other way from every other annotation flag: the JSON default is
+  *on*, so a zero-initialized struct asks for no lines even when it carries a full angle list. Set
+  the three fields, or go through JSON.
+
 ## [4.5.0] - 2026-09-06
 
 ### Added

--- a/doc/gui-state-governance.md
+++ b/doc/gui-state-governance.md
@@ -262,10 +262,19 @@
 | `visible` | 半球裁剪：恒 `full` vs 用户的 |
 | `background` | 显示期合成 vs CLI 烤进图里 |
 | `resolution` | 2:1 纹理 vs 用户的画幅 |
+| `front` | 第二道裁剪：恒关 vs 用户的开关（与 `visible` 正交，见 §9.3） |
 | `grid.horizon` | 恒开 vs 用户的开关 |
+| `grid.angular_dist` / `grid.elevation` / `grid.longitude` | 角度表：commit 臂留空 vs export 臂写用户的表（理由见 §9.4） |
+| `grid.horizon_label` / `grid.label` / `grid.angular_dist_label` | 文字标注开关：commit 臂恒关 vs 用户的开关。文字烤进纹理会被重投影一起重采样，再被预览自己的 label 层画第二遍 |
+| `grid.elevation_line` / `grid.longitude_line` / `grid.angular_dist_line` | 三族各自的**线**开关：commit 臂恒 `true` vs 用户的开关 |
+| `grid.markers` / `grid.markers_opacity` / `grid.markers_radius_px` | 参考点标记：commit 臂留空表 vs export 臂写全六项 + 家族级外观 |
 
-⚠️ **`grid` 是按子键豁免的，不是整键。** 只有 `horizon` 分叉，其余 grid 子字段（counts、colors…）
-在两条臂上应当相同；整键 erase 会连带停止检查它们是否意外漂移。
+⚠️ **`grid` 是按子键豁免的，不是整键。** 上表列出的是 `grid` 下**已分叉**的十三个子键；其余 grid
+子字段（每条线的 colors / opacity…）在两条臂上应当相同，整键 erase 会连带停止检查它们是否意外漂移。
+
+⚠️ 三个 `*_line` 子键有一处**只靠声明成立**的特殊性：commit 臂恒 `true`、export 臂写用户开关，
+而那个用例的 fixture 恰好把两个 GUI 线开关都置为开 ⇒ 不把它们加进清单，比较照样通过。清单在这里
+不是「让红转绿」的补丁，而是唯一记录了「这三个键允许分叉」的地方。
 
 ### 9.3 三处具名例外（有意不分叉，且都不是遗漏）
 
@@ -283,8 +292,9 @@
 ### 9.4 改动纪律
 
 - 动分叉面（增/删/改一个键）时，**先在本节说明理由再改清单**。⛔ 不得因为那道闸红了就把键加进清单绕开。
-- **辅助线相关的键全部已经分叉：`grid.horizon` / `grid.angular_dist` / `grid.elevation` /
-  `grid.longitude` 四个子键在 `kDivergingKeys` 处按子键豁免。**
+- **辅助线相关的键全部已经分叉**：四个线族的角度表与开关（`grid.horizon` / `grid.angular_dist` /
+  `grid.elevation` / `grid.longitude`）、三个文字标注开关，以及后来补上的三个 `*_line` 开关，
+  在 `kDivergingKeys` 处一律按子键豁免。
   上一版这里写的是「`grid.angular_dist` 已分叉、`grid.elevation` 仍不分叉」，后半句已经过期。
   裁定结果是上面两个候选里的**第一个**：core 算注解几何（`LUMICE_ComputeAnnotationOverlay`），
   但 GUI 仍然自己画 overlay，因为标注属于**成品图**而不是那张全天纹理——往纹理里烤线会被重投影
@@ -300,6 +310,20 @@
   （附带一条仍然成立的观察：commit 臂的 `horizon` 值是**惰性**的——GUI 消费
   `LUMICE_FrameGetRawXyz`，而 horizon 画在 `PostSnapshot` 的 mono 烤图里，GUI 从来不读它；
   `angular_dist` 在 commit 臂留空是同一个理由的另一面。）
+- **`grid.elevation_line` / `grid.longitude_line` / `grid.angular_dist_line` 三个子键的加入理由**
+  （按本节纪律，先在这里说明再改清单）：在它们存在之前，这三族「画不画线」等价于「角度表空不空」，
+  于是 export 臂遇到「用户开着 label、关着 line」这个合法 GUI 状态时只有两条路——填表（画出用户
+  关掉的线）或不填（丢掉用户开着的字，core 的标注文字与线读同一张角度表）。当时选了后者。
+  `grid.horizon` 从来不用做这个取舍，因为它的线本来就有独立开关。补上这三个开关之后，
+  **export 臂改为「line 或 label 任一为真就填表」，再用新键忠实写出线开关本身**，取舍消失。
+  三个开关按 core 的表结构拆成三个（而不是仿 label 那样「grid 合并 + angular_dist 独立」两个）：
+  label 的合并粒度是被「GUI 只有一个 label 控件」这个下游事实反向决定的例外，不是 schema 通例；
+  GUI 侧今天仍只有一个 `show_grid_line` 控件，导出时把同一个值写进 `elevation_line` 与
+  `longitude_line` 两个字段。
+  ⭐ 由此**多出一处此前不可达的路径**：角度表的展开与 `LUMICE_MAX_CONFIG_GRID_LINES` 溢出检查
+  现在也发生在「只开 label、关 line」的场景下，所以那个场景也会触发「拒绝导出 + 告警」。方向是
+  对的（label 同样要用展开后的表，截断出来的是一批残缺的**数字**），但它是本次改动里唯一一处
+  行为变宽，单独有一条用例守着。
 - 两条臂**是否真的只在清单上分叉**由上面那个用例守；两条臂**各自是否正确**由跨进程的
   CLI↔GUI 出图对照守（`test/gui/parity/`，见 `doc/testing-architecture.md` §4.10）。
   两道闸问的是不同的问题，缺一不可。

--- a/src/config/config_compare.hpp
+++ b/src/config/config_compare.hpp
@@ -118,7 +118,9 @@ inline bool operator==(const RenderConfig& a, const RenderConfig& b) {
          std::equal(std::begin(a.ray_color_), std::end(a.ray_color_), std::begin(b.ray_color_)) &&
          a.intensity_factor_ == b.intensity_factor_ && a.overlap_ == b.overlap_ && a.ev_mode_ == b.ev_mode_ &&
          a.angular_dist_grid_ == b.angular_dist_grid_ && a.elevation_grid_ == b.elevation_grid_ &&
-         a.longitude_grid_ == b.longitude_grid_ && a.horizon_ == b.horizon_ && a.zenith_nadir_ == b.zenith_nadir_ &&
+         a.longitude_grid_ == b.longitude_grid_ && a.horizon_ == b.horizon_ &&
+         a.elevation_grid_line_ == b.elevation_grid_line_ && a.longitude_grid_line_ == b.longitude_grid_line_ &&
+         a.angular_dist_grid_line_ == b.angular_dist_grid_line_ && a.zenith_nadir_ == b.zenith_nadir_ &&
          a.markers_ == b.markers_ && a.markers_opacity_ == b.markers_opacity_ &&
          a.markers_radius_px_ == b.markers_radius_px_;
 }

--- a/src/config/config_manager.cpp
+++ b/src/config/config_manager.cpp
@@ -124,6 +124,18 @@ RenderConfig ParseRenderConfig(const nlohmann::json& j_render, const ConfigManag
     if (j_grid.contains("horizon")) {
       j_grid.at("horizon").get_to(render.horizon_);
     }
+    // The other three families' line switches. Nothing is written when the key is absent: the
+    // members already default to true, which is what makes a document that predates these keys
+    // render exactly as it did. Twin of the same three reads in c_api.cpp's decoder.
+    if (j_grid.contains("elevation_line")) {
+      j_grid.at("elevation_line").get_to(render.elevation_grid_line_);
+    }
+    if (j_grid.contains("longitude_line")) {
+      j_grid.at("longitude_line").get_to(render.longitude_grid_line_);
+    }
+    if (j_grid.contains("angular_dist_line")) {
+      j_grid.at("angular_dist_line").get_to(render.angular_dist_grid_line_);
+    }
     // The three text-label switches. Read next to the lines they annotate rather than under a
     // "labels" object of their own: "grid.label" is a property of the grid, and nesting it one
     // level deeper would give one concept two paths into the same object.

--- a/src/config/render_config.cpp
+++ b/src/config/render_config.cpp
@@ -265,6 +265,12 @@ void to_json(nlohmann::json& j, const RenderConfig& r) {
   j["grid"].emplace("elevation", r.elevation_grid_);
   j["grid"].emplace("longitude", r.longitude_grid_);
   j["grid"].emplace("horizon", r.horizon_);
+  // The other three families' line switches, beside the lists they gate. No "grid" in the key
+  // names: they already sit under "grid", exactly as "elevation" / "longitude" / "angular_dist"
+  // above drop the suffix their C++ members carry.
+  j["grid"].emplace("elevation_line", r.elevation_grid_line_);
+  j["grid"].emplace("longitude_line", r.longitude_grid_line_);
+  j["grid"].emplace("angular_dist_line", r.angular_dist_grid_line_);
   j["grid"].emplace("horizon_label", r.horizon_label_);
   j["grid"].emplace("label", r.grid_label_);
   j["grid"].emplace("angular_dist_label", r.angular_dist_label_);
@@ -296,6 +302,15 @@ bool NeedsRebuild(const RenderConfig& a, const RenderConfig& b) {
   // accumulates into, so a config that edits them reaches an existing consumer through ResetWith()
   // with no rebuild — which is why RebuildMarkerPoints() is called from there as well as from the
   // constructor.
+  // Still 224 after the three family LINE switches (elevation_grid_line_ / longitude_grid_line_ /
+  // angular_dist_grid_line_), and the reason is worth stating because it is not the reason the
+  // label switches were free: the bool run grew from four bytes to eight, and the four bytes that
+  // paid for it came from the padding between ZenithNadirParam (4-byte aligned, 24 bytes) and
+  // markers_ (8-byte aligned), which the longer run now closes. So an UNCHANGED number here is
+  // once again only safe once the new fields have been classified — and these three are
+  // APPEARANCE, for the same reason the label switches are: they decide whether a line is
+  // composited onto the finished image, never the buffer it accumulates into, so a config that
+  // flips one reaches an existing consumer through ResetWith() with no rebuild.
   static_assert(sizeof(RenderConfig) == 224, "Update NeedsRebuild when RenderConfig fields change");
   // Compare layout-affecting fields only. Appearance fields (background, ray_color,
   // intensity_factor, ev_mode, grids) are handled by ResetWith() without rebuild.

--- a/src/config/render_config.hpp
+++ b/src/config/render_config.hpp
@@ -192,6 +192,34 @@ struct RenderConfig {
   // no `grid.outline` key at all). Turning an annotation on for every render is a product decision
   // nobody has made, so the default states the one thing that is certain: draw it when asked.
   bool horizon_ = false;
+  // The other three families' LINE switches — the parallels, the meridians and the
+  // angular-distance circles — one per list beside it, and the same kind of flag `horizon_` is.
+  //
+  // WHY THEY EXIST AT ALL: without them "is this family drawn" was the same question as "is its
+  // angle list non-empty", so a caller that wanted the family's NUMBERS but not its LINES had no
+  // way to say so — filling the list to get the labels drew the lines too. Only the horizon could
+  // express that combination, and the GUI's exporter had to choose between drawing lines the user
+  // had switched off and dropping text the user had switched on (src/gui/file_io.cpp).
+  //
+  // TRUE by default, the opposite of `horizon_` above, and the difference is not an inconsistency:
+  // an absent `horizon` key used to draw NOTHING (the flag is what turns the annotation on), while
+  // an absent `elevation_line` key belongs to a config whose non-empty `elevation` list already
+  // drew its lines. Opt-in there preserves "no annotation nobody asked for"; default-on here
+  // preserves "every config written before this field renders exactly as it did".
+  //
+  // WHAT THEY GATE, stated so core and the GUI do not each infer it (the *_label_ block below
+  // makes the same statement for the text): the LINE's own compositing in
+  // RenderConsumer::PostSnapshot, and nothing else. The label geometry is NOT gated by them — a
+  // `grid_label_` with `elevation_grid_line_` false still produces the parallels' anchors, exactly
+  // as `horizon_label_` with `horizon_` false produces the horizon's.
+  //
+  // THE TWO WAYS A FAMILY CAN BE ABSENT are not a priority rule, because they never contradict:
+  // an EMPTY list has no line to draw whatever this flag says (the flag is then unobservable), and
+  // a non-empty list with the flag false draws no line but keeps its labels. There is no third
+  // reading for a consumer to pick.
+  bool elevation_grid_line_ = true;
+  bool longitude_grid_line_ = true;
+  bool angular_dist_grid_line_ = true;
   // Draw the TEXT labels — the angle each line stands for, "22\u00b0" and the like — next to the
   // three line families. One switch per family, mirroring the GUI's three
   // (show_horizon_label / show_grid_label / show_sun_circles_label, gui_state.hpp), because those
@@ -200,7 +228,9 @@ struct RenderConfig {
   //
   // TWO LAYERS, and they are not the same statement. Whether the label GEOMETRY is computed is
   // what these fields decide, independently of whether the family's own line is drawn: a
-  // horizon_label_ with horizon_ false still produces the anchors. Whether the label is VISIBLE
+  // horizon_label_ with horizon_ false still produces the anchors, and since the three line
+  // switches above exist the same holds for every other family (grid_label_ with
+  // elevation_grid_line_ false, and so on). Whether the label is VISIBLE
   // once drawn is NOT independent — the compositor gives a label its family's own colour and
   // opacity (GridLineParam::opacity_ for the grid families, the horizon's fixed constants for the
   // horizon), so a line at opacity 0 takes its labels with it. That is the GUI's behaviour too

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -1915,6 +1915,12 @@ ScenePtr BuildScene(const GuiState& state, SceneIntent intent, FilterOverflowInf
       // a restricted special case of it, not the other way round. The width field is left at its
       // default: nothing reads it (the mask generator derives its own half-width), so writing the
       // GUI's line width there would export a number that changes no pixel.
+      // No overflow check here, unlike the grid below: `state.sun_circle_angles` is not an expanded
+      // list, it is the user's own typed list, and it is capped at `kMaxSunCircles` (16) the moment
+      // an angle is added (gui_constants.hpp / sun_circle_rules.hpp) — well under
+      // `LUMICE_MAX_CONFIG_GRID_LINES` (64). Widening this gate to `|| label` therefore does not
+      // open a reachable overflow path the way it does for the grid, whose list is FOV-derived and
+      // can genuinely exceed the ABI cap; there is nothing to refuse here.
       dst.angular_dist_count = 0;
       if (state.show_sun_circles_line || state.show_sun_circles_label) {
         FillGridLines(state.sun_circle_angles, state.sun_circles_color, state.sun_circles_alpha, dst.angular_dist,

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -1901,15 +1901,14 @@ ScenePtr BuildScene(const GuiState& state, SceneIntent intent, FilterOverflowInf
       // off. What differs from the horizon is that these carry data, not just a flag — the angles
       // are the user's own list.
       //
-      // The LINE switch gates the list, and the label switch above does NOT widen that gate — a
-      // known and accepted limit rather than an oversight. For the two grid families and the
-      // circles, core's "is this family drawn" question IS "is its angle list non-empty": there is
-      // no separate line flag to turn off. So a GUI state of "circles' labels on, circles' lines
-      // off" has no faithful encoding — filling the list to get the numbers would draw the lines
-      // the user switched off, which is strictly worse than dropping the numbers. Only the horizon,
-      // whose line has a flag of its own, can express that combination (`horizon_label` with
-      // `horizon` zero). Giving the other two families the same expressiveness means giving core a
-      // per-family line flag, which is a schema change, not a fill-site change.
+      // TWO SWITCHES, TWO FIELDS. The angle list is filled when EITHER switch is on, because the
+      // list is what both of them need — core draws a family's numbers off the same angles it draws
+      // its lines from — and `angular_dist_line` then says which of the two the user actually
+      // asked for. Reading only the line switch for the list is what this arm used to do, and it
+      // dropped the numbers of anyone who had turned the lines off and the labels on; filling the
+      // list unconditionally would instead draw lines they had switched off. Neither trade is
+      // needed any more: core grew a per-family line flag in v4.26, which is what makes "labels
+      // without lines" expressible at all.
       //
       // Every entry gets the SAME colour and opacity because the GUI has one colour picker and one
       // alpha slider for the whole set; core's schema styles each line individually and the GUI is
@@ -1917,10 +1916,11 @@ ScenePtr BuildScene(const GuiState& state, SceneIntent intent, FilterOverflowInf
       // default: nothing reads it (the mask generator derives its own half-width), so writing the
       // GUI's line width there would export a number that changes no pixel.
       dst.angular_dist_count = 0;
-      if (state.show_sun_circles_line) {
+      if (state.show_sun_circles_line || state.show_sun_circles_label) {
         FillGridLines(state.sun_circle_angles, state.sun_circles_color, state.sun_circles_alpha, dst.angular_dist,
                       &dst.angular_dist_count);
       }
+      dst.angular_dist_line = state.show_sun_circles_line ? 1 : 0;
       // The coordinate grid — parallels and meridians. Same gating and same shared-appearance
       // story as the circles above, with one difference that matters: the angles are NOT a list
       // the user typed. The GUI derives them from ONE FOV-adaptive step (ComputeGridStep), and
@@ -1929,7 +1929,13 @@ ScenePtr BuildScene(const GuiState& state, SceneIntent intent, FilterOverflowInf
       // request, so the exported list is the same list the screen is showing.
       dst.elevation_grid_count = 0;
       dst.longitude_grid_count = 0;
-      if (state.show_grid_line) {
+      dst.elevation_line = state.show_grid_line ? 1 : 0;
+      dst.longitude_line = state.show_grid_line ? 1 : 0;
+      // One GUI switch writes both core fields: the panel has a single grid line control, exactly
+      // as it has a single grid label control. Core splits the two families because its schema
+      // splits their angle lists; a hand-written config can therefore draw the parallels without
+      // the meridians, which is expressiveness the GUI does not offer and does not need to.
+      if (state.show_grid_line || state.show_grid_label) {
         const float step = ComputeGridStep(r.fov);
         const std::vector<float> elevation = ComputeGridElevationAngles(step);
         const std::vector<float> longitude = ComputeGridLongitudeAngles(step);
@@ -1937,6 +1943,10 @@ ScenePtr BuildScene(const GuiState& state, SceneIntent intent, FilterOverflowInf
         // overflows the ABI cap with no unusual document involved (72 lines at a 20 deg FOV), so
         // this is a reachable state, not a defensive branch — and a silently shortened grid would
         // be a CLI render that differs from the screen while reporting success.
+        // Inside the widened gate, so it also covers the state that gate made reachable: labels on,
+        // lines off. The list is expanded there too, so it can overflow there too, and a refusal is
+        // the same right answer — the alternative would be a truncated set of NUMBERS instead of a
+        // truncated set of lines.
         const GridOverflowInfo::Family over = elevation.size() > static_cast<size_t>(LUMICE_MAX_CONFIG_GRID_LINES) ?
                                                   GridOverflowInfo::Family::kElevation :
                                               longitude.size() > static_cast<size_t>(LUMICE_MAX_CONFIG_GRID_LINES) ?
@@ -2000,7 +2010,15 @@ ScenePtr BuildScene(const GuiState& state, SceneIntent intent, FilterOverflowInf
       // time (u_front). Stated rather than left to the zero-init, so the two arms read as one
       // deliberate divergence instead of an omission.
       dst.front = 0;
-      dst.horizon = 1;  // core RenderConfig::horizon_ default (true)
+      dst.horizon = 1;  // this arm annotates the texture itself; see kDivergingKeys
+      // Core's defaults for the three family line switches, stated rather than left to the
+      // zero-init — which would mean the opposite (see the WARNING at the fields in lumice.h).
+      // Unobservable on this arm either way: it writes no angle list, so there is no line for the
+      // flags to gate. Written for the same reason `front` and `visible` above are: so the two
+      // arms read as one deliberate divergence rather than as an omission on this one.
+      dst.elevation_line = 1;
+      dst.longitude_line = 1;
+      dst.angular_dist_line = 1;
       // view / background keep their zero-initialized values, matching both the pre-v4.11
       // hardcoded encoding and core's defaults.
     }

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -203,7 +203,23 @@ extern "C" {
 // positions are recomputed on ResetWith as well. That second half is not tidiness — four of the six
 // directions are defined relative to the sun, and the sun is exactly what ResetWith can change.
 // A caller that leaves markers_count at 0 sees no change at all.
-#define LUMICE_API_VERSION 425
+//
+// BREAKING (v4.26): LUMICE_RenderParam gains a trailing block of three fields — `elevation_line`,
+// `longitude_line` and `angular_dist_line`, whether the CLI renderer draws each of those three
+// families' LINES. They are APPENDED after `markers_radius_px`, so every existing field keeps its
+// offset while sizeof() grows; a caller that was NOT recompiled hands the API a shorter struct and
+// the new fields are read past the end of it. Recompile against this header. The JSON keys are
+// "grid.elevation_line", "grid.longitude_line" and "grid.angular_dist_line".
+// This completes what v4.21 started. That version made the TEXT independent of the LINE at the
+// geometry layer, but only the horizon could actually be asked for text without its line: it was
+// the one family with a line switch (`horizon`) separate from its angle list. For the other three,
+// "draw this family" WAS "is the angle list non-empty", so a producer wanting their numbers had to
+// fill the list and get the lines with it. The GUI's exporter took the other horn and dropped the
+// numbers (src/gui/file_io.cpp), which is the defect this closes.
+// DEFAULT TRUE on the JSON side, unlike every other annotation flag in this struct — see the
+// WARNING at the fields themselves. Nothing is removed and nothing changes meaning: a config that
+// carries none of the three keys renders the pixels it always did.
+#define LUMICE_API_VERSION 426
 #define LUMICE_MAX_RENDER_RESULTS 16
 #define LUMICE_MAX_STATS_RESULTS 1
 
@@ -1007,7 +1023,10 @@ typedef struct LUMICE_RenderParam_ {
   // line stands for, formatted by core ("22\u00b0"). Opt-in, like every annotation field above.
   //
   // INDEPENDENT OF THE LINE SWITCHES, at the geometry layer only: `horizon_label` with `horizon`
-  // zero draws the horizon's numbers without its line. NOT independent at the compositing layer —
+  // zero draws the horizon's numbers without its line, and since v4.26 gave the other three
+  // families a line switch of their own the same now holds for them (`grid_label` with
+  // `elevation_line` / `longitude_line` zero, `angular_dist_label` with `angular_dist_line` zero).
+  // NOT independent at the compositing layer —
   // a label is painted in its family's own colour and opacity (each LUMICE_GridLine's `opacity` /
   // `color` for the two grid families and the circles; the horizon's fixed constants for the
   // horizon), so a line at opacity 0 is invisible together with its labels. See the v4.21 note at
@@ -1050,6 +1069,27 @@ typedef struct LUMICE_RenderParam_ {
   int markers_count;
   float markers_opacity;
   float markers_radius_px;
+  // ADDED (v4.26). Non-zero = draw that family's LINES. One per angle list: `elevation_line` gates
+  // elevation_grid[], `longitude_line` gates longitude_grid[], `angular_dist_line` gates
+  // angular_dist[]. The horizon's equivalent is `horizon` above, which these three are modelled on.
+  //
+  // WARNING, and it is the reverse of every other annotation flag in this struct: their JSON
+  // default is TRUE, so a ZERO-INITIALIZED struct asks for no lines even where it carries a full
+  // angle list — while a document with no such key gets lines. `horizon` has no such trap (false on
+  // both sides). Set all three, or go through JSON.
+  // The direction is deliberate rather than an oversight. An absent `horizon` key drew nothing
+  // because that flag is what turns the annotation on at all; an absent `elevation_line` key
+  // belongs to a config whose non-empty `elevation` list was ALREADY drawing lines, so defaulting
+  // it off would silently change what every existing config renders.
+  //
+  // WHAT THEY GATE is the LINE only, which is the half that makes "labels without lines"
+  // expressible: the label geometry is decided by `grid_label` / `angular_dist_label` above and is
+  // NOT affected by these, exactly as `horizon_label` is not affected by `horizon`. An EMPTY angle
+  // list has no line to draw whatever the flag says, so the two ways a family can be absent never
+  // contradict and there is no priority rule to learn.
+  int elevation_line;
+  int longitude_line;
+  int angular_dist_line;
 } LUMICE_RenderParam;
 
 // =============== Scene (opaque handle) ===============

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -675,6 +675,11 @@ static nlohmann::json RendererToJson(const LUMICE_RenderParam& r, int id) {
   jr["grid"]["elevation"] = GridLinesToCore(r.elevation_grid, r.elevation_grid_count);
   jr["grid"]["longitude"] = GridLinesToCore(r.longitude_grid, r.longitude_grid_count);
   jr["grid"]["horizon"] = r.horizon != 0;
+  // The other three families' line switches, beside the lists they gate. Same key names core's own
+  // to_json writes, for the same reason the label block below states.
+  jr["grid"]["elevation_line"] = r.elevation_line != 0;
+  jr["grid"]["longitude_line"] = r.longitude_line != 0;
+  jr["grid"]["angular_dist_line"] = r.angular_dist_line != 0;
   // The three text-label switches, next to the lines they annotate. Same key names core's own
   // to_json writes (render_config.cpp), which is what test_json_parser_parity.cpp compares.
   jr["grid"]["horizon_label"] = r.horizon_label != 0;
@@ -2527,6 +2532,14 @@ static LUMICE_ErrorCode JsonToRenderers(const nlohmann::json& render_arr, Config
     r.elevation_grid_count = 0;
     r.longitude_grid_count = 0;
     r.horizon = 0;  // core RenderConfig::horizon_ defaults to false
+    // 1, NOT 0, and the only default in this block that is not zero-shaped: core's three
+    // *_grid_line_ members default to TRUE, because a document written before those keys existed
+    // already drew the lines its angle lists name. Zeroing them here instead would make the C API
+    // decoder render every legacy config without its grid — a divergence from ParseRenderConfig,
+    // which the parity gate compares whole RenderConfigs to catch.
+    r.elevation_line = 1;
+    r.longitude_line = 1;
+    r.angular_dist_line = 1;
     // Same default and same reason as `horizon` above: core's three *_label_ fields are opt-in.
     r.horizon_label = 0;
     r.grid_label = 0;
@@ -2593,6 +2606,28 @@ static LUMICE_ErrorCode JsonToRenderers(const nlohmann::json& render_arr, Config
           return err;
         }
         r.horizon = outline ? 1 : 0;
+      }
+      // The other three families' line switches, read the same way the label block below is and
+      // kept a SEPARATE array from it: the loop bodies are identical, but a line switch and a label
+      // switch are two different questions about a family, and one table holding both would have to
+      // be split again the first time either group grows or loses a member.
+      {
+        const std::pair<const char*, int*> kLineKeys[] = {
+          { "elevation_line", &r.elevation_line },
+          { "longitude_line", &r.longitude_line },
+          { "angular_dist_line", &r.angular_dist_line },
+        };
+        for (const auto& [key, field] : kLineKeys) {
+          if (!gj.contains(key)) {
+            continue;
+          }
+          bool on = false;
+          const LUMICE_ErrorCode err = DecodeCoreField(gj.at(key), on);
+          if (err != LUMICE_OK) {
+            return err;
+          }
+          *field = on ? 1 : 0;
+        }
       }
       // The three text-label switches. One loop over (key, field) rather than three copies of the
       // same six lines: they differ only in which key names which int, and a fourth family would

--- a/src/server/render.cpp
+++ b/src/server/render.cpp
@@ -735,14 +735,27 @@ void RenderConsumer::PostSnapshot() {
   // The coordinate grid — parallels then meridians, both under the angular-distance circles.
   // One list, not two: the blend loop treats every line identically, and the two families' order
   // relative to each other is unobservable (they share an appearance model and a blend operator).
+  //
+  // Each family's own line switch gates it HERE and only here, the same place and for the same
+  // reason `config_.horizon_` gates the outline above: the masks and the label anchors are built
+  // regardless (RebuildLineFamilyMasks / RebuildAngularDistMasks read the angle list, never these
+  // flags), so a family with its line switched off still contributes its numbers through
+  // PaintLabels. That is the whole point of the flags — before them, "no lines" could only be said
+  // by emptying the angle list, which took the labels with it.
   std::vector<LineLayer> grid_layers;
   grid_layers.reserve(elevation_masks_.size() + longitude_masks_.size());
-  collect_layers(elevation_masks_, config_.elevation_grid_, grid_layers);
-  collect_layers(longitude_masks_, config_.longitude_grid_, grid_layers);
+  if (config_.elevation_grid_line_) {
+    collect_layers(elevation_masks_, config_.elevation_grid_, grid_layers);
+  }
+  if (config_.longitude_grid_line_) {
+    collect_layers(longitude_masks_, config_.longitude_grid_, grid_layers);
+  }
 
   std::vector<LineLayer> angular_dist_layers;
   angular_dist_layers.reserve(angular_dist_masks_.size());
-  collect_layers(angular_dist_masks_, config_.angular_dist_grid_, angular_dist_layers);
+  if (config_.angular_dist_grid_line_) {
+    collect_layers(angular_dist_masks_, config_.angular_dist_grid_, angular_dist_layers);
+  }
 
   // The ring markers, on top of everything else — the layer order the preview shader uses
   // (overlayAuxLines draws them last). No mask: the ring is a circle of a config-named radius
@@ -964,6 +977,13 @@ void RenderConsumer::PaintLabels() {
   // Turn one family's (labels, line list) pair into draws, dropping the ones whose line is fully
   // transparent. Mirrors PostSnapshot's collect_layers, and drops for the same reason: an alpha of
   // zero composites to a no-op, and skipping it up front also skips the rasterization.
+  //
+  // What it deliberately does NOT read is the family's LINE switch (elevation_grid_line_ and its
+  // two siblings, or horizon_ for the block below). A label survives its line being switched off —
+  // that is the independence the switches exist to make expressible — while it does not survive
+  // its line being made transparent, because opacity is the appearance a label inherits. The two
+  // look alike and are not: see render_config.hpp's *_label_ comment for why the second half is
+  // deliberate rather than an omission.
   const auto collect = [&draws](const std::vector<annotation::Label>& labels, const std::vector<GridLineParam>& lines) {
     for (const annotation::Label& label : labels) {
       const auto index = static_cast<size_t>(label.index);

--- a/test/composition-correctness/gui/test_scene_commit_chain.cpp
+++ b/test/composition-correctness/gui/test_scene_commit_chain.cpp
@@ -239,6 +239,12 @@ TEST(SceneCommitChain, TheExportIntentDescribesTheDocumentsView) {
       << "the exported config dropped the horizon's numbers — most likely by reading the line switch";
   EXPECT_TRUE(r["grid"]["label"].get<bool>());
   EXPECT_TRUE(r["grid"]["angular_dist_label"].get<bool>());
+  // The three family LINE switches, the other half of each of those pairs. All three lines are on
+  // in this fixture, so what they pin here is only that the keys are emitted and carry the
+  // document's value; the off state is the two cases below, where it is the whole point.
+  EXPECT_TRUE(r["grid"]["elevation_line"].get<bool>());
+  EXPECT_TRUE(r["grid"]["longitude_line"].get<bool>());
+  EXPECT_TRUE(r["grid"]["angular_dist_line"].get<bool>());
   // The sun circles, which the CLI now draws. Angles are the user's list; the colour and opacity
   // are one shared pair repeated per entry, because that is all the GUI has controls for.
   ASSERT_EQ(r["grid"]["angular_dist"].size(), 3u) << "the exported config lost the user's sun circles";
@@ -292,8 +298,14 @@ TEST(SceneCommitChain, TheExportIntentDescribesTheDocumentsView) {
 // the user's switch, and a test that only ever seeds the switch on cannot see that: an emitter
 // ignoring the flag entirely, and one reading it correctly, produce the same document when the
 // flag happens to be on.
-TEST(SceneCommitChain, TheExportIntentOmitsCirclesTheUserTurnedOff) {
-  SeedNonDefaultView();
+//
+// What "off" encodes to changed with v4.26 and the change is the fix, not a regression: the angles
+// stay in the document and `angular_dist_line` carries the switch. The list is what the family's
+// LABELS are drawn from too, so emptying it — which is what this arm used to do — silently dropped
+// the numbers of every user who had the circles' labels on and their lines off. The two-arm split
+// below is what keeps both readings pinned: this case holds the label on, the next turns it off.
+TEST(SceneCommitChain, TheExportIntentTurnsOffCircleLinesWithoutDroppingTheirLabels) {
+  SeedNonDefaultView();  // leaves show_sun_circles_label true
   // Everything else about the circles stays as the fixture set it — only the switch moves, so a
   // difference in the output can be attributed to the switch and nothing else.
   g_state.show_sun_circles_line = false;
@@ -303,16 +315,66 @@ TEST(SceneCommitChain, TheExportIntentOmitsCirclesTheUserTurnedOff) {
   ASSERT_EQ(export_doc["render"].size(), 1u);
   const nlohmann::json& grid = export_doc["render"][0]["grid"];
 
+  ASSERT_TRUE(grid.contains("angular_dist_line"));
+  EXPECT_FALSE(grid["angular_dist_line"].get<bool>()) << "the exported config draws sun circles the user switched off";
+  // The angles survive, because the labels the user left ON are drawn from them. An empty list here
+  // is the pre-v4.26 encoding, and it renders no numbers at all.
+  ASSERT_EQ(grid["angular_dist"].size(), 3u) << "the exported config lost the angles its labels are drawn from";
+  EXPECT_TRUE(grid["angular_dist_label"].get<bool>());
+}
+
+// Both switches off, which is the one state that still encodes to an empty list — and the reason
+// the case above cannot be trusted to cover it: an emitter that had stopped reading
+// show_sun_circles_line altogether, and always filled the list, would pass everything up there
+// except the one boolean.
+TEST(SceneCommitChain, TheExportIntentOmitsCirclesTheUserTurnedOffEntirely) {
+  SeedNonDefaultView();
+  g_state.show_sun_circles_line = false;
+  g_state.show_sun_circles_label = false;
+
+  nlohmann::json export_doc;
+  ASSERT_NO_THROW(export_doc = nlohmann::json::parse(CoreJson(g_state)));
+  ASSERT_EQ(export_doc["render"].size(), 1u);
+  const nlohmann::json& grid = export_doc["render"][0]["grid"];
+
   ASSERT_TRUE(grid.contains("angular_dist"));
-  EXPECT_TRUE(grid["angular_dist"].empty()) << "the exported config draws sun circles the user switched off";
+  EXPECT_TRUE(grid["angular_dist"].empty()) << "the exported config carries angles nothing will draw";
+  EXPECT_FALSE(grid["angular_dist_line"].get<bool>());
+  EXPECT_FALSE(grid["angular_dist_label"].get<bool>());
 }
 
 // The grid's half of the same off-state check, and it is not redundant with the circles': the two
 // families read different switches, and an emitter that gated the grid on show_sun_circles_line —
 // or on nothing at all — passes the case above unchanged.
-TEST(SceneCommitChain, TheExportIntentOmitsTheGridTheUserTurnedOff) {
+TEST(SceneCommitChain, TheExportIntentTurnsOffGridLinesWithoutDroppingTheirLabels) {
+  SeedNonDefaultView();  // leaves show_grid_label true
+  g_state.show_grid_line = false;
+
+  nlohmann::json export_doc;
+  ASSERT_NO_THROW(export_doc = nlohmann::json::parse(CoreJson(g_state)));
+  ASSERT_EQ(export_doc["render"].size(), 1u);
+  const nlohmann::json& grid = export_doc["render"][0]["grid"];
+
+  ASSERT_TRUE(grid.contains("elevation_line"));
+  ASSERT_TRUE(grid.contains("longitude_line"));
+  // One GUI switch, two core fields — so both must move, and a wiring that fed only one of them
+  // would leave half the grid drawn.
+  EXPECT_FALSE(grid["elevation_line"].get<bool>()) << "the exported config draws parallels the user switched off";
+  EXPECT_FALSE(grid["longitude_line"].get<bool>()) << "the exported config draws meridians the user switched off";
+  // The expanded angle lists survive for the labels, which the fixture leaves on.
+  EXPECT_EQ(grid["elevation"].size(), 16u) << "the exported config lost the angles its labels are drawn from";
+  EXPECT_EQ(grid["longitude"].size(), 36u);
+  EXPECT_TRUE(grid["label"].get<bool>());
+  // The circles are untouched by that switch, which is what says the two families are gated
+  // separately rather than by one flag serving both.
+  EXPECT_EQ(grid["angular_dist"].size(), 3u);
+  EXPECT_TRUE(grid["angular_dist_line"].get<bool>());
+}
+
+TEST(SceneCommitChain, TheExportIntentOmitsTheGridTheUserTurnedOffEntirely) {
   SeedNonDefaultView();
   g_state.show_grid_line = false;
+  g_state.show_grid_label = false;
 
   nlohmann::json export_doc;
   ASSERT_NO_THROW(export_doc = nlohmann::json::parse(CoreJson(g_state)));
@@ -321,11 +383,10 @@ TEST(SceneCommitChain, TheExportIntentOmitsTheGridTheUserTurnedOff) {
 
   ASSERT_TRUE(grid.contains("elevation"));
   ASSERT_TRUE(grid.contains("longitude"));
-  EXPECT_TRUE(grid["elevation"].empty()) << "the exported config draws parallels the user switched off";
-  EXPECT_TRUE(grid["longitude"].empty()) << "the exported config draws meridians the user switched off";
-  // The circles are untouched by that switch, which is what says the two families are gated
-  // separately rather than by one flag serving both.
-  EXPECT_EQ(grid["angular_dist"].size(), 3u);
+  EXPECT_TRUE(grid["elevation"].empty()) << "the exported config carries angles nothing will draw";
+  EXPECT_TRUE(grid["longitude"].empty());
+  EXPECT_FALSE(grid["elevation_line"].get<bool>());
+  EXPECT_FALSE(grid["longitude_line"].get<bool>());
 }
 
 // The refusal the narrow end of the FOV range makes reachable. ComputeGridStep drops to 5 deg below
@@ -348,6 +409,38 @@ TEST(SceneCommitChain, AGridTooDenseToEncodeRefusesTheExportRatherThanTruncating
   // The positive control: the same document at a wider fov exports. Without it, an export that
   // refused unconditionally would satisfy everything above.
   g_state.renderer.fov = 55.0f;
+  warning.clear();
+  EXPECT_TRUE(BuildExportJsonOrWarn(g_state, &json, &warning)) << warning;
+  EXPECT_FALSE(json.empty());
+}
+
+// The same refusal from the state v4.26 made reachable: the grid's LINES are off and only its
+// LABELS are on. The list is expanded on this path too now — that is what lets the labels survive
+// a switched-off line — so it can overflow on this path too, and a truncated set of NUMBERS is no
+// better than a truncated set of lines.
+//
+// Before the line switches existed this branch could not be entered at all: "labels on, lines off"
+// skipped the expansion entirely, so the overflow check ran only when the lines were on. Widening
+// the fill condition without widening the check is the specific way this fix could have gone
+// wrong, which is why it is a case of its own rather than a row in the one above.
+TEST(SceneCommitChain, AGridTooDenseToEncodeIsRefusedEvenWhenOnlyItsLabelsAreOn) {
+  SeedNonDefaultView();
+  g_state.show_grid_line = false;
+  g_state.show_grid_label = true;
+  g_state.renderer.fov = 20.0f;  // 5 deg step -> 72 meridians against a cap of 64
+
+  std::string json;
+  std::string warning;
+  EXPECT_FALSE(BuildExportJsonOrWarn(g_state, &json, &warning))
+      << "a label-only grid dense enough to overflow the ABI cap was exported anyway";
+  EXPECT_TRUE(json.empty()) << "a refused export must write nothing at all";
+  EXPECT_NE(warning.find("72"), std::string::npos) << warning;
+  EXPECT_NE(warning.find("longitude"), std::string::npos) << warning;
+
+  // The positive control, and here it carries more than symmetry: with BOTH grid switches off the
+  // same dense document must export fine, because nothing expands the list at all. An overflow
+  // check that had been hoisted out of the fill condition entirely would refuse this too.
+  g_state.show_grid_label = false;
   warning.clear();
   EXPECT_TRUE(BuildExportJsonOrWarn(g_state, &json, &warning)) << warning;
   EXPECT_FALSE(json.empty());
@@ -545,7 +638,13 @@ TEST(SceneCommitChain, IntentionalDivergenceFieldsMatchDocumentedSet) {
     //   angular_dist_label
     //                   commit arm's texture would be re-projected with the sky and then drawn a
     //                   second time by the preview's own label pass, so that arm asks for none.
-    // All eight are the same divergence with eight spellings, which is why they share this note
+    //   elevation_line— the LINE switch beside each of those three families (v4.26). The commit arm
+    //   longitude_line  writes a constant true and the export arm the user's own switch, so they
+    //   angular_dist_line
+    //                   agree only when the user has the lines on — which this fixture happens to
+    //                   do, and which is exactly why the exemption has to be declared rather than
+    //                   left to a comparison that passes today.
+    // All eleven are the same divergence with eleven spellings, which is why they share this note
     // rather than each earning a bullet: an annotation belongs to the picture, and only one of the
     // two arms describes a picture.
   };
@@ -594,11 +693,12 @@ TEST(SceneCommitChain, IntentionalDivergenceFieldsMatchDocumentedSet) {
       commit_doc["render"][0].erase(key);
       export_doc["render"][0].erase(key);
     }
-    // "grid" itself stays in the comparison below: only its ten diverging sub-fields are exempted
-    // here, by sub-key rather than by erasing the whole object, so any remaining grid sub-field
-    // keeps being checked for an accidental intent-dependent drift.
-    for (const char* sub : { "horizon", "angular_dist", "elevation", "longitude", "markers", "markers_opacity",
-                             "markers_radius_px", "horizon_label", "label", "angular_dist_label" }) {
+    // "grid" itself stays in the comparison below: only its thirteen diverging sub-fields are
+    // exempted here, by sub-key rather than by erasing the whole object, so any remaining grid
+    // sub-field keeps being checked for an accidental intent-dependent drift.
+    for (const char* sub :
+         { "horizon", "angular_dist", "elevation", "longitude", "markers", "markers_opacity", "markers_radius_px",
+           "horizon_label", "label", "angular_dist_label", "elevation_line", "longitude_line", "angular_dist_line" }) {
       EXPECT_TRUE(commit_doc["render"][0]["grid"].contains(sub))
           << "offset " << offset << ": \"grid." << sub << "\" is no longer emitted";
       commit_doc["render"][0]["grid"].erase(sub);

--- a/test/unit-correctness/config/test_render_config.cpp
+++ b/test/unit-correctness/config/test_render_config.cpp
@@ -186,6 +186,25 @@ TEST(RenderConfigTest, EachAppearanceField_ReturnsFalse) {
     EXPECT_FALSE(lumice::NeedsRebuild(base, mod)) << "horizon";
   }
 
+  // The three family line switches, same classification as `horizon` above and for the same
+  // reason: they decide whether a line is composited onto the finished image, never the shape of
+  // the buffer it is composited onto.
+  {
+    auto mod = base;
+    mod.elevation_grid_line_ = false;
+    EXPECT_FALSE(lumice::NeedsRebuild(base, mod)) << "elevation_grid_line";
+  }
+  {
+    auto mod = base;
+    mod.longitude_grid_line_ = false;
+    EXPECT_FALSE(lumice::NeedsRebuild(base, mod)) << "longitude_grid_line";
+  }
+  {
+    auto mod = base;
+    mod.angular_dist_grid_line_ = false;
+    EXPECT_FALSE(lumice::NeedsRebuild(base, mod)) << "angular_dist_grid_line";
+  }
+
   // ev_mode: it selects WHICH exposure formula PostSnapshot uses, not the accumulation layout,
   // so it must NOT force a consumer rebuild (same classification as intensity_factor above).
   {
@@ -596,6 +615,99 @@ TEST(RenderConfigFrontTest, OperatorEq_ComparesFront) {
   // Not aliased onto visible_: two configs that differ ONLY in front must still compare unequal
   // while their visible_ agree.
   EXPECT_EQ(a.visible_, b.visible_);
+}
+
+// ===== The three family LINE switches (v4.26) =====
+//
+// One per angle list — the parallels, the meridians, the angular-distance circles — and the thing
+// that makes them unlike every other annotation field in this struct is the DIRECTION of their
+// default. `horizon_`, the three *_label_ switches, `zenith_nadir_` and `markers_` are all opt-in,
+// because each of them turns an annotation on that a config predating the field never asked for.
+// These three turn one OFF: the config that predates them was already drawing the lines its
+// non-empty angle list names, and a false default would silently stop it.
+TEST(RenderConfigFamilyLineSwitchTest, DefaultIsOnUnlikeEveryOtherAnnotationSwitch) {
+  const lumice::RenderConfig defaults;
+  EXPECT_TRUE(defaults.elevation_grid_line_);
+  EXPECT_TRUE(defaults.longitude_grid_line_);
+  EXPECT_TRUE(defaults.angular_dist_grid_line_);
+  // Read together with the opt-in neighbours, because "true" is only meaningful here as the
+  // deliberate opposite of what sits beside it — a copy-paste that gave these the same default as
+  // `horizon_` would look perfectly consistent in isolation.
+  EXPECT_FALSE(defaults.horizon_);
+  EXPECT_FALSE(defaults.horizon_label_);
+  EXPECT_FALSE(defaults.grid_label_);
+  EXPECT_FALSE(defaults.angular_dist_label_);
+}
+
+TEST(RenderConfigFamilyLineSwitchTest, ToJson_EmitsOneKeyPerFamilyUnderGrid) {
+  auto cfg = MakeBaseline();
+  cfg.elevation_grid_line_ = false;
+  cfg.longitude_grid_line_ = true;
+  cfg.angular_dist_grid_line_ = false;
+
+  const nlohmann::json j = cfg;
+
+  ASSERT_TRUE(j.contains("grid"));
+  ASSERT_TRUE(j["grid"].contains("elevation_line"));
+  ASSERT_TRUE(j["grid"].contains("longitude_line"));
+  ASSERT_TRUE(j["grid"].contains("angular_dist_line"));
+  // Three distinct values in one document: a writer that emitted the same member three times
+  // passes any test that sets them all alike.
+  EXPECT_FALSE(j["grid"]["elevation_line"].get<bool>());
+  EXPECT_TRUE(j["grid"]["longitude_line"].get<bool>());
+  EXPECT_FALSE(j["grid"]["angular_dist_line"].get<bool>());
+}
+
+// The key names carry no "grid" of their own — they already sit under "grid", exactly as
+// "elevation" / "longitude" / "angular_dist" do while their C++ members are *_grid_. Pinned
+// because the C++ spelling and the JSON spelling deliberately differ, so a rename on one side
+// that "fixed" the asymmetry would be a silent schema break.
+TEST(RenderConfigFamilyLineSwitchTest, ToJson_UsesTheListsOwnKeySpelling) {
+  const nlohmann::json j = MakeBaseline();
+  EXPECT_FALSE(j["grid"].contains("elevation_grid_line"));
+  EXPECT_FALSE(j["grid"].contains("longitude_grid_line"));
+  EXPECT_FALSE(j["grid"].contains("angular_dist_grid_line"));
+}
+
+// The switch does not touch the list it gates. Stated because the alternative encoding — "no lines"
+// meaning "empty list" — is what this field replaced, and a decoder or a writer that still cleared
+// the list would take the family's LABELS with it, which is the whole defect being fixed.
+TEST(RenderConfigFamilyLineSwitchTest, TheSwitchLeavesItsAngleListAlone) {
+  auto cfg = MakeBaseline();
+  cfg.elevation_grid_.push_back(lumice::GridLineParam{ 30.0f, 1.0f, 1.0f, { 1, 1, 1 } });
+  cfg.angular_dist_grid_.push_back(lumice::GridLineParam{ 22.0f, 1.0f, 1.0f, { 1, 1, 1 } });
+  cfg.elevation_grid_line_ = false;
+  cfg.angular_dist_grid_line_ = false;
+
+  const nlohmann::json j = cfg;
+  ASSERT_EQ(j["grid"]["elevation"].size(), 1u);
+  ASSERT_EQ(j["grid"]["angular_dist"].size(), 1u);
+  EXPECT_NEAR(j["grid"]["elevation"][0]["value"].get<float>(), 30.0f, 1e-5f);
+  EXPECT_NEAR(j["grid"]["angular_dist"][0]["value"].get<float>(), 22.0f, 1e-5f);
+}
+
+TEST(RenderConfigFamilyLineSwitchTest, OperatorEq_ComparesEachOfTheThree) {
+  // One case per field rather than one flipping all three: a comparison that reads the same member
+  // three times, or that reads only one of them, passes the combined form.
+  {
+    auto a = MakeBaseline();
+    auto b = MakeBaseline();
+    ASSERT_TRUE(a == b);
+    b.elevation_grid_line_ = false;
+    EXPECT_FALSE(a == b) << "elevation_grid_line";
+  }
+  {
+    auto a = MakeBaseline();
+    auto b = MakeBaseline();
+    b.longitude_grid_line_ = false;
+    EXPECT_FALSE(a == b) << "longitude_grid_line";
+  }
+  {
+    auto a = MakeBaseline();
+    auto b = MakeBaseline();
+    b.angular_dist_grid_line_ = false;
+    EXPECT_FALSE(a == b) << "angular_dist_grid_line";
+  }
 }
 
 }  // namespace

--- a/test/unit-correctness/server/test_json_parser_parity.cpp
+++ b/test/unit-correctness/server/test_json_parser_parity.cpp
@@ -340,6 +340,11 @@ void AddMarkers(const std::vector<lumice::MarkerStyleParam>& a, const std::vecto
 // same width, or two same-width fields reordered. The size does not move, so the assert stays
 // quiet while the enumeration below silently reads the wrong member. These sentinels cover growth
 // and shrinkage only.
+//
+// A third gap, and this one has actually happened: a field ADDED into existing padding. The three
+// family line switches (v4.26) left sizeof(RenderConfig) at 224 because the bytes they needed were
+// already being wasted between ZenithNadirParam and markers_. So the assert below is a tripwire
+// for MOST additions, not for all of them, and adding a field is not licensed by it staying quiet.
 std::string FieldDiff(const lumice::RenderConfig& a, const lumice::RenderConfig& b) {
   static_assert(sizeof(lumice::RenderConfig) == 224, "Update FieldDiff when RenderConfig fields change");
   static_assert(sizeof(lumice::GridLineParam) == 24, "Update AddGridLines when GridLineParam fields change");
@@ -366,6 +371,12 @@ std::string FieldDiff(const lumice::RenderConfig& a, const lumice::RenderConfig&
   AddGridLines("grid.elevation", a.elevation_grid_, b.elevation_grid_, &out);
   AddGridLines("grid.longitude", a.longitude_grid_, b.longitude_grid_, &out);
   AddScalar("grid.horizon", static_cast<int>(a.horizon_), static_cast<int>(b.horizon_), &out);
+  AddScalar("grid.elevation_line", static_cast<int>(a.elevation_grid_line_), static_cast<int>(b.elevation_grid_line_),
+            &out);
+  AddScalar("grid.longitude_line", static_cast<int>(a.longitude_grid_line_), static_cast<int>(b.longitude_grid_line_),
+            &out);
+  AddScalar("grid.angular_dist_line", static_cast<int>(a.angular_dist_grid_line_),
+            static_cast<int>(b.angular_dist_grid_line_), &out);
   AddScalar("zenith_nadir.enabled", static_cast<int>(a.zenith_nadir_.enabled_),
             static_cast<int>(b.zenith_nadir_.enabled_), &out);
   AddFloat("zenith_nadir.radius_px", a.zenith_nadir_.radius_px_, b.zenith_nadir_.radius_px_, &out);
@@ -1181,6 +1192,71 @@ TEST(JsonParserParity, GridMarkersNonArrayRejectedByBothParsers) {
   const std::string text = WrapRenderWithGrid(R"({ "markers": { "id": "sun" } })");
   EXPECT_FALSE(ParseWithCore(text).ok);
   EXPECT_FALSE(CapiAcceptsEndToEnd(text));
+}
+
+// --- render.grid.{elevation,longitude,angular_dist}_line: the family line switches (v4.26) ---
+//
+// Structurally blind in the corpus for the reason grid.longitude is — no shipped config carries
+// the keys. What makes these need more than the present/absent pair every other grid key gets is
+// the DIRECTION of their default: alone among the annotation flags they default to TRUE, so an
+// absent key and a zero-initialized C API struct mean OPPOSITE things. That is exactly the shape
+// of divergence two independently written decoders produce — one seeding from core's struct, the
+// other from a memset — and it is invisible to a corpus sweep because no corpus document has an
+// opinion about the keys at all.
+
+TEST(JsonParserParity, GridFamilyLineSwitchesSurviveBothParsers) {
+  // Three different values in one document, so a decoder that read one key into all three fields
+  // (or the same key three times) cannot pass by accident.
+  const std::string text = WrapRenderWithGrid(
+      R"({ "elevation": [ { "value": 30.0 } ], "longitude": [ { "value": 90.0 } ],
+           "angular_dist": [ { "value": 22.0 } ],
+           "elevation_line": false, "longitude_line": true, "angular_dist_line": false })");
+  BothParsed p;
+  ASSERT_TRUE(ParseWithBoth(text, &p));
+  ASSERT_EQ(p.via_capi.renderers_.size(), 1u);
+  const auto& renderer = p.via_capi.renderers_.begin()->second;
+
+  EXPECT_FALSE(renderer.elevation_grid_line_);
+  EXPECT_TRUE(renderer.longitude_grid_line_);
+  EXPECT_FALSE(renderer.angular_dist_grid_line_);
+  // The lists are untouched by their switches — the whole point of the fields is that "no lines"
+  // stopped meaning "no angles", so a decoder that cleared the list would undo the fix silently.
+  ASSERT_EQ(renderer.elevation_grid_.size(), 1u);
+  ASSERT_EQ(renderer.longitude_grid_.size(), 1u);
+  ASSERT_EQ(renderer.angular_dist_grid_.size(), 1u);
+
+  // The whole renderer, which is what a missed branch on either side actually breaks.
+  EXPECT_TRUE(renderer == p.core.renderers_.begin()->second);
+}
+
+TEST(JsonParserParity, GridFamilyLineSwitchesOmittedLeaveBothParsersDrawingLines) {
+  // The case the C API decoder can only pass by seeding a NON-ZERO default. A memset-shaped
+  // decoder answers false here, and every config written before v4.26 would then load through the
+  // C API with its grid missing and through core with its grid intact — the same document
+  // rendering two ways depending on which entry point read it.
+  const std::string text = Document(kCrystalBlock, kFilterBlock, kMinimalSceneBlock, kMinimalRenderBlock);
+  BothParsed p;
+  ASSERT_TRUE(ParseWithBoth(text, &p));
+  const auto& via_capi = p.via_capi.renderers_.begin()->second;
+  const auto& core = p.core.renderers_.begin()->second;
+  EXPECT_TRUE(via_capi.elevation_grid_line_);
+  EXPECT_TRUE(via_capi.longitude_grid_line_);
+  EXPECT_TRUE(via_capi.angular_dist_grid_line_);
+  EXPECT_TRUE(core.elevation_grid_line_);
+  EXPECT_TRUE(core.longitude_grid_line_);
+  EXPECT_TRUE(core.angular_dist_grid_line_);
+}
+
+TEST(JsonParserParity, GridFamilyLineSwitchesExplicitTrueIsNotConfusedWithOmitted) {
+  // Both mean "draw the lines", so this cannot be caught by comparing the parsed value — what it
+  // pins is that an explicit true is ACCEPTED by both rather than rejected as a type error by one,
+  // the same proposition FrontFalseIsNotConfusedWithFrontMissing pins for the opposite default.
+  const std::string text =
+      WrapRenderWithGrid(R"({ "elevation_line": true, "longitude_line": true, "angular_dist_line": true })");
+  BothParsed p;
+  ASSERT_TRUE(ParseWithBoth(text, &p));
+  EXPECT_TRUE(p.via_capi.renderers_.begin()->second == p.core.renderers_.begin()->second);
+  EXPECT_TRUE(p.via_capi.renderers_.begin()->second.elevation_grid_line_);
 }
 
 // --- render.front: the second clip dimension (v4.20) ---

--- a/test/unit-correctness/server/test_render_consumer_label.cpp
+++ b/test/unit-correctness/server/test_render_consumer_label.cpp
@@ -21,6 +21,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <vector>
@@ -48,6 +49,17 @@ struct LabelSwitches {
   bool angular_dist = false;
 };
 
+// Which LINE switches a case wants on, the same shape and for the same reason. All four default to
+// ON because that is what the four config fields do — three of them literally (the *_grid_line_
+// triple defaults true) and `horizon_` because every case here that does not name it wants its
+// line drawn.
+struct LineSwitches {
+  bool horizon = true;
+  bool elevation = true;
+  bool longitude = true;
+  bool angular_dist = true;
+};
+
 // A linear 120 deg view centred 45 deg up: wide enough that the horizon, a 30 deg parallel, a
 // meridian and a 22 deg circle around the sun all cross the frame, so every family has somewhere
 // to put a label. Black background, so any non-black pixel is annotation or ray.
@@ -60,7 +72,7 @@ struct LabelSwitches {
 //
 // `line_opacity` is a parameter because the compositing-layer case needs to set it to zero while
 // leaving everything else — including the angle list, i.e. the geometry — untouched.
-RenderConfig MakeLabelConfig(LabelSwitches on, bool draw_horizon_line = true, float line_opacity = 1.0f) {
+RenderConfig MakeLabelConfig(LabelSwitches on, LineSwitches lines = {}, float line_opacity = 1.0f) {
   RenderConfig cfg;
   cfg.id_ = 0;
   cfg.lens_.type_ = LensParam::kLinear;
@@ -69,7 +81,10 @@ RenderConfig MakeLabelConfig(LabelSwitches on, bool draw_horizon_line = true, fl
   cfg.resolution_[1] = kH;
   cfg.view_.el_ = 45.0f;
   cfg.visible_ = RenderConfig::kFull;
-  cfg.horizon_ = draw_horizon_line;
+  cfg.horizon_ = lines.horizon;
+  cfg.elevation_grid_line_ = lines.elevation;
+  cfg.longitude_grid_line_ = lines.longitude;
+  cfg.angular_dist_grid_line_ = lines.angular_dist;
   cfg.horizon_label_ = on.horizon;
   cfg.grid_label_ = on.grid;
   cfg.angular_dist_label_ = on.angular_dist;
@@ -233,17 +248,19 @@ TEST(RenderConsumerLabel, TheThreeSwitchesDoNotReachEachOther) {
 }
 
 // (d) GEOMETRY LAYER. `horizon_label_` drives the anchors on its own: with `horizon_` false — no
-// line drawn at all — the numbers still appear. The horizon is the family this can be asked of,
-// because it is the only one whose line has a switch separate from its geometry (the other three
-// are "is the angle in the list").
+// line drawn at all — the numbers still appear. The horizon was the first family this could be
+// asked of, because for a long time it was the only one whose line had a switch separate from its
+// geometry; the other three said "no lines" by having an empty angle list, which took their
+// numbers with them. Case (d2) below is the same proposition for those three, now that they have
+// switches of their own.
 TEST(RenderConsumerLabel, TheHorizonLabelIsDrawnWithTheLineSwitchedOff) {
-  RenderConsumer no_line_no_label(MakeLabelConfig(LabelSwitches{}, /*draw_horizon_line=*/false), ColorClassTable{},
-                                  MakeSun());
+  RenderConsumer no_line_no_label(MakeLabelConfig(LabelSwitches{}, LineSwitches{ /*horizon=*/false }),
+                                  ColorClassTable{}, MakeSun());
   const std::vector<uint8_t> img_off = SnapshotOnce(&no_line_no_label);
   ASSERT_EQ(img_off.size(), static_cast<size_t>(kTotalPix) * 3);
   ASSERT_TRUE(HasAnyNonBlackPixel(img_off)) << "the reference frame is entirely black — see MakeLabelConfig";
 
-  RenderConsumer label_only(MakeLabelConfig(LabelSwitches{ true, false, false }, /*draw_horizon_line=*/false),
+  RenderConsumer label_only(MakeLabelConfig(LabelSwitches{ true, false, false }, LineSwitches{ /*horizon=*/false }),
                             ColorClassTable{}, MakeSun());
   const std::vector<uint8_t> img_on = SnapshotOnce(&label_only);
   ASSERT_EQ(img_on.size(), static_cast<size_t>(kTotalPix) * 3);
@@ -275,20 +292,186 @@ TEST(RenderConsumerLabel, TheHorizonLabelIsDrawnWithTheLineSwitchedOff) {
       << "most of the horizon mask came out red — the line was painted despite horizon_ being false";
 }
 
+// How many of a mask's own pixels changed between two frames. The judge for "was the LINE painted":
+// a line paints essentially every pixel its mask marks, while the family's labels sit ON that curve
+// and cover a handful of them, so the two are orders of magnitude apart rather than adjacent.
+int MaskedDifferingPixels(const std::vector<uint8_t>& a, const std::vector<uint8_t>& b,
+                          const std::vector<uint8_t>& mask) {
+  if (mask.size() != static_cast<size_t>(kTotalPix)) {
+    return -1;
+  }
+  int n = 0;
+  for (int i = 0; i < kTotalPix; ++i) {
+    if (mask[static_cast<size_t>(i)] == 0) {
+      continue;
+    }
+    const size_t base = static_cast<size_t>(i) * 3;
+    if (a[base] != b[base] || a[base + 1] != b[base + 1] || a[base + 2] != b[base + 2]) {
+      ++n;
+    }
+  }
+  return n;
+}
+
+// (d2) GEOMETRY LAYER, for the three families that are not the horizon — the case this file could
+// not contain until they had line switches at all. With the family's line switched off and its
+// angle list INTACT, the numbers must still be computed and painted while the line is not.
+//
+// Three frames, because two cannot say the second half. The labels sit ON the curve they annotate,
+// so a fair slice of a family's own mask is glyph ink even when no line was drawn — measured, on
+// this fixture: 13 of 570 masked pixels for the parallels, 45 of 194 for the meridians, and 146 of
+// 291 for the circles, whose mask is short and carries four anchors. A "few masked pixels changed"
+// rule calibrated on the first would call the third a painted line. So the line is measured by
+// TURNING IT ON with the labels held on:
+//   all_off      — labels off, line off. The reference the label ink is counted against.
+//   labels_only  — labels on, line off. What the switch has to make possible.
+//   both         — labels on, line ON. Differs from labels_only by the LINE and nothing else.
+// The last comparison is also the red-state detector: without the gate in PostSnapshot the switch
+// is inert, `both` and `labels_only` are the same image, and the count is zero.
+TEST(RenderConsumerLabel, TheGridAndCircleLabelsAreDrawnWithTheirLinesSwitchedOff) {
+  struct Row {
+    const char* name;
+    LabelSwitches labels;
+    LineSwitches lines_off;  // this family's line off, the other two left as they are
+    LineSwitches lines_on;   // the same, with this family's line back on
+    const std::vector<std::vector<uint8_t>>& (RenderConsumer::*masks)() const;
+    const std::vector<annotation::Label>& (RenderConsumer::*anchors)() const;
+  };
+  // The horizon's line stays OFF in every arm: it is not the family under test, and a red line
+  // across the frame would put pixels into the difference that belong to no family's mask.
+  const Row rows[] = {
+    { "elevation", LabelSwitches{ false, true, false }, LineSwitches{ false, false, true, true },
+      LineSwitches{ false, true, true, true }, &RenderConsumer::ElevationMasksForTest,
+      &RenderConsumer::ElevationLabelsForTest },
+    { "longitude", LabelSwitches{ false, true, false }, LineSwitches{ false, true, false, true },
+      LineSwitches{ false, true, true, true }, &RenderConsumer::LongitudeMasksForTest,
+      &RenderConsumer::LongitudeLabelsForTest },
+    { "angular_dist", LabelSwitches{ false, false, true }, LineSwitches{ false, true, true, false },
+      LineSwitches{ false, true, true, true }, &RenderConsumer::AngularDistMasksForTest,
+      &RenderConsumer::AngularDistLabelsForTest },
+  };
+
+  for (const Row& row : rows) {
+    // Non-fatal throughout: one broken family must not take the other two's reports with it, and
+    // WHICH family is the whole diagnostic.
+    RenderConsumer all_off(MakeLabelConfig(LabelSwitches{}, row.lines_off), ColorClassTable{}, MakeSun());
+    const std::vector<uint8_t> img_all_off = SnapshotOnce(&all_off);
+    RenderConsumer labels_only(MakeLabelConfig(row.labels, row.lines_off), ColorClassTable{}, MakeSun());
+    const std::vector<uint8_t> img_labels_only = SnapshotOnce(&labels_only);
+    RenderConsumer both(MakeLabelConfig(row.labels, row.lines_on), ColorClassTable{}, MakeSun());
+    const std::vector<uint8_t> img_both = SnapshotOnce(&both);
+    if (img_all_off.size() != static_cast<size_t>(kTotalPix) * 3 ||
+        img_labels_only.size() != static_cast<size_t>(kTotalPix) * 3 ||
+        img_both.size() != static_cast<size_t>(kTotalPix) * 3) {
+      ADD_FAILURE() << row.name << ": a snapshot came back the wrong size";
+      continue;
+    }
+    if (!HasAnyNonBlackPixel(img_all_off)) {
+      ADD_FAILURE() << row.name << ": the reference frame is entirely black — see MakeLabelConfig";
+      continue;
+    }
+
+    // The angle list is untouched by the switch, so the mask is built either way — which is both
+    // what makes the counting below possible and the property the fix rests on.
+    const std::vector<std::vector<uint8_t>>& masks = (labels_only.*row.masks)();
+    if (masks.empty() || masks[0].size() != static_cast<size_t>(kTotalPix)) {
+      ADD_FAILURE() << row.name << ": no mask was built for a family whose angle list is non-empty";
+      continue;
+    }
+    const auto marked = static_cast<int>(std::count(masks[0].begin(), masks[0].end(), uint8_t{ 1 }));
+    if (marked <= 0) {
+      ADD_FAILURE() << row.name << ": an empty mask makes the counts below vacuous";
+      continue;
+    }
+
+    EXPECT_FALSE(((labels_only.*row.anchors)()).empty())
+        << row.name << ": no anchor was computed — the label switch was read as depending on the line switch";
+    EXPECT_GT(DifferingPixels(img_all_off, img_labels_only), 0) << row.name << ": the numbers did not reach the image";
+
+    // The line, isolated: the only difference between these two frames is this family's own switch.
+    // A third of the mask is well under the measured margins (527 / 570, 125 / 194 and 145 / 291
+    // masked pixels the line lights beyond the glyph ink) and well over the zero a missing gate
+    // produces.
+    const int added_by_line = MaskedDifferingPixels(img_labels_only, img_both, masks[0]);
+    EXPECT_GT(added_by_line, marked / 3)
+        << row.name << ": turning the line on changed only " << added_by_line << " of " << marked
+        << " masked pixels — the labels arm was already painting the line, i.e. the switch does not gate it";
+  }
+}
+
+// (d3) The three switches reach only their own family. One flag serving all three, or the wrong
+// flag wired to a family, passes (d2) — every arm there switches off the family it is measuring.
+TEST(RenderConsumerLabel, EachFamilyLineSwitchGatesOnlyItsOwnFamily) {
+  RenderConsumer all_on(MakeLabelConfig(LabelSwitches{}, LineSwitches{ false, true, true, true }), ColorClassTable{},
+                        MakeSun());
+  const std::vector<uint8_t> img_all_on = SnapshotOnce(&all_on);
+  ASSERT_EQ(img_all_on.size(), static_cast<size_t>(kTotalPix) * 3);
+
+  struct Row {
+    const char* name;
+    LineSwitches lines;
+    const std::vector<std::vector<uint8_t>>& (RenderConsumer::*off_masks)() const;
+    const std::vector<std::vector<uint8_t>>& (RenderConsumer::*other_masks)() const;
+  };
+  for (const Row& row : { Row{ "elevation", LineSwitches{ false, false, true, true },
+                               &RenderConsumer::ElevationMasksForTest, &RenderConsumer::LongitudeMasksForTest },
+                          Row{ "longitude", LineSwitches{ false, true, false, true },
+                               &RenderConsumer::LongitudeMasksForTest, &RenderConsumer::ElevationMasksForTest },
+                          Row{ "angular_dist", LineSwitches{ false, true, true, false },
+                               &RenderConsumer::AngularDistMasksForTest, &RenderConsumer::ElevationMasksForTest } }) {
+    RenderConsumer one_off(MakeLabelConfig(LabelSwitches{}, row.lines), ColorClassTable{}, MakeSun());
+    const std::vector<uint8_t> img_one_off = SnapshotOnce(&one_off);
+    if (img_one_off.size() != static_cast<size_t>(kTotalPix) * 3) {
+      ADD_FAILURE() << row.name << ": the snapshot came back the wrong size";
+      continue;
+    }
+    const std::vector<std::vector<uint8_t>>& off_masks = (one_off.*row.off_masks)();
+    const std::vector<std::vector<uint8_t>>& other_masks = (one_off.*row.other_masks)();
+    if (off_masks.empty() || other_masks.empty()) {
+      ADD_FAILURE() << row.name << ": a mask is missing, so the counts below say nothing";
+      continue;
+    }
+    // Its own family went dark...
+    const int own = MaskedDifferingPixels(img_all_on, img_one_off, off_masks[0]);
+    const auto own_marked = static_cast<int>(std::count(off_masks[0].begin(), off_masks[0].end(), uint8_t{ 1 }));
+    EXPECT_GT(own, own_marked / 2) << row.name << ": switching this family's line off changed almost nothing";
+    // ...and a family whose switch stayed on did not. Read on the OTHER family's mask minus the
+    // pixels the two masks share, since a crossing point belongs to both curves and would report
+    // as a change here for a reason that has nothing to do with this switch.
+    int other_changed = 0;
+    int other_exclusive = 0;
+    for (int i = 0; i < kTotalPix; ++i) {
+      const auto k = static_cast<size_t>(i);
+      if (other_masks[0][k] == 0 || off_masks[0][k] != 0) {
+        continue;
+      }
+      ++other_exclusive;
+      const size_t base = k * 3;
+      if (img_all_on[base] != img_one_off[base] || img_all_on[base + 1] != img_one_off[base + 1] ||
+          img_all_on[base + 2] != img_one_off[base + 2]) {
+        ++other_changed;
+      }
+    }
+    EXPECT_GT(other_exclusive, 0) << row.name << ": the two masks coincide entirely; the check below is vacuous";
+    EXPECT_EQ(other_changed, 0) << row.name << ": " << other_changed << " of " << other_exclusive
+                                << " pixels belonging only to another family's line changed — one switch reached "
+                                   "a family it does not own";
+  }
+}
+
 // (e) COMPOSITING LAYER, and the case that pins the decision this file's header explains. A grid
 // line at opacity 0 is invisible, and its labels go with it — even though the switch is on and the
 // anchors WERE computed. The two halves are asserted separately on purpose: "the anchors exist"
 // is what rules out the alternative explanation that the geometry was skipped, which would make
 // the image assertion pass for the wrong reason.
 TEST(RenderConsumerLabel, AZeroOpacityLineTakesItsLabelWithIt) {
-  RenderConsumer off(MakeLabelConfig(LabelSwitches{}, /*draw_horizon_line=*/true, /*line_opacity=*/0.0f),
-                     ColorClassTable{}, MakeSun());
+  RenderConsumer off(MakeLabelConfig(LabelSwitches{}, LineSwitches{}, /*line_opacity=*/0.0f), ColorClassTable{},
+                     MakeSun());
   const std::vector<uint8_t> img_off = SnapshotOnce(&off);
   ASSERT_EQ(img_off.size(), static_cast<size_t>(kTotalPix) * 3);
   ASSERT_TRUE(HasAnyNonBlackPixel(img_off)) << "the reference frame is entirely black — see MakeLabelConfig";
 
-  RenderConsumer on(MakeLabelConfig(LabelSwitches{ false, true, true }, /*draw_horizon_line=*/true,
-                                    /*line_opacity=*/0.0f),
+  RenderConsumer on(MakeLabelConfig(LabelSwitches{ false, true, true }, LineSwitches{}, /*line_opacity=*/0.0f),
                     ColorClassTable{}, MakeSun());
   const std::vector<uint8_t> img_on = SnapshotOnce(&on);
   ASSERT_EQ(img_on.size(), static_cast<size_t>(kTotalPix) * 3);


### PR DESCRIPTION
## 问题

`horizon` 有独立的线开关（`grid.horizon`），所以「`horizon_label=true` + `horizon=false`」——
画出地平线的数字而不画它的线——可以被 config 忠实表达，473.7 实现过并有测试钉住。

**其余三族没有。** `grid.elevation` / `grid.longitude` / `grid.angular_dist` 的「画不画」被编码成
「角度列表空不空」，于是 `BuildScene` 导出臂只能二选一：填列表（**画出用户关掉的线**）或不填
（**丢掉用户开着的字**）。现取后者。

⇒ **谁会疼**：在 GUI 里开了 grid label 却关了 grid line、然后导出 config 去 CLI 出图的用户——
他们的数字会消失，且没有任何提示。

## 做了什么

给三族各加一个与 `grid.horizon` **同构**的 family 级 line 开关（config schema + C API 追加，v4.26），
导出臂改为忠实表达用户的两个开关，CLI 消费臂同步。

⭐ **语义不留隐式默认**（这条是本 PR 最容易做错的地方）：新开关落地后，「角度列表非空」与
「line 开关为 true」同时存在，必须明确谁优先、以及「列表非空但开关为 false」是什么意思——
否则就是又造一处 core 与 GUI 各自猜一遍的隐式默认（同族先例：scrum-436 里两侧对缺失 `axis`
给出**物理相反**的朝向，各自自洽、彼此不同、都不报错）。判定已落进注释与 doc。

⭐ **旧注释一并改掉**：`src/gui/file_io.cpp` 导出臂原有一段解释「为什么只能二选一、为什么选不填」的
注释——那个取舍在本 PR 之后不复存在，留着就是一条解释一个已不存在的权衡的注释。

## 默认行为逐字不变

**零参考图改动**。既有 config / `.lmc` 文档在改动前后渲染逐像素相同——这是 AC，不是巧合：
新开关的默认值取的就是「与今天等价」，本仓有过「改 struct/config 默认静默重标已加载 config」的先例。

## 同源的另一半：先判后做，结论是 no-go

backlog §2.D 原有两条同源缺口，另一条是「隐藏辅助线但保留它的文字 label 今天两侧都做不到」
（根因是 label 的合成 alpha 继承所属 family 的 `opacity_`，把 opacity 调到 0 会连字一起杀掉）。

本 scrum 的第二个子任务**没有直接去实现它**，而是先取证：**上面那三个 line 开关落地之后，
「藏线留字」还疼不疼？** 实测结论是 **no-go**——CLI/GUI 两侧 + 导出往返都确认，现在可以
「关 line 开关 / 保持 opacity / 开 label 开关」忠实表达，原来唯一的疼点已消失 ⇒ 不需要再给
label 独立的外观字段。

⚠️ `lumice.h:1009-1013` 那句「合成层不独立」今天**仍逐字为真**（负对照正面复核过），但它已经
不对应任何用户拿不到的效果：可见性这一维已被两个开关覆盖，剩下的只有「都可见但外观不同」
（例：网格线要淡、数字要清晰）那一维，而那一维至今**零诉求**。该判据与重新评估触发条件已作为
一行写进 backlog 的触发闸表，⛔ 不要因为「合成层不独立」这句话本身重开。

## 验证

- 零参考图改动；`./scripts/test.sh pr` 绿；四道 diff-scoped 门禁 + `format.sh --check` 全绿。
- 新增测试钉住「某一族的数字在它的线被关掉之后仍然存在」，改动前为红。
- code review：两个子任务均 **APPROVE**（0 Critical / 0 Major）。
- C API 为**追加**，`LUMICE_API_VERSION` → v4.26，`CHANGELOG.md` 同步。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Dzk6oieAM7Px5CApP2JAp