### PR TITLE
fix(gui): reject malformed raypath summand rows on the .lmc load path

### DIFF
--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -802,6 +802,7 @@ void DoOpen(const std::filesystem::path& path) {
   // can leave a count behind that belongs to no load at all.
   TakeShapeDistDowngradeCount();
   TakeFilterNoPredicateDowngradeCount();
+  TakeInvalidSummandRowCount();
   bool tex_radiance_only = false;
   if (LoadLmcFile(path, g_state, tex_data, tex_w, tex_h, tex_radiance_only)) {
     // Data restore + command-semantic fields (path/dirty/run_intent stay in handler).
@@ -840,6 +841,19 @@ void DoOpen(const std::filesystem::path& path) {
           "Some filters in this file described no rule (no ray paths and no entry/exit faces). They "
           "were loaded as no filter at all, so the entries they belonged to now let every ray "
           "through. Re-add the rule in the entry's Filter tab if the file was meant to carry one.");
+    }
+
+    // Notify: a filter row in the file was not a valid filter expression — an empty step in a face
+    // path ("3--5", "-3-5", "3-5-"), a face number no crystal has, a malformed entry:/exit:/len:
+    // factor. The row was dropped. It used to be read by the tolerant parser instead, which skips
+    // what it cannot make sense of, so "3--5" loaded as the path 3-5: a path that looks entirely
+    // reasonable and is not the one the file states. Same one-time popup as the two notices above.
+    if (TakeInvalidSummandRowCount() > 0) {
+      SetImportComplexFilterWarning(
+          "Some filter rows in this file were not valid filter expressions (for example a face path "
+          "with an empty step, like \"3--5\"). Those rows were dropped rather than guessed at, so "
+          "the filters they belonged to now match less than the file described. Re-enter the "
+          "affected rows in the entry's Filter tab.");
     }
   }
 }

--- a/src/gui/file_io.cpp
+++ b/src/gui/file_io.cpp
@@ -14,6 +14,7 @@
 #include <map>
 #include <nlohmann/json.hpp>
 #include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -1081,6 +1082,19 @@ int TakeRaypathCommaMigratedCount() {
   return n;
 }
 
+// Count of `summands` rows dropped on load because the text was not a valid filter expression (an
+// empty face-path token such as "3--5", a face number no crystal has, a malformed entry:/exit:/len:
+// factor). Same TU-local counter shape as the three above, and the same "drain once before a load
+// to discard any stale count, read again after it" discipline the Shape / FilterNoPredicate pair
+// follows in DoOpen -- this is a third member of that family, not a new concept.
+static int g_invalid_summand_row_count = 0;
+
+int TakeInvalidSummandRowCount() {
+  int n = g_invalid_summand_row_count;
+  g_invalid_summand_row_count = 0;
+  return n;
+}
+
 // The single place that decides both "how is a legacy ',' rewritten" and "does that count". Both
 // readers below need the pair, and they need the same answer; a second spelling of it is a second
 // thing to keep in sync. The two call sites keep their own downstream construction (a SummandText
@@ -1095,14 +1109,15 @@ static std::string MigrateAndCountRaypathComma(const std::string& text) {
 
 // The single disposition point for "the file's filter object states no predicate".
 //
-// Both readers below can end there — a v3 `summands` array that yields no rows, and a legacy form
-// whose `raypath_text` is absent or empty (including an unknown/removed `type` that falls through
-// to the raypath arm). Both used to answer it by writing a 1-row / 1-factor SoP holding an empty
-// RaypathParams. That shape is NOT "no filter": a row carrying a factor whose text is empty is the
-// editor's match-all and commits as core's `none`, so under filter_out the entry excluded every ray
-// and the render was black, with nothing on screen saying why. Under filter_in it admitted
-// everything, so the same shape was harmless there — the harm is asymmetric in `action`, while
-// having no filter at all is harmless under both.
+// Both readers below can end there — a v3 `summands` array that yields no rows (either because the
+// array was empty, or because every row in it was refused by the syntax gate in the reader below),
+// and a legacy form whose `raypath_text` is absent or empty (including an unknown/removed `type`
+// that falls through to the raypath arm). Both used to answer it by writing a 1-row / 1-factor SoP
+// holding an empty RaypathParams. That shape is NOT "no filter": a row carrying a factor whose text
+// is empty is the editor's match-all and commits as core's `none`, so under filter_out the entry
+// excluded every ray and the render was black, with nothing on screen saying why. Under filter_in
+// it admitted everything, so the same shape was harmless there — the harm is asymmetric in
+// `action`, while having no filter at all is harmless under both.
 //
 // Removing the predicate rather than picking a value for it is the disposition the load-degrade
 // contract settled on for a filter the GUI's own format left underspecified. Returning
@@ -1138,6 +1153,38 @@ static std::optional<FilterConfig> ParseFilterFromGuiJson(const json& jf) {
         continue;
       }
       std::string text = MigrateAndCountRaypathComma(js.get<std::string>());
+      // The load path's syntax gate, and the only one this row ever meets. ParseSummandText below
+      // is deliberately tolerant -- it skips what it cannot read so a half-typed row in the editor
+      // still shows the part that parses -- and the editor pairs that tolerance with
+      // ValidateSummandText on its OK button. This reader had the tolerance and not the pairing, so
+      // a row spelling an empty face-path token ("3--5", "-3-5", "3-5-") came back as the path 3-5:
+      // a path that looks entirely reasonable and is not the one the file states, with nothing said
+      // about it. Validating here is what pairs them, using the editor's own validator rather than
+      // a second spelling of "what is a legal row".
+      //
+      // The judgement is local (`state != LUMICE_RAYPATH_VALID`) rather than
+      // edit_modal_rules.hpp's SummandRowBlocksCommit: that function answers "may the OK button be
+      // pressed", which happens to agree here but is a different question asked in a different
+      // language. kIncomplete is refused alongside kInvalid -- in the editor it means "still
+      // typing", but a file is not still typing.
+      //
+      // kind = PYRAMID because this call site has no crystal in hand and the pyramid legal-face set
+      // is the union over every kind (see raypath_validation.cpp), i.e. the widest baseline
+      // available. PRISM would refuse face numbers that are legal on a pyramid.
+      const GuiValidationResult v = ValidateSummandText(text, LUMICE_CRYSTAL_PYRAMID);
+      if (v.state != LUMICE_RAYPATH_VALID) {
+        ++g_invalid_summand_row_count;
+        // kIncomplete carries no message: in the editor it is not an error, only a row the user has
+        // not finished, so there is nothing to say to them yet. Here it is a finished file that ends
+        // or starts on a separator, and a log line reading "(...)" would name no reason at all.
+        const std::string reason = !v.message.empty() ? v.message :
+                                                        (v.state == LUMICE_RAYPATH_INCOMPLETE ?
+                                                             std::string("the row starts or ends on a path separator") :
+                                                             std::string("invalid"));
+        GUI_LOG_WARNING("[FileIO] Filter '{}' row \"{}\" is not a valid filter expression ({}); skipping row.", f.name,
+                        text, reason);
+        continue;
+      }
       sop.push_back(SummandText{ text, ParseSummandText(text) });
     }
     // An empty summands array is not a valid state, and the disposition is the one at the bottom

--- a/src/gui/file_io.hpp
+++ b/src/gui/file_io.hpp
@@ -231,6 +231,16 @@ int TakeFilterNoPredicateDowngradeCount();
 // above: drain once before a load to discard any stale count, and again after it.
 int TakeRaypathCommaMigratedCount();
 
+// Returns the number of `summands` rows dropped since the last call because the file's text was not
+// a valid filter expression, and resets the counter. The GUI-native load path used to hand every
+// row straight to the tolerant parser, which reads an empty face-path token as if it were not there
+// -- "3--5" came back as the path 3-5, a path the user never wrote, with nothing on screen saying
+// so. Rows are now validated with the same ValidateSummandText the editor gates its OK button on,
+// and a row that fails is dropped rather than reinterpreted. Same call discipline as the three
+// above: drain once before a load to discard any stale count, and again after it to decide whether
+// to show the notice.
+int TakeInvalidSummandRowCount();
+
 // Export preview as PNG (renders via FBO, must be called on GL thread).
 // Thin wrapper over RenderExportToRgba + WriteRgbaBufferToPng.
 bool ExportPreviewPng(const std::filesystem::path& path, PreviewRenderer& renderer, const PreviewViewport& vp);

--- a/src/gui/raypath_segments.hpp
+++ b/src/gui/raypath_segments.hpp
@@ -240,6 +240,22 @@ inline GuiValidationResult ValidateRaypathTextMultiSegment(const std::string& te
 // without setting the flag. That divergence predates this function's tightening and is untouched
 // by it — a different predicate on a different input class, left where it was rather than folded
 // in here.
+//
+// It stays split deliberately, and the obvious one-line closure — set has_invalid_token on the
+// empty token too — is worse than the split, measured rather than argued. It makes this function
+// return {} for the whole segment; ParseRaypathTextMultiSegment then drops that segment for having
+// an empty result; and a Factor left with no segments lowers, in file_io.cpp's FactorAlternatives,
+// to the one alternative that is an empty sequence — which is core's match-all. So "3--5" would go
+// from filtering one path the user did not write to filtering nothing at all, just as silently.
+// The ambiguity that makes that happen is that "no segments" today means both "the user wrote no
+// predicate" and "the text would not parse", and no fail-closed change here can be right until
+// those are two different things.
+//
+// So the gate is not here. It is on the one caller that used to have no gate: the .lmc reader
+// (ParseFilterFromGuiJson) validates each summands row with ValidateSummandText and drops the row
+// loudly, which is what the editor has always done on its own input. Both of this function's
+// callers now sit behind a validator, and its tolerance goes on serving what it was written for —
+// showing the part of a half-typed row that does parse.
 inline std::vector<int> ParseRaypathSegment(const std::string& seg) {
   std::vector<int> ints;
   std::string tok;

--- a/src/gui/raypath_segments.hpp
+++ b/src/gui/raypath_segments.hpp
@@ -251,11 +251,13 @@ inline GuiValidationResult ValidateRaypathTextMultiSegment(const std::string& te
 // predicate" and "the text would not parse", and no fail-closed change here can be right until
 // those are two different things.
 //
-// So the gate is not here. It is on the one caller that used to have no gate: the .lmc reader
-// (ParseFilterFromGuiJson) validates each summands row with ValidateSummandText and drops the row
-// loudly, which is what the editor has always done on its own input. Both of this function's
-// callers now sit behind a validator, and its tolerance goes on serving what it was written for —
-// showing the part of a half-typed row that does parse.
+// So the gate is not here. This function is reached from exactly one place — through
+// ParseRaypathTextMultiSegment, from FactorAlternatives in file_io.cpp — and the text that arrives
+// there is a SummandText::text that entered the state through one of two doors: the editor, which
+// has always run ValidateSummandText before writing one, and the .lmc reader
+// (ParseFilterFromGuiJson), which did not and now does. Closing the second door is what makes the
+// tolerance here safe to keep, and it goes on serving what it was written for: showing the part of
+// a half-typed row that does parse, while the row is still being typed.
 inline std::vector<int> ParseRaypathSegment(const std::string& seg) {
   std::vector<int> ints;
   std::string tok;

--- a/test/composition-correctness/gui/test_document_roundtrip_chain.cpp
+++ b/test/composition-correctness/gui/test_document_roundtrip_chain.cpp
@@ -23,6 +23,7 @@
 #include "gui/file_io.hpp"
 #include "gui/gui_state.hpp"
 #include "gui/raypath_segments.hpp"
+#include "support/scene_json_helpers.hpp"
 
 namespace lumice::gui {
 namespace {
@@ -934,6 +935,33 @@ TEST(DocumentRoundtripChain, SchemaVersionIsFour) {
   ASSERT_TRUE(root.contains("schema_version"));
   EXPECT_EQ(root["schema_version"].get<int>(), 4);
 }
+
+// ===== TEMPORARY AC0 PROBE — removed/rewritten before this task lands =====
+TEST(DocumentRoundtripChain, AC0ProbeEmptyTokenLoadPath) {
+  const char* kInputs[] = { "3--5", "-3-5", "3-5-", "3---5", "99" };
+  for (const char* in : kInputs) {
+    GuiState s;
+    TakeFilterNoPredicateDowngradeCount();
+    TakeRaypathCommaMigratedCount();
+    ClearImportComplexFilterWarning();
+    const bool ok = DeserializeGuiStateJson(V3DocWithSummand(in), s);
+    std::string text = "<none>";
+    size_t nrows = 0;
+    if (ok && !s.filters.empty()) {
+      nrows = s.filters.at(0).param.size();
+      if (nrows > 0) {
+        text = s.filters.at(0).param[0].text;
+      }
+    }
+    nlohmann::json committed = ok ? lumice::test::CommitSceneJson(s) : nlohmann::json{};
+    std::string filt = committed.is_null() || !committed.contains("filter") ? "<null>" : committed["filter"].dump();
+    fprintf(stderr, "AC0PROBE input=%-8s deser=%d rows=%zu text=%-10s nopred=%d warn=[%s] filter=%s\n", in,
+            static_cast<int>(ok), nrows, text.c_str(), TakeFilterNoPredicateDowngradeCount(),
+            std::string(PeekImportComplexFilterWarning()).c_str(), filt.c_str());
+    ClearImportComplexFilterWarning();
+  }
+}
+// ===== END TEMPORARY AC0 PROBE =====
 
 }  // namespace
 

--- a/test/composition-correctness/gui/test_document_roundtrip_chain.cpp
+++ b/test/composition-correctness/gui/test_document_roundtrip_chain.cpp
@@ -936,32 +936,127 @@ TEST(DocumentRoundtripChain, SchemaVersionIsFour) {
   EXPECT_EQ(root["schema_version"].get<int>(), 4);
 }
 
-// ===== TEMPORARY AC0 PROBE — removed/rewritten before this task lands =====
-TEST(DocumentRoundtripChain, AC0ProbeEmptyTokenLoadPath) {
-  const char* kInputs[] = { "3--5", "-3-5", "3-5-", "3---5", "99" };
-  for (const char* in : kInputs) {
-    GuiState s;
-    TakeFilterNoPredicateDowngradeCount();
-    TakeRaypathCommaMigratedCount();
-    ClearImportComplexFilterWarning();
-    const bool ok = DeserializeGuiStateJson(V3DocWithSummand(in), s);
-    std::string text = "<none>";
-    size_t nrows = 0;
-    if (ok && !s.filters.empty()) {
-      nrows = s.filters.at(0).param.size();
-      if (nrows > 0) {
-        text = s.filters.at(0).param[0].text;
-      }
+// The .lmc reader's syntax gate.
+//
+// The GUI-native load path used to hand every `summands` row straight to ParseSummandText, which is
+// deliberately tolerant — it skips what it cannot read so a half-typed row in the editor still shows
+// the part that parses. The editor pairs that tolerance with ValidateSummandText on its OK button.
+// This reader had the tolerance and not the pairing, and an empty step in a face path is exactly the
+// shape that slips through it: the parser's flush() returns early on an empty token without marking
+// the row bad, so "3--5" parsed as {3, 5} and committed as the path 3-5. Not a crash, not a blank
+// picture — a path that looks entirely reasonable and is not the one the file states, with nothing
+// on screen saying so.
+//
+// Asserted through the committed scene rather than through the loaded rows, because the row is where
+// the defect is invisible: `param[0].text` came back as "3--5" verbatim in the broken build too. What
+// changed shape was the document handed to the simulator.
+//
+// The one-line fix this looks like it wants — mark the empty token invalid in ParseRaypathSegment —
+// is worse, and the reason is pinned in that function's comment: it makes the row lower to core's
+// match-all, i.e. from filtering one path the user did not write to filtering nothing at all, just as
+// silently. The gate belongs on this caller, which is the one that never had one.
+TEST(DocumentRoundtripChain, AMalformedSummandRowIsRejectedRatherThanReinterpreted) {
+  struct Case {
+    const char* name;
+    const char* summand;
+  };
+  const Case kCases[] = {
+    // The whole empty-token class, not just the middle one: the parser's flush() treats a leading,
+    // a trailing and an interior empty token identically, so all four spellings used to collapse
+    // onto the same wrong answer, {3, 5}.
+    { "an interior empty step", "3--5" },
+    { "a leading empty step", "-3-5" },
+    { "a trailing empty step", "3-5-" },
+    // Two empty steps in a row: the judgement is "any empty token", not "exactly one".
+    { "several empty steps", "3---5" },
+    // Not an AC of its own — reusing the editor's whole validator rather than writing a fresh
+    // empty-token predicate means face-number legality comes along with it. Pinned so that a later
+    // narrowing of the gate to "empty tokens only" is a visible choice rather than a silent loss.
+    { "a face number no crystal has", "99" },
+    { "a malformed entry: factor", "entry:abc & 3-5" },
+  };
+
+  for (const Case& c : kCases) {
+    SCOPED_TRACE(c.name);
+    TakeInvalidSummandRowCount();  // discard anything a previous case in this binary left
+    GuiState loaded;
+    if (!DeserializeGuiStateJson(V3DocWithSummand(c.summand), loaded)) {
+      ADD_FAILURE() << c.name << ": the document failed to deserialize";
+      continue;  // no load to check; the rest of the cases still get their turn
     }
-    nlohmann::json committed = ok ? lumice::test::CommitSceneJson(s) : nlohmann::json{};
-    std::string filt = committed.is_null() || !committed.contains("filter") ? "<null>" : committed["filter"].dump();
-    fprintf(stderr, "AC0PROBE input=%-8s deser=%d rows=%zu text=%-10s nopred=%d warn=[%s] filter=%s\n", in,
-            static_cast<int>(ok), nrows, text.c_str(), TakeFilterNoPredicateDowngradeCount(),
-            std::string(PeekImportComplexFilterWarning()).c_str(), filt.c_str());
-    ClearImportComplexFilterWarning();
+
+    // The row is gone, not kept with an empty parse: a row whose text survives is a row the editor
+    // would show back to the user as if the file had said something valid.
+    EXPECT_TRUE(loaded.filters.empty() || loaded.filters.at(0).param.empty())
+        << c.name << ": the malformed row survived the load";
+
+    // What the simulator is handed. The empty-token cases used to arrive here as
+    // {"type": "raypath", "raypath": [3, 5]}; a fail-closed parser change would make them arrive as
+    // {"type": "none"}, which is core's match-all. Neither is the file's meaning, and asserting the
+    // absence of both is what separates this fix from that one.
+    const nlohmann::json committed = lumice::test::CommitSceneJson(loaded);
+    if (committed.is_null()) {
+      ADD_FAILURE() << c.name << ": the document did not commit at all";
+      continue;
+    }
+    const std::string emitted = committed.value("filter", nlohmann::json::array()).dump();
+    EXPECT_EQ(emitted.find("\"raypath\""), std::string::npos)
+        << c.name << ": a face path the file never stated reached the simulator: " << emitted;
+    EXPECT_EQ(emitted.find("\"none\""), std::string::npos)
+        << c.name << ": the row lowered to core's match-all, which filters nothing: " << emitted;
+
+    // Counted, and counted once — DoOpen reads this to decide whether to raise the import notice,
+    // so a row dropped without being counted is a row dropped in silence, which is the state this
+    // whole case exists to leave behind.
+    EXPECT_EQ(TakeInvalidSummandRowCount(), 1) << c.name << ": the dropped row was not counted";
+    EXPECT_EQ(TakeInvalidSummandRowCount(), 0)
+        << c.name << ": the counter did not clear on read, so the notice would never go away";
   }
 }
-// ===== END TEMPORARY AC0 PROBE =====
+
+// The other half: the gate must not refuse anything the editor can write.
+//
+// Every .lmc this GUI saves has already been through ValidateSummandText on the way in, so a false
+// positive here would reject a file the program itself produced. Kept separate from the cases above
+// on purpose — those say "the bad input is caught", this says "the good input still loads", and a
+// gate can pass the first while failing the second.
+TEST(DocumentRoundtripChain, ValidSummandRowsStillLoadAndAreNotCounted) {
+  struct Case {
+    const char* name;
+    const char* summand;
+    const char* expected_text;
+  };
+  const Case kCases[] = {
+    { "a plain face path", "3-5", "3-5" },
+    { "several ORed segments", "3-5;1-3", "3-5;1-3" },
+    { "an entry facelist ANDed with a path", "entry:1,2 & 3-5", "entry:1,2 & 3-5" },
+    // Migration runs before the gate, so what is validated is the rewritten row. A gate placed
+    // before the rewrite would refuse every pre-retirement document.
+    { "a row the ',' migration rewrote", "3-5,1-2", "3-5-1-2" },
+    // The widest face number that is legal on some crystal. The gate validates against the pyramid
+    // set (the union over every kind) precisely so a pyramid-only face is not refused by a reader
+    // that has no crystal in hand.
+    { "a face legal only on a pyramid", "28", "28" },
+    { "a length factor", "len:<=4 & 3-5", "len:<=4 & 3-5" },
+  };
+
+  for (const Case& c : kCases) {
+    SCOPED_TRACE(c.name);
+    TakeInvalidSummandRowCount();
+    GuiState loaded;
+    if (!DeserializeGuiStateJson(V3DocWithSummand(c.summand), loaded)) {
+      ADD_FAILURE() << c.name << ": the document failed to deserialize";
+      continue;
+    }
+    if (loaded.filters.size() != 1u || loaded.filters.at(0).param.size() != 1u) {
+      ADD_FAILURE() << c.name << ": the row did not survive the load";
+      continue;  // the text read below would be out of bounds
+    }
+    EXPECT_EQ(loaded.filters.at(0).param[0].text, std::string(c.expected_text))
+        << c.name << ": the row came back saying something else";
+    EXPECT_EQ(TakeInvalidSummandRowCount(), 0) << c.name << ": a valid row was refused by the gate";
+  }
+}
 
 }  // namespace
 

--- a/test/composition-correctness/gui/test_document_roundtrip_chain.cpp
+++ b/test/composition-correctness/gui/test_document_roundtrip_chain.cpp
@@ -15,13 +15,17 @@
 
 #include <gtest/gtest.h>
 
+#include <filesystem>
 #include <nlohmann/json.hpp>
 #include <string>
+#include <system_error>
+#include <utility>
 #include <vector>
 
 #include "gui/app.hpp"
 #include "gui/file_io.hpp"
 #include "gui/gui_state.hpp"
+#include "gui/preview_renderer.hpp"
 #include "gui/raypath_segments.hpp"
 #include "support/scene_json_helpers.hpp"
 
@@ -1012,6 +1016,95 @@ TEST(DocumentRoundtripChain, AMalformedSummandRowIsRejectedRatherThanReinterpret
     EXPECT_EQ(TakeInvalidSummandRowCount(), 0)
         << c.name << ": the counter did not clear on read, so the notice would never go away";
   }
+}
+
+// The last link in the chain, and the one nothing above it covers: the count reaching the user.
+//
+// Every case above stops at the counter, which is the same place the two counters this one was
+// modelled on stop. That leaves the wiring in DoOpen — the drain before the load and the notice
+// after it — with no cover at all: drop the notice block, or drop the pre-load drain, and every
+// assertion above stays green while the user is told nothing, or told about someone else's load.
+// The whole point of the change is that the drop is not silent, so the silence is what has to be
+// asserted against.
+//
+// Driven through a real .lmc rather than DeserializeGuiStateJson, because DoOpen is the only caller
+// that reads the counter and it only reads it on that path. The malformed row is planted by writing
+// the row text directly: that is what a file written by a pre-gate build of this GUI holds, and the
+// editor will not produce one.
+struct RoundtripTempFile {
+  std::filesystem::path path;
+
+  explicit RoundtripTempFile(std::filesystem::path p) : path(std::move(p)) {}
+  RoundtripTempFile(const RoundtripTempFile&) = delete;
+  RoundtripTempFile& operator=(const RoundtripTempFile&) = delete;
+  ~RoundtripTempFile() {
+    std::error_code ec;
+    std::filesystem::remove(path, ec);
+  }
+};
+
+// A document whose one filter carries `rows`, written to disk as a .lmc. Rows go in verbatim
+// (SerializeFilterForGui writes SummandText::text as-is), so a row the gate will refuse can be
+// planted without going through the editor that would have refused it first.
+//
+// Callers plant a SECOND, valid row beside the bad one deliberately. A filter left with no rows at
+// all trips the no-predicate notice next door, which announces a different thing through the same
+// popup — and an earlier draft of these cases passed with the notice under test deleted, because it
+// was reading that neighbour's sentence. Keeping one row alive is what makes the popup attributable.
+void SaveDocumentWithSummandRows(const std::filesystem::path& path, const std::vector<std::string>& rows) {
+  DoNew();
+  g_state.filters.assign(1, FilterConfig{});
+  g_state.filters[0].param.clear();
+  for (const std::string& text : rows) {
+    g_state.filters[0].param.push_back(SummandText{ text, ParseSummandText(text) });
+  }
+  // The writer emits filters inline per entry, so an unreferenced one never reaches the file.
+  ASSERT_FALSE(g_state.layers.empty());
+  ASSERT_FALSE(g_state.layers[0].entries.empty());
+  g_state.layers[0].entries[0].filter_id = 0;
+  ASSERT_TRUE(SaveLmcFile(path, g_state, g_preview, /*save_texture=*/false));
+}
+
+TEST(DocumentRoundtripChain, ADroppedSummandRowIsAnnouncedWhenTheDocumentIsOpened) {
+  const RoundtripTempFile bad{ std::filesystem::temp_directory_path() / "lumice_roundtrip_bad_summand.lmc" };
+  ASSERT_NO_FATAL_FAILURE(SaveDocumentWithSummandRows(bad.path, { "3--5", "1-3" }));
+
+  ClearImportComplexFilterWarning();
+  DoOpen(bad.path);
+
+  ASSERT_EQ(g_state.filters.size(), 1u);
+  ASSERT_EQ(g_state.filters.at(0).param.size(), 1u)
+      << "premise: the bad row was dropped and the good one kept, so the filter still states a rule "
+         "and the no-predicate notice next door stays quiet";
+
+  const std::string warning = PeekImportComplexFilterWarning();
+  EXPECT_FALSE(warning.empty()) << "the row was dropped and the user was told nothing about it";
+  EXPECT_NE(warning.find("not valid filter expressions"), std::string::npos)
+      << "the popup did not carry THIS notice's sentence, so something else raised it: " << warning;
+  ClearImportComplexFilterWarning();
+}
+
+// ...and only about its own load. The counter is process-wide and take-on-read, so a count left by
+// an earlier read — MakeNewDocumentState running the user's personal defaults through the same
+// deserializer is the real instance — would be handed to the next document opened. This is the case
+// that fails for a fix that adds the notice without the drain before the load.
+TEST(DocumentRoundtripChain, ACleanDocumentDoesNotInheritAnEarlierReadsDroppedRow) {
+  GuiState scratch;
+  ASSERT_TRUE(DeserializeGuiStateJson(V3DocWithSummand("3--5"), scratch)) << "premise: the seeding read succeeds";
+  ASSERT_TRUE(scratch.filters.empty() || scratch.filters.at(0).param.empty())
+      << "premise: the seeding read dropped a row, i.e. left a count behind";
+
+  const RoundtripTempFile good{ std::filesystem::temp_directory_path() / "lumice_roundtrip_good_summand.lmc" };
+  ASSERT_NO_FATAL_FAILURE(SaveDocumentWithSummandRows(good.path, { "3-5" }));
+
+  ClearImportComplexFilterWarning();
+  DoOpen(good.path);
+
+  ASSERT_EQ(g_state.filters.size(), 1u);
+  EXPECT_EQ(g_state.filters.at(0).param.size(), 1u) << "premise: this document's row is valid and loaded";
+  EXPECT_TRUE(PeekImportComplexFilterWarning().empty())
+      << "a clean load announced an earlier read's dropped row: " << PeekImportComplexFilterWarning();
+  ClearImportComplexFilterWarning();
 }
 
 // The other half: the gate must not refuse anything the editor can write.


### PR DESCRIPTION
## 缺陷

`.lmc` 加载路径对 raypath 文本**不做任何语法校验**——校验器（`ValidateRaypathText` / `ValidateSummandText`）的调用点全在交互编辑器里，加载链条一次都不碰它。于是一行 `3--5`（含空 token，前导 `-3-5` / 尾随 `3-5-` 同理）被静默解析成 `{3, 5}`：**一条看起来完全合理、但不是用户写的光路**。反差就在同一个函数里——旁边一行对「summand 行不是字符串」都在发 `GUI_LOG_WARNING`，注释写着 *"Loud, not silent"*。

## 为什么不是「把空 token 也判 invalid」那一行修法

那样 `ParseRaypathSegment` 返回空 → segment 被 skip → `FactorAlternatives` 得到空 raypath = **match-all**，从「过滤了一条错的光路」变成「什么都不过滤」，同样无声、且更糟。根因是一个语义歧义：`segs.empty()` 今天同时表示「用户没写 ⇒ 匹配全部」和「解析失败」。本 PR 在**加载路径**上守，不动解析器的容错哲学（`ParseSummandText` 跳过非法 token 是有意设计）。

## 改动

- 加载路径复用既有的 `ValidateSummandText`，拒绝含空 token / 越界面号的畸形 summand 行（**整行丢弃**，不进 filter）。
- 信号三通道，形态照该文件既有规矩：丢弃计数器 + `GUI_LOG_WARNING` + `DoOpen` 弹窗——⛔「静默」不是选项。
- 覆盖整个输入类：前导 / 尾随 / 中间空 token 各有用例（`test/composition-correctness/gui/`）。

## AC0 推翻了立项时的可达性假设

issue 里写的是「可能只有手改 `.lmc` 才碰得到」。实测查明 **v4.1.14 / v4.2.0 的编辑器输入框本就无闸**，用户可以直接写出畸形行并存盘 ⇒ 这是升级路径上的真实缺陷，不是只有手工编辑文件才够得到。

## 验证

- `./scripts/test.sh quick` 全绿；四道 diff-scoped 门禁 + `./scripts/format.sh --check` 全绿。
- code review APPROVE，0 Critical / 0 Major（1 Minor + 3 Suggestion 均不阻塞）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Dzk6oieAM7Px5CApP2JAp