### PR TITLE
build(cpm): default the dependency-source cache to a machine-level directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,23 @@ produce a shared library. Release artifacts are installed to `build/cmake_instal
 CMake build tree is `build/cmake_build/<flavor>/` and compiler output lands in
 `build/<BUILD_TYPE>/<flavor>/{bin,lib}/`.
 
+Dependency **sources**, by contrast, are cached per-*machine*, not per-source-tree: CPM downloads
+land in `$HOME/.cache/lumice-cpm` by default (`$USERPROFILE/.cache/lumice-cpm` on a Windows shell
+that sets no `HOME`; and if neither variable exists, the old repo-local `build/cpm_cache`, so a
+configure can never fail for want of a home directory). That is what makes a fresh clone or a new
+`git worktree` cheap — it reuses whatever this machine has already downloaded instead of re-fetching
+~300MB of the same 13 packages, which is the cost that was actually being paid: four trees on one
+machine each held their own ~300MB copy. `CPM_SOURCE_CACHE` still overrides it unconditionally —
+the default is only computed when neither the CMake variable nor the environment variable is set —
+which is how CI keeps its own per-workspace cache (`.github/workflows/{ci,release}.yml`) unaffected.
+Two consequences worth knowing. `rm -rf build/`, and `./scripts/build.sh -x` with it, no longer
+clears the dependency sources, because they are no longer under `build/`; delete the cache directory
+by hand when you genuinely want them re-downloaded, and note that doing so bills every other
+worktree on the machine for the re-download, not just yours. And the compiler-output and build trees
+above stay deliberately per-tree — only the immutable, content-addressed dependency sources are
+shared, which is why concurrent configures are safe (CPM takes a `file(LOCK)` per package directory
+before downloading into it).
+
 ## Code Structure
 
 - `src/config/`: configuration parsing and simulation config data

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,10 +260,23 @@ endif()
 
 # ==================================================================================================
 # CPM.cmake — lightweight dependency manager (wrapper around FetchContent)
-# Cache CPM downloads outside cmake_build so clean builds (-k) don't re-download
+# Cache CPM downloads outside cmake_build so clean builds (-k) don't re-download, and — since the
+# default below is a machine-level directory rather than a per-source-tree one — so that a fresh
+# clone or a new `git worktree` reuses whatever this machine already downloaded instead of
+# re-fetching every dependency source. Three-tier fallback; the last tier is the old repo-local
+# behaviour, so configure can never fail just because no home directory is discoverable.
 if(NOT DEFINED CPM_SOURCE_CACHE AND NOT DEFINED ENV{CPM_SOURCE_CACHE})
-  set(CPM_SOURCE_CACHE "${CMAKE_SOURCE_DIR}/build/cpm_cache"
-      CACHE PATH "Directory to cache CPM dependency sources")
+  if(DEFINED ENV{HOME})
+    set(_lumice_cpm_cache_default "$ENV{HOME}/.cache/lumice-cpm")
+  elseif(DEFINED ENV{USERPROFILE})  # Windows shells that do not set HOME
+    set(_lumice_cpm_cache_default "$ENV{USERPROFILE}/.cache/lumice-cpm")
+  else()
+    set(_lumice_cpm_cache_default "${CMAKE_SOURCE_DIR}/build/cpm_cache")
+  endif()
+  set(CPM_SOURCE_CACHE "${_lumice_cpm_cache_default}"
+      CACHE PATH "Directory to cache CPM dependency sources (machine-level and shared across \
+worktrees/clones by default; override with the CPM_SOURCE_CACHE env var, as CI does)")
+  unset(_lumice_cpm_cache_default)
 endif()
 include(cmake/CPM.cmake)
 

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -52,7 +52,10 @@ The project uses CMake for building and provides a `scripts/build.sh` script to 
 - `-b`: Build benchmarks (Google Benchmark)
 - `-j`: Parallel compilation
 - `-k`: Clean build artifacts (keep dependency cache)
-- `-x`: Clean everything including dependency cache
+- `-x`: Wipe `build/` entirely (both flavors). It does **not** clear the CPM
+  dependency-source cache — that defaults to a machine-level directory outside
+  `build/` (`$HOME/.cache/lumice-cpm`) shared with every other clone and worktree.
+  Delete that directory by hand to force a re-download.
 - `-s`: Build shared libraries (static libraries by default)
 - `-h`: Show help information
 

--- a/doc/developer-guide_zh.md
+++ b/doc/developer-guide_zh.md
@@ -52,7 +52,9 @@ sudo apt-get install cmake ninja-build
 - `-b`: 构建基准测试（Google Benchmark）
 - `-j`: 并行编译
 - `-k`: 清理构建产物（保留依赖缓存）
-- `-x`: 清理全部（含依赖缓存）
+- `-x`: 清空整个 `build/`（两种 flavor 都清）。它**不会**清 CPM 依赖源码缓存——
+  该缓存默认落在 `build/` 之外的机器级目录（`$HOME/.cache/lumice-cpm`），
+  与本机其他 clone / worktree 共享。确需强制重下时手动删除该目录。
 - `-s`: 构建共享库（默认为静态库）
 - `-h`: 显示帮助信息
 

--- a/doc/gpu-remote-cuda-build-testing.md
+++ b/doc/gpu-remote-cuda-build-testing.md
@@ -54,7 +54,9 @@
   rsync -az --exclude '__pycache__' src/ $HOSTALIAS:$REPO/src/   # test/ 同理
   ```
   ⚠️ 首次同步整棵树时**别在机器上从 GitHub 拉**——见 `machines.md` 的网络实测，
-  从开发机 rsync 过去快得多，`build/cpm_cache` 尤其（省掉全部依赖下载）。
+  从开发机 rsync 过去快得多，CPM 依赖源码缓存尤其（省掉全部依赖下载）。它默认落在
+  机器级的 `~/.cache/lumice-cpm`（**不在** `build/` 下），两端同路径，
+  一份服务该机器上的所有 clone 与 worktree——命令见 `machines.md` 的网络那一条。
 
 - **build**（shared flavor，parity 需要 `.so`）：
   ```bash

--- a/doc/machines.md
+++ b/doc/machines.md
@@ -94,8 +94,15 @@
 3. **网络：GitHub 慢，Docker Hub 不通。** 实测 GitHub 直下约 69 KB/s、
    Docker Hub 连不上；而 apt（阿里云镜像）、pypi、NVIDIA 的
    `developer.download.nvidia.cn`（26–30 MB/s）都很快。
-   ⇒ CPM 依赖不要在这两台机器上下载，从开发机经局域网 rsync `build/cpm_cache`
-   （约 282 MB）过去。⚠️ Mac 上的缓存里**没有 `glad`**（它是 `WIN32` 才用的依赖，
+   ⇒ CPM 依赖不要在这两台机器上下载，从开发机经局域网 rsync 依赖源码缓存
+   （约 282 MB）过去。**两端的路径都是 `~/.cache/lumice-cpm`**——那是
+   `CMakeLists.txt` 给 `CPM_SOURCE_CACHE` 的机器级默认值（`$HOME` 取不到时退
+   `$USERPROFILE`，都取不到才退回旧的 repo-local `build/cpm_cache`），所以它一份
+   服务该机器上的所有 clone 与 worktree，不必按仓库路径各推一份：
+   ```bash
+   rsync -az ~/.cache/lumice-cpm/ $HOSTALIAS:~/.cache/lumice-cpm/
+   ```
+   ⚠️ Mac 上的缓存里**没有 `glad`**（它是 `WIN32` 才用的依赖，
    Mac 从不构建它），Windows 首次构建会自行拉取。
 
 ## 相关文档

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -110,7 +110,12 @@ help() {
   echo "               build/<BUILD_TYPE>/<flavor>/. A liblumice there survives -k, and"
   echo "               it is the first thing the e2e C API loader looks for — so after"
   echo "               -k it can still load a pre-clean library. Use -x to wipe build/."
-  echo "  -x:          Clean everything including dependency cache (both flavors)."
+  echo "  -x:          Wipe build/ entirely — both flavors, plus the compiler output"
+  echo "               tree that -k leaves behind. It does NOT clear the CPM"
+  echo "               dependency-source cache, which defaults to a machine-level"
+  echo "               directory outside build/ (\$HOME/.cache/lumice-cpm) shared with"
+  echo "               every other clone and worktree; delete that directory by hand if"
+  echo "               you really want the sources re-downloaded."
   echo "  -s:          Build shared library (default: static)."
   echo "  -h:          Show this message."
 }
@@ -137,8 +142,12 @@ clean_all() {
   rm -rf "${BUILD_DIR}" "${INSTALL_DIR}"
 }
 
+# Wipes this tree's build/ only. The CPM dependency-source cache defaults to a machine-level
+# directory outside build/, and is deliberately left alone: it is shared with every other clone
+# and worktree on this machine, so deleting it from one of them would cost all the others a full
+# re-download. Delete it by hand if that is really what you want.
 clean_everything() {
-  echo "Cleaning all build files and dependency cache..."
+  echo "Cleaning all build files (dependency source cache is shared machine-wide, left intact)..."
   rm -rf "${ROOT_DIR}/build"
 }
 


### PR DESCRIPTION
## 问题

`CMakeLists.txt` 里 CPM 依赖**源码** cache 的默认位置是 `${CMAKE_SOURCE_DIR}/build/cpm_cache` —— **每棵源码树各一份**。于是每拉一个 `git worktree`、每做一次 fresh clone，都要把 13 个依赖包整包重下一遍。

实测代价（2026-09-09，本机四棵树同时存在）：主仓 282M + 三棵 worktree 各 295–323M。三个并行任务同时卡在下载上，这是本 PR 的直接起因——不是想象中的风险。

## 改动

`CMakeLists.txt` 的默认值改为三档 fallback，env 覆盖的优先级**不变**：

1. `$ENV{HOME}/.cache/lumice-cpm`
2. `$ENV{USERPROFILE}/.cache/lumice-cpm`（不设 `HOME` 的 Windows shell）
3. `${CMAKE_SOURCE_DIR}/build/cpm_cache`（即旧行为）——最后一档保证 configure 永远不会因为找不到 home 目录而失败

配套：
- `scripts/build.sh` 的 `-x` 语义更正——它现在只清本树的 `build/`，**不再**清依赖源码 cache（那份是全机共享的，从一棵树删掉会让其余所有树各赔一次全量重下）。help 文案与实现注释同步。
- `AGENTS.md` / `doc/developer-guide{,_zh}.md` 写清新位置、覆盖入口与这条语义变化。
- 顺带修掉同根因变错的两处 rsync recipe（`doc/machines.md`、`doc/gpu-remote-cuda-build-testing.md` 里仍指向旧的 `build/cpm_cache`）。

## CI 不受影响

`ci.yml:33` 与 `release.yml:9` 显式设了 `CPM_SOURCE_CACHE: ${{ github.workspace }}/cpm_cache`，而那道 `if(NOT DEFINED ENV{CPM_SOURCE_CACHE})` guard 未动 ⇒ env 仍然优先，actions/cache 的 key 与路径全部照旧。

## 验证

- 红→绿两态实测：冷态 59.25s / 9.7M 下载 → 命中共享 cache 后 1.15s / 0 下载（51.5×）。
- 并发安全有正面证据：`cmake/CPM.cmake:812` 的 `file(LOCK ...)` 本就是为共享 cache 存在的。
- `./scripts/test.sh quick` 全绿；四道 diff-scoped 门禁 + `./scripts/format.sh --check` 全绿。
- code review APPROVE，0 Critical / 0 Major。

## 不做什么

- ⛔ 不碰 ccache/sccache（编译产物缓存是另一条正交的路）。
- ⛔ 不共享 `build/cmake_build/` 与 `build/<BUILD_TYPE>/`——那是并行 worktree 赖以成立的隔离。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Dzk6oieAM7Px5CApP2JAp