### PR TITLE
ci: compile the CUDA test TUs (close the CUDA×BUILD_TEST empty intersection)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,20 @@ concurrency:
 
 env:
   CPM_SOURCE_CACHE: ${{ github.workspace }}/cpm_cache
+  # gtest suites contributed by the five CUDA-only test TUs, defined once here because both
+  # `cuda-compile` and `windows-cuda-compile` select on it. A sixth CUDA TU means editing this
+  # one line, not two job bodies that can drift.
+  #
+  # `Cuda*` and nothing else, on purpose. test_cuda_rich_exit.cpp also registers a
+  # `RngObservabilityFacilitySmoke` suite, and widening the filter to pick it up would be
+  # actively harmful: test_metal_root_gen.cpp registers a same-named suite behind
+  # `#if defined(__APPLE__)`, so on a hypothetical macOS leg that name alone would satisfy
+  # the "at least one case was selected" assertion in scripts/ci_verify_cuda_test_tus.sh with
+  # zero CUDA TUs compiled — the exact false green the assertion exists to prevent. Nothing is
+  # lost by excluding it: each of the five TUs still contributes at least one `Cuda*` suite
+  # (CudaKShapePool / CudaGeomPoolRebuild / CudaKShapeFilterParity / CudaComponentMaskParity /
+  # CudaRichExit), so every file is represented.
+  CUDA_TU_GTEST_FILTER: "Cuda*"
 
 jobs:
   # Build + unit tests run once per PR and once per push to main.
@@ -366,6 +380,10 @@ jobs:
   # (e.g. -Werror=switch breaking nvcc, scrum-295 commit 9b9cdacd) without
   # waiting for the rsync→docker→GPU-host loop.
   #
+  # It also configures with BUILD_TEST=ON so the CUDA-only test TUs are compiled
+  # (rationale on the Configure step below). "Compile-only" still describes this
+  # job exactly: the CUDA cases it builds all self-skip for want of a device.
+  #
   # PTX floor = compute_61 (Pascal/2016+); driver JIT-compiles to native sm on
   # any GPU >= sm_61. Matches CMakeLists.txt CMAKE_CUDA_ARCHITECTURES default.
   cuda-compile:
@@ -400,24 +418,52 @@ jobs:
           key: cpm-ubuntu-x64-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: cpm-ubuntu-x64-
 
-      # BUILD_GUI=OFF avoids OpenGL/X11 deps; BUILD_TEST=OFF skips test
-      # targets (no .cu files live under test/, so coverage is complete).
-      # LUMICE_NATIVE_ARCH=OFF matches the rest of CI.
+      # BUILD_GUI=OFF avoids OpenGL/X11 deps. LUMICE_NATIVE_ARCH=OFF matches the
+      # rest of CI.
+      #
+      # BUILD_TEST=ON, not OFF, and the reason is not "more coverage is nicer".
+      # No .cu file lives under test/, so this job's older comment concluded its
+      # coverage was already complete — but five test TUs there are wrapped in
+      # `#if defined(LUMICE_CUDA_ENABLED)`
+      # (test/{unit-correctness,parity-cross-backend}/backend/test_cuda_*.cpp),
+      # and that macro comes from lumice_obj, which the four build-matrix jobs
+      # never enable. CUDA=ON and BUILD_TEST=ON had therefore never been set
+      # together on ANY platform: both halves existed, the intersection was
+      # empty, and those five files compiled to nothing everywhere in CI. The
+      # cost was paid twice — three MSVC incompatibilities that sat unreported
+      # for three weeks, and two ctest wrappers that were never registered
+      # because the build jobs have no pytest.
+      #
+      # BUILD_GUI stays OFF and does not weaken this: the five TUs belong to
+      # unit_correctness_test and parity_test, which link lumice_obj only, while
+      # gui_unit_test / composition_correctness_test / gui_test sit inside
+      # `if(BUILD_GUI)` in test/CMakeLists.txt and are not defined here at all.
       - name: Configure (CUDA compile-only)
         env:
           CUDA_PATH: /usr/local/cuda
         run: >
           cmake -S . -B build -G Ninja
           -DCMAKE_BUILD_TYPE=Release
-          -DBUILD_TEST=OFF
+          -DBUILD_TEST=ON
           -DBUILD_GUI=OFF
           -DLUMICE_CUDA_ENABLED=ON
           -DLUMICE_NATIVE_ARCH=OFF
 
-      # Builds the Lumice CLI; this drives nvcc through cuda_trace_backend.cu
-      # and links CUDA::cudart, exercising both compile and link paths.
-      - name: Build (compiles cuda_trace_backend.cu)
+      # Builds the Lumice CLI plus the test binaries; this drives nvcc through
+      # cuda_trace_backend.cu and links CUDA::cudart, exercising both compile and
+      # link paths, and host-compiles the five CUDA test TUs with the macro on.
+      - name: Build (compiles cuda_trace_backend.cu + the CUDA test TUs)
         run: cmake --build build --parallel
+
+      # Compile coverage only — every case is expected to report SKIPPED, since no GPU is
+      # attached. This step exists to prove the CUDA TUs are non-empty and that their skip
+      # guard works; it does NOT give this job runtime or parity coverage, which still runs
+      # on the reference machines. GTEST_FILTER keeps it to ~26 cases instead of the ~1100
+      # the two binaries hold, so it costs seconds and does not duplicate the build-matrix
+      # jobs' full ctest.
+      - name: Verify CUDA test TUs compile in and self-skip (SKIPPED expected, not a GPU check)
+        shell: bash
+        run: ./scripts/ci_verify_cuda_test_tus.sh build "$CUDA_TU_GTEST_FILTER"
 
   # Windows CUDA compile-only: nvcc + MSVC on windows-2022.
   #
@@ -538,25 +584,39 @@ jobs:
           key: cpm-windows-msvc-x64-cuda-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: cpm-windows-msvc-x64-cuda-
 
-      # BUILD_GUI=OFF + BUILD_TEST=OFF mirrors the Linux cuda-compile job:
-      # no GLAD2/Python generator is invoked (that step is gated on
-      # matrix.build_gui == 'ON' in the build job above), and no test
-      # translation unit owns a .cu file so coverage is complete.
-      # LUMICE_NATIVE_ARCH=OFF matches the rest of CI.
+      # BUILD_GUI=OFF + BUILD_TEST=ON mirrors the Linux cuda-compile job: no
+      # GLAD2/Python generator is invoked (that step is gated on
+      # matrix.build_gui == 'ON' in the build job above), and the five
+      # `#if defined(LUMICE_CUDA_ENABLED)` test TUs get compiled instead of
+      # collapsing to nothing. See the Linux job's Configure comment for why
+      # BUILD_TEST=OFF was the wrong reading of "no .cu file lives under test/".
+      #
+      # This leg is the one that matters most for that gap: the historical
+      # escapes it would have caught were MSVC-only source incompatibilities
+      # (POSIX setenv/unsetenv, M_PI) in test code, which no other job compiles
+      # with CUDA on. LUMICE_NATIVE_ARCH=OFF matches the rest of CI.
       - name: Configure (CUDA compile-only)
         run: >
           cmake -S . -B build -G Ninja
           -DCMAKE_BUILD_TYPE=Release
-          -DBUILD_TEST=OFF
+          -DBUILD_TEST=ON
           -DBUILD_GUI=OFF
           -DLUMICE_CUDA_ENABLED=ON
           -DLUMICE_NATIVE_ARCH=OFF
 
-      # Build the Lumice CLI; this drives nvcc through cuda_trace_backend.cu
-      # and links CUDA::cudart, exercising both compile and link paths under
-      # MSVC. AC2 = this step's log must show nvcc invocation for the .cu TU.
-      - name: Build (compiles cuda_trace_backend.cu via nvcc)
+      # Build the Lumice CLI plus the test binaries; this drives nvcc through
+      # cuda_trace_backend.cu and links CUDA::cudart, exercising both compile and
+      # link paths under MSVC, and compiles the CUDA test TUs through cl.exe.
+      # This step's log must show nvcc invocation for the .cu TU.
+      - name: Build (compiles cuda_trace_backend.cu via nvcc + the CUDA test TUs)
         run: cmake --build build --parallel
+
+      # Same gate as the Linux job, same script, same expectation: every selected case
+      # SKIPPED because windows-2022 hosted runners have no GPU. `shell: bash` is deliberate —
+      # it lets both jobs share one implementation rather than maintaining a pwsh twin.
+      - name: Verify CUDA test TUs compile in and self-skip (SKIPPED expected, not a GPU check)
+        shell: bash
+        run: ./scripts/ci_verify_cuda_test_tus.sh build "$CUDA_TU_GTEST_FILTER"
 
   # Bench compile-only: builds the `lumice_bench` target so BUILD_BENCH=ON cannot
   # rot again. It does NOT run the benchmarks — numbers off a shared, throttled

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -559,10 +559,18 @@ Valuable design/architecture docs live in `doc/` (tracked). Consult the relevant
     `LUMICE_HAS_CUDA` un-skip 闸（须与 `LUMICE_CUDA_ENABLED` **同设**，二者语义不同）、
     parity battery 三文件、验收口径 10/10、「别信 subprocess 自报」纪律，以及 Linux/Windows 两个
     参照机角色各自的 build / parity / 冒烟命令。主机绑定见 `machines.md`。
-    ⚠️ **Windows + CUDA + `BUILD_TEST=ON` 至今没有任何 CI job 走过**——主矩阵 Windows job 开
-    `BUILD_TEST` 但没开 CUDA、CUDA job 开 CUDA 但没开 `BUILD_TEST`，**两半都在、交集为空**。
-    这个缺口一次攒下三处 MSVC 不兼容、三周无信号；它们已修，但缺口本身还在 ⇒ 动 `test/` 或
-    `bench/` 后别拿 mac/Linux 的绿推断 Windows 也绿。
+    ⚠️ **CUDA + `BUILD_TEST=ON` 的编译缺口曾是全平台的，现已在 CI 上补掉（编译那一半）**——
+    旧状态：主矩阵四个 build job 开 `BUILD_TEST` 但没开 CUDA、两个 CUDA job 开 CUDA 但没开
+    `BUILD_TEST`，**两半都在、交集为空**，于是 `test/{unit-correctness,parity-cross-backend}/backend/`
+    下那 5 个包在 `#if defined(LUMICE_CUDA_ENABLED)` 里的 TU 在**每一个**平台的 CI 里都编成空文件
+    （⚠️ 这条以前被写成 Windows 特有，是错的：Windows 只是代价最先显形的那一侧）。
+    这个缺口一次攒下三处 MSVC 不兼容、三周无信号。现在 `cuda-compile` 与 `windows-cuda-compile`
+    都以 `BUILD_TEST=ON`（`BUILD_GUI=OFF`）配置，那 5 个 TU 真的被编译，
+    `scripts/ci_verify_cuda_test_tus.sh` 再断言它们至少选中一个 case（`gtest` 在 filter 匹配 0 个时
+    退出码是 0，所以裸跑 ctest 在「TU 仍为空」时照样绿——这条断言就是为堵这个假绿而存在）。
+    ⛔ **买到的只有编译覆盖**：CI runner 没有 GPU，那些 case 一律 SKIPPED；运行时 / parity 验证
+    仍然只在参照机上按本节协议手动跑 ⇒ 动 `test/` 或 `bench/` 后，语法与可移植性有自动信号了，
+    但别拿 CI 的绿推断 CUDA 运行时行为也验过。
     与 `windows-remote-testing.md`（GUI VSync 物理桌面）场景正交。
   - `testing-architecture.md` — **authoritative test-organization spec**: verification-purpose primary axis × subsystem tag, seven layers (unit-correctness / golden-analytic / parity-cross-backend / e2e-correctness / performance / gui / regression-sentinel), the "how to add a test" decision tree, cross-cutting rules (perf denominator = legacy CPU; parity metric-masks-bugs battery; reference ownership), and the layer×subsystem physical-layout blueprint. **§7 is the test-scope contract**: measured per-scope cost (local `quick`/`full`/`pr` and all 16 CI jobs), what each scope catches that the cheaper one structurally cannot, the budget rule (who declares expected test spend, and when they reconcile it), and why independent re-verification is a fixed-cost multiplier that makes cutting base suite cost worth more than its face value. Read before adding or reorganizing any test — and before claiming any change shortens CI.
 - **Engineering policy**: `env-var-policy.md` — **环境变量使用策略**: user-facing behavior switches must NOT live only in env vars (they cause silent per-machine drift / undebuggable bugs); use CLI/config/API instead. A-class runtime knobs (`LUMICE_TRACE_BACKEND` + 6 perf knobs, with file:line) vs B-class test/build infra (leave alone); three disposition rules; and the **decision gate to answer before adding any new `getenv`**. Read before introducing a new env knob.

--- a/doc/gpu-remote-cuda-build-testing.md
+++ b/doc/gpu-remote-cuda-build-testing.md
@@ -143,15 +143,21 @@
   ⚠️ 长时间构建**别用 `Start-Process` 分离**（实测会静默失败、日志为空）；
   要么同步跑（我方 bash 用后台任务拿 notification），要么用 `schtasks` 建一次性计划任务。
 
-- **⚠️ 这条路径至今没有任何 CI job 走过，所以它的红只会在这台机器上出现。**
-  Windows 上「带 CUDA 编译测试」这个配置的覆盖缺口**仍然存在**，而原因不是漏了 Windows：
-  主矩阵的 Windows job 开了 `BUILD_TEST` 但没开 CUDA、CUDA 编译 job 开了 CUDA 但没开
-  `BUILD_TEST`——**两半都在，交集为空**。这个缺口一次攒下三处 MSVC 不兼容
+- **⚠️ 这条路径的「编译」那一半现在 CI 也走了，「运行」那一半仍然只在这台机器上。**
+  历史状态（2026-09-09 之前）：主矩阵的四个 build job 开了 `BUILD_TEST` 但没开 CUDA、两个 CUDA
+  编译 job 开了 CUDA 但没开 `BUILD_TEST`——**两半都在，交集为空**，而且这个空交集是**全平台**的，
+  不是 Windows 特有（Windows 只是代价最先显形的那一侧）。这个缺口一次攒下三处 MSVC 不兼容
   （两个 `test_cuda_*` 用 POSIX `setenv`/`unsetenv`、一个 bench 文件用 `M_PI`），
   三周无信号，直到这台机器第一次以 `BUILD_TEST=ON` + CUDA 构建才炸出来；它们已经修掉
-  （`test/support/env_var.hpp` 是全树唯一持有该 `#ifdef` 的地方），但**攒下它们的缺口没有**。
-  ⇒ 在缺口补上之前，动 `test/` 或 `bench/` 后请在这台机器上真跑一次本节的构建，
-  别把「mac/Linux 绿」当成 Windows 也绿。
+  （`test/support/env_var.hpp` 是全树唯一持有该 `#ifdef` 的地方）。
+  现在 `cuda-compile` 与 `windows-cuda-compile` 两个 job 都以 `BUILD_TEST=ON` + `BUILD_GUI=OFF`
+  配置，`test/{unit-correctness,parity-cross-backend}/backend/test_cuda_*.cpp` 那 5 个 TU 真的会被
+  编译，同类语法 / 可移植性缺陷在 PR 上当场报错。
+  ⛔ **但这只买到编译覆盖。** CI runner 没有 GPU，那些 case 一律走 `ShouldSkipCudaTests()` /
+  `CudaDeviceAvailable()` 报 SKIPPED；`LUMICE_HAS_CUDA` 也没有任何 CI job 设过。
+  ⇒ 动 `test/` 或 `bench/` 后可以先看 CI 的这两个 job 判断「编不编得过」，
+  但凡涉及 CUDA 运行时行为（parity、数值、吞吐），仍然必须在这台机器上真跑本节的协议，
+  别把 CI 的绿当成运行时也验过了。
 
 - **parity**：
   ```bat

--- a/scripts/ci_verify_cuda_test_tus.sh
+++ b/scripts/ci_verify_cuda_test_tus.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Verify that the CUDA-only test translation units are actually compiled INTO the
+# unit-correctness and parity binaries, and that their cases self-skip rather than fail on a
+# runner with no CUDA device.
+#
+# Why this is a script and not two inline `run:` blocks: both `cuda-compile` (Linux) and
+# `windows-cuda-compile` (Windows) call it, and the two must not drift apart. Both invoke it
+# through `shell: bash`, which windows-2022 provides.
+#
+# Why it asserts a case count instead of just running ctest: the CUDA test TUs are wrapped in
+# `#if defined(LUMICE_CUDA_ENABLED)`. Without that macro they compile to nothing, GTEST_FILTER
+# then selects zero cases, and gtest exits 0 — so a bare ctest run is GREEN in exactly the state
+# this gate exists to detect (that state was the status quo on every platform until these two
+# jobs started configuring with BUILD_TEST=ON). Requiring at least one selected case per binary
+# is what turns "still an empty TU" into a red.
+#
+# Scope: this is COMPILE coverage. Every case here is expected to report SKIPPED, because no GPU
+# is attached to these runners. Runtime and parity validation still run on the CUDA reference
+# machines under the manual protocol in doc/gpu-remote-cuda-build-testing.md; a green run here
+# must not be read as "CUDA all green".
+
+set -euo pipefail
+
+build_dir="${1:?usage: $0 <build-dir> <gtest-filter>}"
+gtest_filter="${2:?usage: $0 <build-dir> <gtest-filter>}"
+
+status=0
+
+for test_name in LumiceUnitCorrectnessTest LumiceParityTest; do
+  log="ctest-${test_name}.log"
+  echo "=== ${test_name} (GTEST_FILTER=${gtest_filter}) ==="
+
+  # --no-tests=error: an empty ctest selection is a broken gate, not a pass. ctest's default
+  # action for "no tests matched" is not something to leave implicit here.
+  if ! GTEST_FILTER="${gtest_filter}" ctest --test-dir "${build_dir}" \
+      -R "^${test_name}\$" --no-tests=error --verbose >"${log}" 2>&1; then
+    cat "${log}"
+    echo "ERROR: ${test_name} did not pass."
+    echo "       On a GPU-less runner every selected CUDA case must SKIP. A FAILED case means the"
+    echo "       ShouldSkipCudaTests()/CudaDeviceAvailable() guard itself is broken — report that"
+    echo "       rather than relaxing this gate."
+    status=1
+    continue
+  fi
+
+  # gtest prints "[==========] Running N tests from M test suites." once per run; ctest --verbose
+  # prefixes it with the test index, hence the leading `.*`.
+  selected="$(sed -n 's/.*Running \([0-9][0-9]*\) test.*/\1/p' "${log}" | head -n 1)"
+  if [ -z "${selected}" ] || [ "${selected}" -eq 0 ]; then
+    cat "${log}"
+    echo "ERROR: ${test_name} selected 0 cases under GTEST_FILTER='${gtest_filter}'."
+    echo "       The CUDA test TUs compiled to nothing, which is the exact gap this job closes."
+    echo "       Check that the configure step still passes -DBUILD_TEST=ON -DLUMICE_CUDA_ENABLED=ON."
+    status=1
+    continue
+  fi
+
+  echo "${test_name}: ${selected} CUDA case(s) selected (SKIPPED expected on a GPU-less runner)."
+  grep -E '\[  SKIPPED \]|\[       OK \]|\[  FAILED  \]' "${log}" || true
+done
+
+exit "${status}"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -427,19 +427,37 @@ endif()
 # label that `ctest -L "unit-correctness|composition-correctness|parity|golden-analytic"` selects.
 # Where these two actually run, which is not where a reader assumes:
 #
-# This find_program gates the whole block, and CI's four build-matrix jobs never install
-# pytest — so on those runners PYTEST_EXECUTABLE is not found, the if() body does not execute,
-# and neither test is ever REGISTERED. Their ctest step reports "out of 3"; the same selector
-# locally reports 5. The two missing ones are exactly CudaMultiMsParity and
+# This find_program gates the whole block, and no CI job that configures with BUILD_TEST=ON
+# installs pytest — not the four build-matrix jobs, and not the two CUDA compile jobs that
+# joined them. So on those runners PYTEST_EXECUTABLE is not found, the if() body does not
+# execute, and neither test is ever REGISTERED. The build-matrix ctest step reports "out of 3";
+# the same selector locally reports 5. The two missing ones are exactly CudaMultiMsParity and
 # CudaRandomGeometryParity.
 #
 # So the capture point for these is a local `./scripts/test.sh quick` (or a direct ctest on
 # a CUDA-capable host), NOT CI. Stated here because "it's an add_test, therefore CI runs it" is
 # the natural reading and it is wrong.
 #
-# Deliberately NOT resolved here: whether to install pytest in the build jobs (making them run)
-# or to accept the status quo (leaving them local-only) is a decision with cost on both sides
-# and is not this comment's to make. Both readings leave the paragraph above true.
+# RESOLVED (2026-09-09): the status quo stands — the build jobs do NOT install pytest, and these
+# two stay unregistered there. What settled it is that the signal installing pytest would buy is
+# already bought, by a job that has had pytest all along. `e2e-test` runs
+# `pytest -v -m "not slow"` over pyproject.toml's testpaths, which include test/parity-cross-backend,
+# and pytest IMPORTS a module before it can read its marks — deselection happens after collection.
+# So both files are imported on every PR today, and an ImportError, a syntax error, or a broken
+# `from test.e2e...` in either of them is already a red there. Measured rather than reasoned:
+# injecting `import __definitely_not_a_module__` into test_cuda_multi_ms_parity.py turns that exact
+# invocation into "1 error during collection", exit 2.
+#
+# What registering them in the build jobs would still buy is thin: a guard that these two add_test()
+# lines themselves stay well-formed (the `-m slow` above, the file paths). It cannot buy any test
+# execution — the pytest guard is `LUMICE_HAS_CUDA == "1"`, which no CI job sets, so every case
+# would report SKIPPED on every runner forever. Paying six `pip install` steps and a permanent
+# Python dependency in the build jobs for always-skipped rows is not worth it; the burden of proof
+# is on the side that adds.
+#
+# Two things would flip this: a CI runner that actually has a CUDA device (then these should run,
+# not just register), or `e2e-test` ceasing to collect test/parity-cross-backend (then the import
+# coverage above disappears and this paragraph is void).
 find_program(PYTEST_EXECUTABLE NAMES pytest pytest3 HINTS ENV PATH)
 if(PYTEST_EXECUTABLE)
   add_test(NAME "CudaMultiMsParity"

--- a/test/unit-correctness/backend/test_cuda_geom_pool_rebuild.cpp
+++ b/test/unit-correctness/backend/test_cuda_geom_pool_rebuild.cpp
@@ -39,12 +39,6 @@
 #include "core/backend/trace_backend.hpp"
 #include "cuda_test_helpers.hpp"
 
-// TEMPORARY red-state probe, reverted by the very next commit. A platform-independent compile
-// error placed inside the LUMICE_CUDA_ENABLED guard: the two CUDA compile jobs must turn red on
-// it, and every other job must stay green (this TU is empty for them). Without that pair of
-// observations, "the job is green" cannot distinguish a compiled TU from an empty one.
-static_assert(false, "red-state probe: this file must actually be compiled by the CUDA jobs");
-
 namespace lumice {
 namespace {
 

--- a/test/unit-correctness/backend/test_cuda_geom_pool_rebuild.cpp
+++ b/test/unit-correctness/backend/test_cuda_geom_pool_rebuild.cpp
@@ -39,6 +39,12 @@
 #include "core/backend/trace_backend.hpp"
 #include "cuda_test_helpers.hpp"
 
+// TEMPORARY red-state probe, reverted by the very next commit. A platform-independent compile
+// error placed inside the LUMICE_CUDA_ENABLED guard: the two CUDA compile jobs must turn red on
+// it, and every other job must stay green (this TU is empty for them). Without that pair of
+// observations, "the job is green" cannot distinguish a compiled TU from an empty one.
+static_assert(false, "red-state probe: this file must actually be compiled by the CUDA jobs");
+
 namespace lumice {
 namespace {
 


### PR DESCRIPTION
## What

`cuda-compile` (Linux) and `windows-cuda-compile` (Windows) configured with `-DBUILD_TEST=OFF`, and the four build-matrix jobs never set `LUMICE_CUDA_ENABLED`. `CUDA=ON` and `BUILD_TEST=ON` had therefore **never been set together on any platform** — both halves existed, the intersection was empty. The five test TUs wrapped in `#if defined(LUMICE_CUDA_ENABLED)` compiled to nothing everywhere in CI:

- `test/unit-correctness/backend/test_cuda_kshape_pool_locality.cpp`
- `test/unit-correctness/backend/test_cuda_geom_pool_rebuild.cpp`
- `test/parity-cross-backend/backend/test_cuda_kshape_filter_parity.cpp`
- `test/parity-cross-backend/backend/test_cuda_component_mask_parity.cpp`
- `test/parity-cross-backend/backend/test_cuda_rich_exit.cpp`

That gap has been paid for twice: three MSVC incompatibilities that sat unreported for three weeks, and two ctest wrappers that were never registered.

This PR buys the **compile** half only. Runtime/parity validation still needs a real GPU and stays on the reference machines under the manual protocol; a green run here must not be read as "CUDA all green".

## How

- Both CUDA jobs configure with `-DBUILD_TEST=ON` (`BUILD_GUI` stays `OFF` — the five TUs belong to `unit_correctness_test` / `parity_test`, which link `lumice_obj` only).
- New shared step calling `scripts/ci_verify_cuda_test_tus.sh`, which runs the CUDA cases under `GTEST_FILTER` and asserts each binary selected at least one case. A bare `ctest` would not do: gtest exits 0 when a filter matches nothing, so it would be green in exactly the empty-TU state being closed here.
- The filter is `Cuda*`, not `Cuda*:RngObservabilityFacilitySmoke.*`: that suite name is registered by both `test_cuda_rich_exit.cpp` and the Apple-only `test_metal_root_gen.cpp`, so the wider filter could satisfy the count assertion with no CUDA TU compiled. Every one of the five TUs still contributes at least one `Cuda*` suite.

## Evidence

**The TUs are really compiled now (red/green pair).** A `static_assert(false, ...)` was pushed inside the CUDA guard and reverted by the next commit — both commits are in this branch's history on purpose.

- Red (`56c70eb3`): `cuda-compile` and `windows-cuda-compile` failed — and **only** those two. gcc reported `static assertion failed`, MSVC `error C2338`. All thirteen other jobs passed, including the four `BUILD_TEST=ON` matrix builds that compile the very same file, where the TU is still empty.
- Green (`26ed5293`): after the revert, all sixteen jobs pass.

**The cases run and skip, they do not fail.** Both CUDA jobs report `LumiceUnitCorrectnessTest: 7 CUDA case(s) selected` and `LumiceParityTest: 16 CUDA case(s) selected` — 23 cases, all `[  SKIPPED ]`, zero `[  FAILED  ]`. The `ShouldSkipCudaTests()` / `CudaDeviceAvailable()` guards work on a GPU-less runner.

**Cost, measured rather than estimated** (job duration, same denominator as `doc/testing-architecture.md` §7.1):

| job | before | after |
|---|---|---|
| `cuda-compile` | 164s | 247s / 315s |
| `windows-cuda-compile` | 221s | 405s / 399s |
| ceiling (`shared-gui-test-build`) | 734s | 703s (same run) |

Both stay far below the critical path, which is still set by `shared-gui-test-build`, so the run's wall clock is unchanged and no narrowed build (`--target unit_correctness_test parity_test`) is needed. The Windows CPM cache was restored, not cold, so 405s is not inflated by a one-off GTest download.

## Also settled here

`test/CMakeLists.txt` carried an explicitly unresolved question: install pytest in the build jobs so `CudaMultiMsParity` / `CudaRandomGeometryParity` register, or leave them local-only. **Resolved as "leave them", with a reason.** The signal installing pytest would buy is already bought: `e2e-test` runs `pytest -m "not slow"` over testpaths that include `test/parity-cross-backend`, and pytest imports a module before it can read its marks — so both files are imported on every PR today. Verified by injecting a bad import into one of them: that exact invocation becomes `1 error during collection`, exit 2. Registering them in the build jobs could not add any execution either, since their guard is `LUMICE_HAS_CUDA == "1"` and no CI job sets it. The comment now also names the two things that would flip the verdict.

`AGENTS.md` and `doc/gpu-remote-cuda-build-testing.md` both described the gap as Windows-specific. It was not — Windows was just where the cost surfaced first. Both passages are corrected, and both say plainly that only the compile half is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184mYskQTetEJZJTmQxkcTk