### PR TITLE
[measurement, do not merge] ccache on the two compile-bound CI legs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,13 @@ jobs:
           echo "SCCACHE_CACHE_SIZE=2G" >> $env:GITHUB_ENV
 
       # [MEASUREMENT BRANCH — DO NOT MERGE] ccache on the Ubuntu x86_64 leg. Mirrors the sccache leg
+      # NOTE on the key namespace: it is `ccache-static-ubuntu-x64-`, not `ccache-ubuntu-x64-`,
+      # because `restore-keys` matches by PREFIX. A `ccache-ubuntu-x64-` fallback also matches
+      # `ccache-ubuntu-x64-shared-gui-test-<sha>`, so this leg silently restored the shared
+      # flavour's cache and hit 2.35% instead of 99.66% -- measured, first time round. The same
+      # prefix relation exists between the `cpm-ubuntu-x64-` restore key and both
+      # `cpm-ubuntu-x64-bench-` and `cpm-ubuntu-x64-shared-gui-test-`, which is a live issue in
+      # this file independent of this branch.
       # above rather than inventing a second shape: same launcher-via-env-var injection
       # (so the shared Configure step below needs no branch), same "one cache entry per
       # commit + restore-keys fallback" key shape. Throwaway measurement branch — not to merge.
@@ -184,8 +191,8 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ccache_cache
-          key: ccache-ubuntu-x64-${{ github.sha }}
-          restore-keys: ccache-ubuntu-x64-
+          key: ccache-static-ubuntu-x64-${{ github.sha }}
+          restore-keys: ccache-static-ubuntu-x64-
 
       # GLAD2 runs the Python code generator at CMake configure time (needs Jinja2).
       - name: Install GLAD2 Python dependencies (MSVC)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,27 @@ jobs:
           echo "SCCACHE_DIR=$env:GITHUB_WORKSPACE\sccache_cache" >> $env:GITHUB_ENV
           echo "SCCACHE_CACHE_SIZE=2G" >> $env:GITHUB_ENV
 
+      # [MEASUREMENT BRANCH — DO NOT MERGE] ccache on the Ubuntu x86_64 leg. Mirrors the sccache leg
+      # above rather than inventing a second shape: same launcher-via-env-var injection
+      # (so the shared Configure step below needs no branch), same "one cache entry per
+      # commit + restore-keys fallback" key shape. Throwaway measurement branch — not to merge.
+      - name: Install ccache (Ubuntu x86_64)
+        if: matrix.cache_key == 'ubuntu-x64'
+        run: |
+          sudo apt-get update && sudo apt-get install -y ccache
+          ccache --version
+          echo "LUMICE_SCCACHE_ARGS=-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
+          echo "CCACHE_DIR=$GITHUB_WORKSPACE/ccache_cache" >> $GITHUB_ENV
+          echo "CCACHE_MAXSIZE=2G" >> $GITHUB_ENV
+
+      - name: Cache ccache directory (Ubuntu x86_64)
+        if: matrix.cache_key == 'ubuntu-x64'
+        uses: actions/cache@v6
+        with:
+          path: ccache_cache
+          key: ccache-ubuntu-x64-${{ github.sha }}
+          restore-keys: ccache-ubuntu-x64-
+
       # GLAD2 runs the Python code generator at CMake configure time (needs Jinja2).
       - name: Install GLAD2 Python dependencies (MSVC)
         if: matrix.msvc && matrix.build_gui == 'ON'
@@ -229,6 +250,13 @@ jobs:
       # slow Build was a cold cache or a real regression. Stopping the server afterwards
       # flushes its state to disk before actions/cache's post-step packs the directory; no
       # compilation happens after this point in the job.
+      # [MEASUREMENT BRANCH — DO NOT MERGE] Hit rate is the second, independent evidence chain: wall
+      # clock alone cannot separate "cache worked" from "faster runner" (measured ~1.5x spread
+      # on identical work, 331 ninja steps either way). Never a gate — hence `|| true`.
+      - name: ccache statistics (Ubuntu x86_64)
+        if: always() && matrix.cache_key == 'ubuntu-x64'
+        run: ccache --show-stats --verbose || true
+
       - name: sccache statistics (Windows MSVC)
         if: always() && matrix.msvc
         shell: bash
@@ -707,6 +735,24 @@ jobs:
           key: cpm-ubuntu-x64-shared-gui-test-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: cpm-ubuntu-x64-shared-gui-test-
 
+      # [MEASUREMENT BRANCH — DO NOT MERGE] ccache on the critical-path leg. This job is 93% compile
+      # (659/708 s measured), and no compiler cache reaches it today: ci.yml's sccache comment
+      # says it is installed "on the one leg where compilation is most of the job", which was
+      # true when written and is not any more. Throwaway measurement branch — not to merge.
+      - name: Install ccache
+        run: |
+          sudo apt-get install -y ccache
+          ccache --version
+          echo "CCACHE_DIR=$GITHUB_WORKSPACE/ccache_cache" >> $GITHUB_ENV
+          echo "CCACHE_MAXSIZE=2G" >> $GITHUB_ENV
+
+      - name: Cache ccache directory
+        uses: actions/cache@v6
+        with:
+          path: ccache_cache
+          key: ccache-ubuntu-x64-shared-gui-test-${{ github.sha }}
+          restore-keys: ccache-ubuntu-x64-shared-gui-test-
+
       - name: Configure (shared + test + GUI)
         run: >
           cmake -S . -B build -G Ninja
@@ -715,9 +761,16 @@ jobs:
           -DBUILD_GUI=ON
           -DBUILD_SHARED_LIBS=ON
           -DLUMICE_NATIVE_ARCH=OFF
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
       - name: Build (compile + link only, no run)
         run: cmake --build build --parallel
+
+      # [MEASUREMENT BRANCH — DO NOT MERGE] see the ccache statistics step in the build job.
+      - name: ccache statistics
+        if: always()
+        run: ccache --show-stats --verbose || true
 
   e2e-test:
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'


### PR DESCRIPTION
**草稿，用于取证，不合并。** 收完数据即关闭并删分支。

## 为什么

先量后改。六次 CI run（三次 push-to-main、三次 pull_request）：

- `shared-gui-test-build` **6/6 都是关键路径**（690–732 s），它的 `Build` 步占该 job 的 **93%**（659/708 s），而这一步的名字就是 `compile + link only, **no run**`。
- `Ubuntu x86_64` **82% 是编译**（506/617 s）；它真正**跑**的东西合计只有 **~81 s**（Test 40 + Benchmark 18 + 视觉回归 11 + AC6 核实 12）。
- 这两条腿**都没有任何编译器缓存**。`ci.yml` 里 sccache 的注释写着装在 "the one leg where compilation is most of the job" —— 写下时成立，今天不再成立。

## 改了什么

只动 `ci.yml`，形态照抄 Windows MSVC 的 sccache 那条腿，不另发明：launcher 经环境变量注入（共享的 Configure 步骤因此不需要自己的分支），缓存键取「一个 commit 一条目 + `restore-keys` 回落到最近的更早那条」。

## 判据为什么是两条链路

墙钟单独扛不动这个结论：**托管 runner 在完全相同的工作量上有 ~1.5× 速度差**——同一个 job、两次 run 的 ninja 步数都是 **331**，而构建跨度是 **340.3 s vs 506.0 s**。所以单次「冷/热」对照与「换了台机器」不可区分。

因此：

1. `ccache --show-stats` 的**命中率**，作为独立于墙钟的第二条链路；
2. 静态那条腿上的**「编译时间 / 链接时间」比值**作为**同 job 内部对照**——编译器缓存**碰不到链接**，机器快慢对分子分母同比例作用而被约掉。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dkvtps96RwKXNENDHzATdu