### PR TITLE
fix(gui): exempt a user-initiated Run from the commit backpressure gate

### DIFF
--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -1081,9 +1081,24 @@ bool DoRun(bool user_initiated) {
   // (~150ms cold, ~50-80ms after the O2 PSO cache) — without a gate, continuous slider drag
   // restarts the sim before StatsConsumer processes a single batch, starving the preview.
   // Design:
-  //   - Gate only fires when a Run is actively RUNNING AND has not yet consumed any rays.
+  //   - Gate only fires on the auto-commit path (`user_initiated == false`), and only when a Run
+  //     is actively RUNNING AND has not yet consumed any rays.
   //     (LiveSimRays counts root rays consumed by StatsConsumer, reset in CommitConfig on both
   //     rebuild and reuse branches, so `> 0` is equivalent to "first batch landed".)
+  //   - Why an explicit Run is exempt: what this gate defends against is a MACHINE cadence —
+  //     kCommitIntervalMs re-submits every 70ms, continuously and without gaps, for as long as a
+  //     slider is being dragged, which is what outruns the first-batch consume. A click is a
+  //     discrete human event and does not have that shape, so exempting it cannot reopen the
+  //     starvation this gate was built for. The reverse cost is real and is the reason the
+  //     exemption exists at all: gating an explicit Run drops the whole commit silently, so a
+  //     user who read the overflow modal, dismissed it and deliberately pressed Run again would
+  //     get nothing back — no re-run, no modal, no log line. Not gating it costs nothing today,
+  //     because the two user-initiated call sites (the top-bar Run button and the Save-Modified
+  //     popup's "Run first") are both drawn only while no Run is in flight, so back-to-back
+  //     explicit Runs into the RUNNING-but-unconsumed window are not reachable through the UI at
+  //     all; the exemption makes that already-true property hold by construction instead of by
+  //     the button-disabling convention alone. See DoRun's declaration in app.hpp for the
+  //     obligation this places on any NEW user-initiated caller.
   //   - Timer is keyed by lifecycle.epoch, not a raw wall-clock static. Epoch changes → timer
   //     resets, so a stale timer from a previous gui_test scenario cannot leak into a new one.
   //     Contract (task-364 review): this relies on lifecycle.epoch being a per-server monotonic
@@ -1103,7 +1118,7 @@ bool DoRun(bool user_initiated) {
   static std::optional<std::chrono::steady_clock::time_point> gate_since;
   LUMICE_SimLifecycleResult lc0{};
   LUMICE_GetSimLifecycle(g_server, &lc0);
-  if (lc0.lifecycle == LUMICE_LIFECYCLE_RUNNING) {
+  if (!user_initiated && lc0.lifecycle == LUMICE_LIFECYCLE_RUNNING) {
     LUMICE_RayCount live_rays = 0;
     LUMICE_GetSimRayCount(g_server, &live_rays);
     if (live_rays == 0) {

--- a/src/gui/app.hpp
+++ b/src/gui/app.hpp
@@ -269,15 +269,25 @@ void CalibrateQualityThreshold();
 // Callers that mirror main.cpp's 70ms throttle (dirty-clear / restart accounting)
 // MUST gate those side effects on the returned bool — see main.cpp,
 // test/gui/test_gui_main.cpp, test/gui/responsiveness/test_gui_perf.cpp.
-// Callers outside the auto-commit throttle (button clicks, DoOpen/DoNew paths)
-// are expected to run when the current Run is not RUNNING, so the gate
-// short-circuits open and they may discard the return value. This expectation is
-// NOT code-enforced: a non-throttle DoRun racing into the narrow
-// RUNNING-but-first-batch-not-yet-landed window would be gated and its commit
-// dropped with no automatic retry. That window is transient (first batch is
-// ~O(100ms)) and no current non-throttle caller is reachable during it; revisit
-// (add an explicit retry or assert) if a future UI path can trigger DoRun
-// mid-first-batch.
+//
+// That gate applies to `user_initiated == false` ONLY, so `false` can never be
+// returned to a user-initiated caller: an explicit Run always reaches either a
+// commit or a pre-commit validation failure, and both of those are `true`. The
+// gate defends against a machine cadence (a continuous 70ms re-submit while a
+// slider is dragged), which a click does not have; and gating a click has a cost
+// of its own — the commit is dropped silently, so a user who dismissed the
+// overflow modal and deliberately pressed Run again would get nothing back at
+// all. The mechanism is spelled out at the gate itself in app.cpp.
+//
+// The obligation that moves onto the caller: because nothing inside this function
+// throttles a user-initiated call any more, a NEW user-initiated call site must
+// itself ensure it cannot fire back-to-back into a Run that is still RUNNING with
+// no batch consumed. Both call sites today do that the same way and it is the
+// pattern to follow — the top-bar Run button and the Save-Modified popup's "Run
+// first" are drawn only while no Run is in flight (see IsSimulating / IsStopping
+// in sim_state_rules.hpp), so neither is clickable during that window. A caller
+// that cannot make that guarantee (a key repeat, a scripted or batch entry point)
+// needs its own throttle before it calls here; this function will not supply one.
 //
 // task-gui-feedback-affordances Step 2 (AC3) — `user_initiated` distinguishes
 // user-clicked Run (top-bar Run button, "Run first" in the Save-Modified

--- a/test/composition-correctness/gui/test_run_warning_chain.cpp
+++ b/test/composition-correctness/gui/test_run_warning_chain.cpp
@@ -15,8 +15,8 @@
 // message, dismisses it, presses Run deliberately, and nothing happens at all.
 //
 // So the rule has two halves that pull against each other, and both are pinned here per trigger.
-// They do not resolve the same way on both branches — the table below says which, and says so
-// explicitly rather than asserting the symmetry a reader would assume.
+// They resolve the same way on both branches: which limit was hit decides what the message says,
+// not whether the modal comes back.
 
 #include <gtest/gtest.h>
 
@@ -129,19 +129,21 @@ TEST(RunWarningChain, ARepeatedOverflowReopensOnlyWhenTheUserAsksAgain) {
     { "a rejected filter, re-committed automatically", SeedClauseOverflowFilter, false, false },
     { "a rejected filter, Run pressed again", SeedClauseOverflowFilter, true, true },
     { "a degraded colour set, re-committed automatically", SeedColourPredicateOverflow, false, false },
-    // ⚠ The two branches DISAGREE here, and this row records the disagreement rather than the
-    // symmetry one would expect. On the rejection branch a deliberate Run clears the in-flight
-    // message first, so the modal opens again; on the degradation branch the commit succeeds and
-    // that clear does not happen, so a user who dismissed the notice and pressed Run again sees
-    // nothing at all. Measured, not assumed — this row was written expecting `true` and the
-    // product said otherwise.
+    // This row used to be pinned at `false`, on the reading that the degradation branch skips the
+    // clear-then-set that the rejection branch performs. It does not: both branches end in the
+    // same two statements, `if (user_initiated) ClearGuiWarning();` followed by
+    // `SetGuiWarning(msg)`. What actually differed was upstream of them — the rejection branch
+    // returns before LUMICE_CommitScene, so no simulation ever starts and DoRun's backpressure
+    // gate is never armed, while the degradation branch commits and leaves a Run in flight. The
+    // second DoRun then met a gate that swallowed the whole commit, and whether it did was a race
+    // against a background poller consuming the first batch, so the row was pinning a coincidence
+    // of scheduling and not a property of either branch.
     //
-    // Whether that is the intended behaviour is a product question and is deliberately not
-    // decided here: this file's job is to state what the collaboration does, and an asymmetry
-    // stated is an asymmetry someone can now argue about. Before this row existed the case was
-    // simply uncovered — the old suite pinned re-fire for the rejection branch and de-duplication
-    // for the degradation branch, and never crossed them.
-    { "a degraded colour set, Run pressed again", SeedColourPredicateOverflow, true, false },
+    // The gate now applies to the auto-commit path only (see DoRun in app.cpp), which is what
+    // makes this row decidable at all: a deliberate Run reaches its branch whatever the running
+    // simulation is doing. Both branches then reopen, which is the half of the rule this file's
+    // header calls "the user reads the message, dismisses it, presses Run, and nothing happens".
+    { "a degraded colour set, Run pressed again", SeedColourPredicateOverflow, true, true },
   };
 
   for (const Case& c : kCases) {


### PR DESCRIPTION
## 起点：一条在 `main` 上的偶发红

`RunWarningChain.ARepeatedOverflowReopensOnlyWhenTheUserAsksAgain` 的**第 4 行**累计红过 **6 次**，
跨 macOS ARM64 与 Windows MSVC，同 commit 重跑即过。它住在 `main` 上 ⇒ 任何从 main 拉分支的人都
带着它，且会被误当成自己改坏的（此前已有人为「把本分支的两条真红与这条既存红分开」花过时间）。

**本 PR 不是「把它弄绿」**——底下压着一个从未被裁定过的产品问题。

## 机制：受控实验坐实，不是推断

第 4 行的结果由 **task-364 的背压闸**决定（`DoRun` 开头：`lifecycle == RUNNING && live_rays == 0
&& < 500 ms` → `return false`，**整个提交被丢弃**）。种子只有 1000 光线（`finishes immediately if
it does start`），于是第二次 `DoRun` 走哪条路，取决于第一批有没有在两次调用之间落地：

| 实验臂 | 结果 |
|---|---|
| 不等待（首批未落，闸关） | **40/40 绿** |
| 强制首批已落（闸开） | **20/20 红** |

⇒ 双臂 100% 确定翻转。这一行钉的从来不是产品契约，是**一个仿真有没有跑完第一批**这个时序巧合；
两端都会红（机器太快 ⇒ 闸开；负载重到超过 500 ms ⇒ 闸超时强制放行）。

## 裁定：`user_initiated` 豁免背压闸

背压闸是为 **70 ms 自动提交**建的，但它今天对用户主动按的 Run 一视同仁 ⇒ **用户特意按 Run，
若距上次 Run 不到 500 ms 且第一批未落，这次 Run 被静默丢弃**——这正是该测试文件头说
「去重规则的另一半是为了防止」的那个失败（「按了 Run 什么都没发生」）。

闸条件改为 `!user_initiated && lifecycle == RUNNING`。

⭐ **论据是机制层的**：机器 70 ms 节拍 vs 用户离散点击；两个真实 user-initiated 调用点在 Run 在飞时
按钮处于禁用态，背靠背不可达。⛔ **没有**拿「测试应当对称」当论据——那会是自证循环。

⚠️ **代价明示接受**：闸的保护从此完全依赖调用方自律，`app.hpp` 里新增的调用方义务是纯文档承诺，
无机械强制。已作为一行带触发条件的账记进 backlog（触发＝出现第三个 user-initiated 调用点，
或任一现有调用点失去按钮禁用态保护）。

## 顺带改掉一段被源码推翻的注释

该行上方原有一段注释断言两条分支行为不对称，理由是降级分支「commit succeeds and **that clear does
not happen**」——**源码里两条分支的收尾是逐字相同的三行**（`if (user_initiated) ClearGuiWarning();
SetGuiWarning(msg);`）。真正的差别是：拒绝分支在 `LUMICE_CommitScene` **之前**就 return，仿真从未
启动，故背压闸未被武装。

那段注释以 "Measured, not assumed" 的口气把一次观测升格成了产品契约，并作为权威站在树上。已重写为
源码支持的说法——**这一条独立于裁定方向，无论怎么裁都要做**。

## 验证

- 红绿双态自证：把裁定的行为改反，该行转红。
- `./scripts/test.sh pr` 全绿（含 GUI 全套——改的是所有提交都要经过的 `DoRun`，不能只跑
  `composition_correctness_test`）。
- code review **APPROVE**（0 Critical / 0 Major）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Dzk6oieAM7Px5CApP2JAp