### PR TITLE
perf(cli): poll completion before sleeping, so a render is not floored at 1s

### DIFF
--- a/doc/performance-testing.md
+++ b/doc/performance-testing.md
@@ -316,8 +316,18 @@ Behavior differences in benchmark mode:
 - **Reduced rays for single pass**: 2M rays (vs the config's original value) to limit CI
   runtime, since single-worker execution is slower
 - **No image I/O**: `SaveRenderResults` is skipped, so `wall_sec` reflects pure simulation time
-- **5ms poll interval** (vs default 1s): caps the IDLE-detection quantization at a few ms
-  (was 100ms; that alone added up to a full poll interval to a fast run's wall time)
+- **No periodic materialization**: the render path re-materializes a result frame every 1s
+  (`kSaveInterval`) to write partial images and print `Stats:`; the benchmark pass does none
+  of that, because `LUMICE_AcquireResultFrame` runs a full `DoSnapshot` + per-pixel sRGB
+  conversion and that cost would be charged to the rate being measured. Held mechanically by
+  the `no-render-in-benchmark-poll` rule in `scripts/check_policies.py`, not by convention —
+  a wall-clock test cannot hold it (reintroducing the defect moved CPU wall time by 1.01x and
+  Metal by 0.88x)
+- **Completion polled at 5ms** (`kFinePollInterval`, was 100ms): caps the IDLE-detection
+  quantization at a few ms; at 100ms the quantization alone added up to a full poll interval
+  to a fast run's wall time. Both polling loops in `src/main.cpp` share this constant now —
+  the render loop used to check completion only once per 1s save, which put a hard one-second
+  floor under every CLI render regardless of ray count
 
 ### Benchmark Scene Registry (canonical throughput scenes)
 

--- a/scripts/check_policies.py
+++ b/scripts/check_policies.py
@@ -119,6 +119,19 @@ Checks:
      a single byte of the program — which is exactly why the cap is worth
      pinning mechanically instead of remembering.
 
+  16. no-render-in-benchmark-poll — RunBenchmarkPass (src/main.cpp) must not
+     call LUMICE_AcquireResultFrame, nor the file's three wrappers around it
+     (SaveRenderResults / SaveCompositeResults / PrintStats). Acquiring a frame
+     runs a full DoSnapshot plus per-pixel sRGB conversion; doing that once per
+     poll is charged to the throughput number the pass exists to report. It has
+     happened once (retired in f717a8f5): the render tax dominated wall time,
+     starved drain-window closure, and on CUDA kept an unbounded session alive
+     long enough to trip the 32-bit device PCG ray-index cap, i.e. a silent
+     fallback to legacy plus a hang. The rule is a source scan and not a timing
+     test because putting the defect back was *measured* to move CPU wall time
+     by 1.01x and Metal by 0.88x — no wall-clock oracle in this repo can see it,
+     while "did the pass acquire a frame at all" is answerable without a run.
+
 Add a new check as a function returning a list of Violation and append it to
 CHECKS, and add a numbered entry above. Keep each check deterministic and
 artifact-inspecting.
@@ -1745,6 +1758,82 @@ def check_pytest_invocation_marker() -> list[Violation]:
     return out
 
 
+# --- no-render-in-benchmark-poll ---------------------------------------------
+#
+# `RunBenchmarkPass` measures throughput, so anything it does per poll is charged
+# to the rate it reports. Materializing a result frame is the expensive thing the
+# CLI can do: LUMICE_AcquireResultFrame runs a full DoSnapshot plus the
+# RenderConsumer's per-pixel sRGB conversion. Doing it once per poll in the
+# drain-count loop dominated wall time, starved drain-window closure, and on CUDA
+# let the unbounded session run long enough to trip the 32-bit device PCG
+# ray-index cap — a silent fallback to legacy plus a hang. That is not a
+# hypothetical: it is what the retired f717a8f5 did, and the fix is the comment
+# above LUMICE_GetSimRayCount saying to read the cheap O(1) counter instead.
+#
+# Why this is a checker rather than a wall-clock test: putting the defect back
+# was measured to move CPU wall time by 1.01x and Metal by 0.88x. Every
+# timing-based oracle in this repo has zero detection power against it. The
+# observable that does separate the two states is "did the pass acquire a frame
+# at all", and a source scan answers that at commit time without a run.
+#
+# The banned names are the C API chokepoint plus this file's own three wrappers
+# around it. Since the legacy result getters were removed in favour of the
+# LUMICE_ResultFrame handle (see src/include/lumice.h), acquiring a frame is the
+# only way to reach a render, so the list is closed rather than a sample.
+BENCHMARK_PASS_SIGNATURE = re.compile(r"^void RunBenchmarkPass\s*\(", re.MULTILINE)
+RENDER_TRIGGERING_CALLS = (
+    "LUMICE_AcquireResultFrame",
+    "SaveRenderResults",
+    "SaveCompositeResults",
+    "PrintStats",
+)
+
+
+def check_no_render_in_benchmark_poll() -> list[Violation]:
+    """`RunBenchmarkPass` in src/main.cpp must not materialize a result frame.
+
+    Locates the function by a column-0 `void RunBenchmarkPass(` line and ends it
+    at the next column-0 `}` — the brace style every top-level function in this
+    file uses. Comments are blanked first (code_lines), so the constant docs that
+    *name* LUMICE_AcquireResultFrame do not trip the rule.
+
+    Known limitation, stated rather than papered over: if the function is renamed
+    or split into helpers, the signature regex matches nothing and this check
+    returns empty forever. That is a loss of detection power, not a false
+    positive — the same shape as the gaps recorded on the two rules above, and
+    the reason test_check_policies_no_render_in_benchmark_poll.py pins the
+    boundary-finding behaviour rather than the wording of the pattern.
+    """
+    out: list[Violation] = []
+    path = SRC / "main.cpp"
+    if not path.is_file():
+        return out
+    lines = list(code_lines(path))
+    start = None
+    for lineno, _orig, code in lines:
+        if start is None:
+            if BENCHMARK_PASS_SIGNATURE.match(code):
+                start = lineno
+            continue
+        if code.startswith("}"):
+            break
+        for name in RENDER_TRIGGERING_CALLS:
+            if re.search(rf"\b{name}\s*\(", code):
+                out.append(
+                    Violation(
+                        path,
+                        lineno,
+                        "no-render-in-benchmark-poll",
+                        f"`{name}` materializes a result frame (full DoSnapshot + sRGB "
+                        "conversion) inside the throughput measurement. Read the live "
+                        "counters instead (LUMICE_GetSimRayCount / LUMICE_QueryServerState / "
+                        "LUMICE_GetDrainStatus); see the comment above the "
+                        "LUMICE_GetSimRayCount call.",
+                    )
+                )
+    return out
+
+
 CHECKS = [
     check_getenv_centralization,
     check_env_knob_registration,
@@ -1761,6 +1850,7 @@ CHECKS = [
     check_msvc_string_literal_limit,
     check_user_defaults_single_write_path,
     check_pytest_invocation_marker,
+    check_no_render_in_benchmark_poll,
 ]
 
 
@@ -1786,7 +1876,7 @@ def main() -> int:
         "gui-state-field-tier-registration, no-msvc-unsafe-builtin, "
         "no-default-constructed-crystal-slots, gui-test-suite-args-sync, no-bare-print, "
         "msvc-string-literal-limit, user-defaults-single-write-path, "
-        "pytest-invocation-marker)."
+        "pytest-invocation-marker, no-render-in-benchmark-poll)."
     )
     return 0
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,14 @@
 namespace {
 
 constexpr int kDefaultJpegQuality = 95;
-constexpr auto kPollInterval = std::chrono::seconds(1);
+// How often the render loop materializes a partial result to disk/stdout, NOT how
+// often it checks whether the run has finished. The two used to be the same number,
+// which put a hard 1s floor under every CLI render: the loop slept a whole interval
+// before its first completion check, so a 20k-ray run that finished in ~20ms still
+// cost 1.02s of wall time. Completion is now polled at kFinePollInterval; this
+// constant only paces the expensive half (SaveRenderResults / SaveCompositeResults /
+// PrintStats all go through LUMICE_AcquireResultFrame, i.e. a full render).
+constexpr auto kSaveInterval = std::chrono::seconds(1);
 
 // Owning wrapper for the short-lived LUMICE_Scene handles the CLI builds from JSON.
 // LUMICE_CommitScene reads the scene as const and keeps no reference to it, so each handle is
@@ -166,7 +173,18 @@ void PrintColorClassSignal(LUMICE_Server* server, const std::filesystem::path& c
 // whose run completes in ~0.2s that deflated rays_per_sec by >30%. 5ms caps the
 // trailing quantization at a few ms while staying sleep-based (negligible CPU
 // steal from trace workers). See task-fix-throughput-bench-honesty.
-constexpr auto kBenchmarkPollInterval = std::chrono::milliseconds(5);
+//
+// Shared by BOTH polling loops in this file — the benchmark pass and the render
+// loop in main() — because the reason for 5ms is the same on both sides: the
+// completion check itself is cheap (a mutex-guarded state read), and any coarser
+// interval quantizes the run's wall time up to a multiple of itself. Keeping one
+// constant is deliberate: two copies of the same "why 5ms" invite a one-sided
+// retune that silently reintroduces the quantization on the other side.
+// If the two loops ever need genuinely different granularities for genuinely
+// different reasons (e.g. the render loop wanting a coarser interval to save
+// power on long runs), split this back into two named constants — do NOT branch
+// on the caller inside one shared constant.
+constexpr auto kFinePollInterval = std::chrono::milliseconds(5);
 constexpr int kBenchmarkSingleRays = 2'000'000;
 // GPU-route warm-up pass ray count: sized to be the smallest value that still
 // reliably touches every one-time init path (CUDA context / Metal PSO compile /
@@ -428,7 +446,7 @@ void RunBenchmarkPass(const std::string& config_str, int num_workers, const char
   int n_drains_in_window = 0;
 
   while (true) {
-    std::this_thread::sleep_for(kBenchmarkPollInterval);
+    std::this_thread::sleep_for(kFinePollInterval);
     LUMICE_ServerState state{};
     if (LUMICE_QueryServerState(server, &state) != LUMICE_OK) {
       continue;
@@ -892,14 +910,15 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  auto t_start = std::chrono::steady_clock::now();
+  // Check completion FIRST, then sleep — the reverse order put a floor of one
+  // kSaveInterval under every render, however small. The two frequencies are
+  // deliberately separate: completion is cheap and polled at kFinePollInterval,
+  // while the materialization below is a full render and stays paced at
+  // kSaveInterval (so a run shorter than one interval now performs it exactly
+  // once, in the final fetch after the loop, instead of twice).
+  auto next_save_time = std::chrono::steady_clock::now() + kSaveInterval;
 
   while (true) {
-    std::this_thread::sleep_for(kPollInterval);
-    SaveRenderResults(server, output_dir, image_format, jpeg_quality);
-    SaveCompositeResults(server, output_dir, image_format, jpeg_quality);
-    PrintStats(server);
-
     // Completion via the explicit single-source lifecycle: COMPLETED = a finite
     // run drained clean (incl. zero-output convergence). Replaces the fragile
     // `IDLE && stats.sim_ray_num>0` side-signal (scrum-296.7 early-IDLE truncation
@@ -908,6 +927,16 @@ int main(int argc, char** argv) {
     if (LUMICE_GetSimLifecycle(server, &lifecycle) == LUMICE_OK && lifecycle.lifecycle == LUMICE_LIFECYCLE_COMPLETED) {
       break;
     }
+
+    auto now = std::chrono::steady_clock::now();
+    if (now >= next_save_time) {
+      SaveRenderResults(server, output_dir, image_format, jpeg_quality);
+      SaveCompositeResults(server, output_dir, image_format, jpeg_quality);
+      PrintStats(server);
+      next_save_time = std::chrono::steady_clock::now() + kSaveInterval;
+    }
+
+    std::this_thread::sleep_for(kFinePollInterval);
   }
 
   // Final fetch after loop exit

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -457,6 +457,12 @@ void RunBenchmarkPass(const std::string& config_str, int num_workers, const char
     // (many polls) that render tax dominated wall-time, starved drain-window
     // closure, and (on CUDA) let the unbounded session run long enough to trip
     // the 32-bit device PCG ray-index cap -> silent legacy fallback + hang.
+    // This is now a gate, not a comment: the `no-render-in-benchmark-poll` rule
+    // in scripts/check_policies.py rejects an acquire anywhere in this function.
+    // The same principle paces the render loop in main() — it polls completion
+    // at this same interval and materializes only once per kSaveInterval — so
+    // "cheap counter to decide, expensive frame only when publishing" is one
+    // rule with two call sites, not a benchmark-only precaution.
     LUMICE_RayCount cur_rays = 0;
     LUMICE_GetSimRayCount(server, &cur_rays);
     auto now = std::chrono::steady_clock::now();

--- a/test/unit-correctness/scripts/test_check_policies_no_render_in_benchmark_poll.py
+++ b/test/unit-correctness/scripts/test_check_policies_no_render_in_benchmark_poll.py
@@ -1,0 +1,138 @@
+"""Regression net for `check_no_render_in_benchmark_poll` in `scripts/check_policies.py`.
+
+Read the note at the top of `test_check_new_refs.py` first: this repo does not
+test symbol-matching checks, only the ones that would fail silently. This rule
+qualifies because it owns a parser, and every way that parser can break fails
+toward green.
+
+The rule is not "does `LUMICE_AcquireResultFrame` appear in main.cpp" — the file
+is full of legitimate calls to it, three of them, and one mention inside a
+comment. It is "does it appear *between* the `void RunBenchmarkPass(` line and
+the column-0 `}` that closes it". So the whole rule rests on finding two line
+numbers, and a mistake in either direction is invisible: a start marker that
+matches nothing yields an empty scan, an end marker found too early yields a
+short one. Both print "Policy check passed".
+
+The cases below therefore pin *where the window is*, not the wording of any
+pattern: a call inside the function is caught, the same call before and after it
+is not, and the mention that lives only in a comment is not. A rewrite that keeps
+those four facts should keep this file green.
+
+Not pinned, deliberately: the rule's own stated limitation, that renaming or
+splitting `RunBenchmarkPass` silently disables it. There is no assertion that
+would make that state red without also re-deciding what the function is called,
+which is the judgement the rule declines to automate.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
+
+import check_policies  # noqa: E402
+
+RULE = "no-render-in-benchmark-poll"
+
+
+@pytest.fixture
+def src_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    src = tmp_path / "src"
+    src.mkdir()
+    monkeypatch.setattr(check_policies, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(check_policies, "SRC", src)
+    return src
+
+
+def _violations(src_root: Path, body: str) -> list:
+    (src_root / "main.cpp").write_text(body, encoding="utf-8")
+    return check_policies.check_no_render_in_benchmark_poll()
+
+
+def _main_cpp(before: str = "", inside: str = "", after: str = "") -> str:
+    """A miniature main.cpp with the three regions the rule has to tell apart."""
+    return (
+        "namespace {\n"
+        "\n"
+        "void PrintStats(LUMICE_Server* server) {\n"
+        f"{before}"
+        "}\n"
+        "\n"
+        "void RunBenchmarkPass(const std::string& config_str, int num_workers) {\n"
+        "  while (true) {\n"
+        f"{inside}"
+        "    LUMICE_GetSimRayCount(server, &cur_rays);\n"
+        "  }\n"
+        "}\n"
+        "\n"
+        "}  // namespace\n"
+        "\n"
+        "int main() {\n"
+        f"{after}"
+        "}\n"
+    )
+
+
+def test_clean_benchmark_pass_is_accepted(src_root: Path):
+    assert _violations(src_root, _main_cpp()) == []
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        "LUMICE_AcquireResultFrame(server, &raw_frame)",
+        "SaveRenderResults(server, output_dir, image_format, jpeg_quality)",
+        "SaveCompositeResults(server, output_dir, image_format, jpeg_quality)",
+        "PrintStats(server)",
+    ],
+)
+def test_render_trigger_inside_the_pass_is_caught(src_root: Path, call: str):
+    """Each banned name is banned: the C API chokepoint and all three wrappers."""
+    found = _violations(src_root, _main_cpp(inside=f"    {call};\n"))
+    assert [v.rule for v in found] == [RULE], f"{call} was not reported"
+
+
+def test_same_call_outside_the_pass_is_not_flagged(src_root: Path):
+    """The window matters, not the file.
+
+    `PrintStats` legitimately acquires a frame, and `main()` legitimately calls
+    all three wrappers. A rule that fired on those would have to be turned off,
+    which is the failure mode one step worse than not existing.
+    """
+    body = _main_cpp(
+        before="  LUMICE_AcquireResultFrame(server, &raw_frame);\n",
+        after="  SaveRenderResults(server, dir, fmt, q);\n  PrintStats(server);\n",
+    )
+    assert _violations(src_root, body) == []
+
+
+def test_mention_in_a_comment_inside_the_pass_is_not_flagged(src_root: Path):
+    """Comments are blanked before the scan.
+
+    The constant declarations in the real main.cpp explain themselves by naming
+    LUMICE_AcquireResultFrame, and the benchmark loop carries a comment saying
+    precisely not to call it. A rule that read those as violations would punish
+    the documentation that states it.
+    """
+    body = _main_cpp(inside="    // NOT LUMICE_AcquireResultFrame(server, &f) -- see above.\n")
+    assert _violations(src_root, body) == []
+
+
+def test_violation_points_at_the_offending_line(src_root: Path):
+    """The reported line must be the call, not the function header.
+
+    A rule that reports the window's start instead sends the reader to a
+    signature that looks fine, which is how a real violation gets dismissed.
+    """
+    body = _main_cpp(inside="    PrintStats(server);\n")
+    found = _violations(src_root, body)
+    assert len(found) == 1
+    reported = body.splitlines()[found[0].line - 1]
+    assert "PrintStats(server);" in reported
+
+
+def test_absent_main_cpp_is_not_an_error(src_root: Path):
+    """An empty src/ yields no violations rather than an exception."""
+    assert check_policies.check_no_render_in_benchmark_poll() == []


### PR DESCRIPTION
## 问题

`src/main.cpp` 的出图循环是「**先睡 `kPollInterval` 再查完成**」，而 `kPollInterval = 1s`
⇒ 任何一次 CLI 渲染的墙钟都被向上取整到整秒。不是斜坡，是**整秒台阶**：

| `ray_num` | 100 | 1 M | 3 M | 6 M | 10 M | 20 M |
|---|---|---|---|---|---|---|
| 墙钟 | 1.023 s | 1.056 s | 1.053 s | 1.051 s | 2.090 s | 3.132 s |

100 条光线和 6,000,000 条光线花一样的时间。

**同一个文件里就有对照组**：benchmark 路径用 5 ms 轮询，且其注释正是在讲 100 ms 的量化就已经会污染
benchmark 计时——**同一个机制，那条路径修过，出图这条没有。**

## 做了什么

把「先睡后查」翻成「**先查后睡**」，并把「完成检测」与「落盘/打印」两个频率拆开
（后者不能随轮询变密而变多——`src/main.cpp` 既有注释记着「渲染税在多次轮询时会主导墙钟」，
那是 benchmark 路径踩过的坑）。

**净收益实测（净机，AC1）**：单次 20k-ray 渲染 **1.02 s → 0.04 s（约 25×）**，
且 `SaveRenderResults` / `PrintStats` 的调用次数**不增反减**——收益不是拿渲染税换来的。

## ⚠️ 不要把它读成「CI/测试套件会快很多」

这是本 PR 最容易被高估的一处，已实测钉死：

- 串行推算会得出 −41%，**但那是错的**；
- `scripts/test.sh` 与 CI 实际走的 `pytest -n auto` 并行模式下，实测 **73.1 s → 70.6 s（−3.5%）**。
  机制：并行下各 worker 的 1 s sleep 互相重叠，墙钟由**总 CPU 工作量**而非量化决定。

⇒ 本 PR 的价值在**用户可感知的 CLI 出图延迟**，不在测试时间。AC 判据也是建在单次渲染净收益上的，
与套件耗时无关。

（顺带发现 `doc/testing-architecture.md` §7.1 的 96 s 那个数今天不复现——实测 73.1 s。
已记回 backlog，**本 PR 不刷新那份文档**：那是另一条根因，a07。）

## 顺带裁掉一条同源待决项（AC4）

`f717a8f5` 退役 `test_benchmark_infinite_no_hang.py` 时留下一个刻意未决的问题：不变量
「`--benchmark` 轮询循环不得触发渲染」今天只由一句注释守着。本 PR 动的正是同一个文件的另一个
轮询循环 ⇒ 一并裁定：**立闸**。

⭐ 但判据**必须与墙钟无关**——退役那次已实测过：把缺陷放回去，CPU 墙钟只动 1.01×、Metal 0.88×，
渲染税落进 poll 线程既有的 sleep 余量里，**任何以墙钟为判据的闸对它检出力都是零**。
所以这里用的是静态规则而非计时断言：`scripts/check_policies.py` 新增
`no-render-in-benchmark-poll`，配红绿两态取证的单元测试。

## 验证

- `pytest` 121 passed；`./scripts/test.sh quick` PASS；四道 diff-scoped 门禁 + `format.sh --check` 全绿。
- code review **APPROVE**（0 Critical / 0 Major；两条 Minor 均为「锁定当前正确行为的回归防护」建议，非现有缺陷）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Dzk6oieAM7Px5CApP2JAp