### PR TITLE
refactor(config): guard RenderConfig's field set by member count, not sizeof

### DIFF
--- a/doc/accumulator-consumer-architecture.md
+++ b/doc/accumulator-consumer-architecture.md
@@ -378,9 +378,15 @@ kept it at 136. What the tripwire *does* catch is a change **within** a field �
 nested struct gaining a member, a type widening — which moves the byte size without
 moving the field count, and which the guard is in turn blind to. Hence both.
 
-Either one firing carries the same duty: classify the field as layout-affecting (add
-it to the `NeedsRebuild` comparisons) or appearance-only (no change needed), so that
-a new layout field cannot silently drift past `NeedsRebuild`.
+Which one fired says what has to be classified, and the two are not the same
+question. The **guard** firing means a field was added or removed: classify that
+field as layout-affecting (add it to the `NeedsRebuild` comparisons) or
+appearance-only (no change needed). The **tripwire** firing alone means no field was
+added or removed — some existing field grew — so there is no new name to classify;
+the question is instead whether the grown field's new content changes what the
+accumulator buffer must be. Either way the pinned number is only safe again once
+that question has been answered, so that a layout change cannot silently drift past
+`NeedsRebuild`.
 
 ### §5.3 ResetWith Path
 

--- a/doc/accumulator-consumer-architecture.md
+++ b/doc/accumulator-consumer-architecture.md
@@ -350,18 +350,37 @@ mask (e.g. "one 2-bit `any` class" ↔ "two 1-bit classes") still rebuilds — a
 `RenderConsumer` would otherwise keep a stale per-class lane layout. This check is
 orthogonal to the per-renderer one above.
 
-### §5.2 sizeof Sentinel
+### §5.2 Field-Set Guard and Size Tripwire
+
+Two checks sit at the head of `NeedsRebuild`, and they are complements rather than
+one guard stated twice:
 
 ```cpp
-static_assert(sizeof(RenderConfig) == 136,
-              "Update NeedsRebuild when RenderConfig fields change");
+// render_config.hpp, beside the struct — the field-set guard
+inline void RenderConfigFieldSetGuard(const RenderConfig& c) {
+  [[maybe_unused]] const auto& [id, lens, /* ... one name per member ... */] = c;
+}
+
+// render_config.cpp, first statement of NeedsRebuild — the size tripwire
+static_assert(sizeof(RenderConfig) == 224,
+              "RenderConfig layout changed — re-check the classification in NeedsRebuild");
 ```
 
-This sentinel (`render_config.cpp:168`, first statement of `NeedsRebuild`) forces a
-compile error when any field is added to or removed from `RenderConfig`. The
-developer must then classify the new field as layout-affecting (add to
-`NeedsRebuild` comparisons) or appearance-only (no change needed). This prevents
-silent drift where a new layout field is added but `NeedsRebuild` is not updated.
+The **field-set guard** is what makes adding or removing a field a compile error. A
+structured binding is checked against the member *declarations*, so the count is
+unaffected by how the compiler lays the members out.
+
+The **size tripwire** does not make that guarantee, and an earlier revision of this
+section said it did. A field that lands in an alignment hole leaves `sizeof`
+unchanged and the assert silent — measured on this struct twice: adding a `bool` to
+the run below `horizon_` keeps it at 224, and removing `opacity_` (a `float`) once
+kept it at 136. What the tripwire *does* catch is a change **within** a field — a
+nested struct gaining a member, a type widening — which moves the byte size without
+moving the field count, and which the guard is in turn blind to. Hence both.
+
+Either one firing carries the same duty: classify the field as layout-affecting (add
+it to the `NeedsRebuild` comparisons) or appearance-only (no change needed), so that
+a new layout field cannot silently drift past `NeedsRebuild`.
 
 ### §5.3 ResetWith Path
 

--- a/src/config/config_compare.hpp
+++ b/src/config/config_compare.hpp
@@ -108,8 +108,12 @@ inline bool operator==(const LensParam& a, const LensParam& b) {
 }
 
 inline bool operator==(const RenderConfig& a, const RenderConfig& b) {
-  // Bump this when adding fields to RenderConfig.
-  static_assert(sizeof(RenderConfig) == 224, "Update operator== when RenderConfig fields change");
+  // A SIZE tripwire. "A field was added or removed" is guarded by RenderConfigFieldSetGuard
+  // (render_config.hpp), which counts member declarations and therefore cannot be defeated by a
+  // field landing in an alignment hole — this assert can, and has been (see that comment). What
+  // it catches instead is a change WITHIN a field, which moves the size without moving the
+  // count. Both fire on the same duty: decide whether the comparison below must cover it.
+  static_assert(sizeof(RenderConfig) == 224, "RenderConfig layout changed — re-check what operator== compares");
   return a.id_ == b.id_ && a.lens_ == b.lens_ &&
          std::equal(std::begin(a.lens_shift_), std::end(a.lens_shift_), std::begin(b.lens_shift_)) &&
          std::equal(std::begin(a.resolution_), std::end(a.resolution_), std::begin(b.resolution_)) &&

--- a/src/config/render_config.cpp
+++ b/src/config/render_config.cpp
@@ -285,9 +285,19 @@ void to_json(nlohmann::json& j, const RenderConfig& r) {
 
 
 // See doc/accumulator-consumer-architecture.md §5.1 (layout vs. appearance classification),
-// §5.2 (sizeof sentinel).
+// §5.2 (field-set guard and size tripwire).
 bool NeedsRebuild(const RenderConfig& a, const RenderConfig& b) {
-  // Bump this when adding fields to RenderConfig — then classify as layout or appearance.
+  // A SIZE tripwire, not the field-set guard, and the distinction is what the two comments below
+  // about "an unchanged number" are already circling. RenderConfigFieldSetGuard
+  // (render_config.hpp) is what turns "a field was added or removed" into a compile error; it
+  // counts member declarations, so padding cannot hide one from it. The static_assert here sees
+  // a different class — a change WITHIN a field, a nested struct gaining a member or a type
+  // widening — which leaves the field count alone and moves the byte size. Neither subsumes the
+  // other, which is why both are kept.
+  // What this one is blind to, measured rather than theorised: a field that lands in an alignment
+  // hole. Adding a bool to the run below horizon_ leaves sizeof at 224 and this assert silent;
+  // removing opacity_ (a float) once left it at 136 the same way.
+  // Either way the duty is the same: classify the new field as layout or appearance.
   // Still 192 after the three text-label switches were added: they landed in the tail padding
   // `horizon_` already carried ahead of ZenithNadirParam's 4-byte alignment. The number is a
   // tripwire for "a field was added", not a size budget, so an unchanged one is only safe to leave
@@ -311,7 +321,8 @@ bool NeedsRebuild(const RenderConfig& a, const RenderConfig& b) {
   // APPEARANCE, for the same reason the label switches are: they decide whether a line is
   // composited onto the finished image, never the buffer it accumulates into, so a config that
   // flips one reaches an existing consumer through ResetWith() with no rebuild.
-  static_assert(sizeof(RenderConfig) == 224, "Update NeedsRebuild when RenderConfig fields change");
+  static_assert(sizeof(RenderConfig) == 224,
+                "RenderConfig layout changed — re-check the classification in NeedsRebuild");
   // Compare layout-affecting fields only. Appearance fields (background, ray_color,
   // intensity_factor, ev_mode, grids) are handled by ResetWith() without rebuild.
 

--- a/src/config/render_config.cpp
+++ b/src/config/render_config.cpp
@@ -297,7 +297,11 @@ bool NeedsRebuild(const RenderConfig& a, const RenderConfig& b) {
   // What this one is blind to, measured rather than theorised: a field that lands in an alignment
   // hole. Adding a bool to the run below horizon_ leaves sizeof at 224 and this assert silent;
   // removing opacity_ (a float) once left it at 136 the same way.
-  // Either way the duty is the same: classify the new field as layout or appearance.
+  // Which one fired says what has to be classified, and the two are not the same question. The
+  // guard firing means a field was added or removed: classify that field, layout or appearance.
+  // This assert firing ALONE means no field was added or removed — some existing field grew — so
+  // there is no new field to classify; the question is whether the grown field's new content
+  // changes what the accumulator buffer must be. Do not go looking for a new name in that case.
   // Still 192 after the three text-label switches were added: they landed in the tail padding
   // `horizon_` already carried ahead of ZenithNadirParam's 4-byte alignment. The number is a
   // tripwire for "a field was added", not a size budget, so an unchanged one is only safe to leave

--- a/src/config/render_config.hpp
+++ b/src/config/render_config.hpp
@@ -271,6 +271,36 @@ struct RenderConfig {
   float markers_radius_px_ = 8.0f;
 };
 
+// The field-set guard for RenderConfig, kept beside the struct so the list of names has one owner
+// rather than one copy per consumer.
+//
+// WHAT IT MEASURES: the number of non-static data members. A structured binding is checked against
+// the member DECLARATIONS, so a field that costs no bytes still changes the count.
+//
+// WHY IT IS NOT THE sizeof PIN: the two `static_assert(sizeof(RenderConfig) == 224)` in
+// NeedsRebuild (render_config.cpp) and operator== (config_compare.hpp) measure the byte size, and
+// a field that lands in an alignment hole does not change it. That is measured, not theorised:
+// adding a bool to the run below `horizon_` leaves sizeof at 224 and every sizeof pin silent, and
+// removing `opacity_` (a float) once left it at 136 for the same reason. A binding list has no
+// padding for a field to hide in.
+//
+// WHEN IT FIRES the compiler says "decomposes into N elements, but M names were provided" on the
+// binding below. A field was added or removed, and three duties follow:
+//   - classify it as layout or appearance in NeedsRebuild (render_config.cpp);
+//   - decide whether operator== must compare it (config_compare.hpp);
+//   - add or drop its name here.
+//
+// WHAT IT DOES NOT COVER, and why the sizeof pins stay: a change WITHIN a field — a nested struct
+// gaining a member, a type widening — keeps the count unchanged and is invisible here. The sizeof
+// pins do see that class, so the two are complements and neither replaces the other.
+inline void RenderConfigFieldSetGuard(const RenderConfig& c) {
+  [[maybe_unused]] const auto& [id, lens, lens_shift, resolution, view, visible, front, background, ray_color,
+                                intensity_factor, overlap, ev_mode, angular_dist_grid, elevation_grid, longitude_grid,
+                                horizon, elevation_grid_line, longitude_grid_line, angular_dist_grid_line,
+                                horizon_label, grid_label, angular_dist_label, zenith_nadir, markers, markers_opacity,
+                                markers_radius_px] = c;
+}
+
 NLOHMANN_JSON_SERIALIZE_ENUM(    // declare
     RenderConfig::VisibleRange,  // type
     {

--- a/src/config/render_config.hpp
+++ b/src/config/render_config.hpp
@@ -243,6 +243,7 @@ struct RenderConfig {
   // The parallels and the meridians share one switch, as they share one appearance in the GUI.
   bool grid_label_ = false;
   bool angular_dist_label_ = false;
+  bool probe_pad_field_ = false;  // TEMPORARY red-state probe
   // The zenith / nadir ring markers. Opt-in for the same reason horizon_ is: an annotation nobody
   // asked for must not appear in a config that predates the field.
   //

--- a/src/config/render_config.hpp
+++ b/src/config/render_config.hpp
@@ -243,7 +243,6 @@ struct RenderConfig {
   // The parallels and the meridians share one switch, as they share one appearance in the GUI.
   bool grid_label_ = false;
   bool angular_dist_label_ = false;
-  bool probe_pad_field_ = false;  // TEMPORARY red-state probe
   // The zenith / nadir ring markers. Opt-in for the same reason horizon_ is: an annotation nobody
   // asked for must not appear in a config that predates the field.
   //

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -549,11 +549,15 @@ namespace {
 // that the guard does not, is a change WITHIN a field — a nested struct gaining a member, a type
 // widening — which moves the byte size without moving the member count.
 //
-// Once either one fires, a field was added/removed — the author must decide between three
+// WHICH ONE fired says what is being decided, and the two are not the same question. The GUARD
+// firing means a field was added or removed, and that field has to be placed in one of three
 // dispositions: it belongs in RenderConfigResimFields above (participates in resim eligibility);
 // it is excluded outright, captured by nothing (like exposure_offset and the T-view fields); or it
 // is excluded from resim eligibility but still Revert-tracked through its own ConfigSnapshot slot
-// (like background — see ConfigSnapshot::renderer_background).
+// (like background — see ConfigSnapshot::renderer_background). This SIZE assert firing ALONE
+// means no field was added or removed — some existing field grew — so there is no new name to
+// place; what has to be re-checked is whether the grown field's new content changes the
+// disposition already recorded for it.
 //
 // ev_mode (v4.16) is EXCLUDED, and it now HAS a control (the Display group's Mode combo, plus the
 // defaults panel's registered editor) — so the exclusion is a decision, not the absence of one.

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -514,6 +514,22 @@ struct RenderConfigResimFields {
   friend bool operator!=(const RenderConfigResimFields& a, const RenderConfigResimFields& b) { return !(a == b); }
 };
 
+// The field-set guards for the two structs above. Deliberately OUTSIDE the platform gate that
+// follows: a member COUNT is the same on every target, so gating it would buy nothing and would
+// leave Linux/Windows without the half of the check that works there. The sizeof pins below stay
+// gated because a byte size is not portable.
+//
+// WHEN ONE FIRES the compiler says "decomposes into N elements, but M names were provided". A
+// field was added to or removed from that struct, and the dispositions spelled out under the
+// platform gate below are what has to be decided.
+inline void RenderConfigFieldSetGuard(const RenderConfig& c) {
+  [[maybe_unused]] const auto& [lens_type, fov, elevation, azimuth, roll, sim_resolution_index, visible, front,
+                                background, ray_color, exposure_offset, ev_mode] = c;
+}
+inline void RenderConfigResimFieldsGuard(const RenderConfigResimFields& r) {
+  [[maybe_unused]] const auto& [sim_resolution_index] = r;
+}
+
 // Apple Silicon + libc++ only. Layout pins, mirroring the EntryCard pattern (see below).
 // Linux/Windows CI still compiles both structs; this only pins the Apple main-dev platform.
 #if defined(__APPLE__) && defined(__aarch64__)
@@ -536,13 +552,25 @@ struct RenderConfigResimFields {
 // its anchor from config_.ev_mode_ at CommitConfig time), and there it deliberately takes effect
 // on the next Run rather than the next frame — see the note at component_compositor.cpp's
 // CompositeAnchorScale. That is a slower path to the same value, not a resim dependency.
-static_assert(sizeof(RenderConfig) == 64, "RenderConfig size changed — check RenderConfigResimFields for new fields");
+static_assert(sizeof(RenderConfig) == 64, "RenderConfig layout changed — see RenderConfigFieldSetGuard above");
 // RenderConfigResimFields: naming the field list once does NOT by itself keep the three
 // directions in step. From() aggregate-initializes, so a newly added field is silently
 // value-initialized rather than rejected, and ApplyTo()/operator== would quietly keep working on
-// the old subset. Pinning the size is what turns that omission into a compile error.
+// the old subset.
+//
+// Pinning the SIZE does not turn that omission into a compile error either, which is what this
+// comment used to claim. sizeof is blind to a field that lands in an alignment hole — measured
+// on the two structs above, and this one is one member away from having such a hole itself (add
+// an int and a bool and the next bool is free). RenderConfigResimFieldsGuard above is what makes
+// "a field was added or removed" a compile error, because it counts member declarations.
+//
+// What NOTHING here guarantees is the three-way part: once the guard has told you a field
+// appeared, keeping From / ApplyTo / operator== consistent about it is a code-review duty, not a
+// compile-time one. A stronger mechanism (a user-declared constructor to force From to name every
+// field) is deliberately not built: this struct holds one field and no drift has ever escaped
+// here, so the cost is not carried by any observed harm.
 static_assert(sizeof(RenderConfigResimFields) == 4,
-              "RenderConfigResimFields size changed — update From/ApplyTo/operator== together");
+              "RenderConfigResimFields layout changed — re-check From/ApplyTo/operator== together");
 #endif
 
 // Resettable subset of RenderConfig (the View `Reset` button targets these

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -522,18 +522,34 @@ struct RenderConfigResimFields {
 // WHEN ONE FIRES the compiler says "decomposes into N elements, but M names were provided". A
 // field was added to or removed from that struct, and the dispositions spelled out under the
 // platform gate below are what has to be decided.
-inline void RenderConfigFieldSetGuard(const RenderConfig& c) {
+//
+// Anonymous-namespace, not inline: unlike the shared RenderConfig (core) guard in
+// render_config.hpp, these two have no second consumer translation unit, so an internal-linkage
+// copy per including TU is the right shape — no reason to give a never-called probe external
+// linkage.
+namespace {
+[[maybe_unused]] void RenderConfigFieldSetGuard(const RenderConfig& c) {
   [[maybe_unused]] const auto& [lens_type, fov, elevation, azimuth, roll, sim_resolution_index, visible, front,
                                 background, ray_color, exposure_offset, ev_mode] = c;
 }
-inline void RenderConfigResimFieldsGuard(const RenderConfigResimFields& r) {
+[[maybe_unused]] void RenderConfigResimFieldsGuard(const RenderConfigResimFields& r) {
   [[maybe_unused]] const auto& [sim_resolution_index] = r;
 }
+}  // namespace
 
 // Apple Silicon + libc++ only. Layout pins, mirroring the EntryCard pattern (see below).
 // Linux/Windows CI still compiles both structs; this only pins the Apple main-dev platform.
 #if defined(__APPLE__) && defined(__aarch64__)
-// RenderConfig: if this fires, a field was added/removed — the author must decide between three
+// RenderConfig: this SIZE tripwire is not what turns "a field was added/removed" into a compile
+// error — that guarantee belongs to RenderConfigFieldSetGuard above, which counts member
+// declarations and fires unconditionally on every platform, not just this Apple-gated one.
+// Pinning the SIZE here does not by itself catch that case: sizeof is blind to a field that lands
+// in an alignment hole, the same failure mode measured on the two structs above (add a bool
+// somewhere padding-friendly and this assert stays silent). What this assert alone still catches,
+// that the guard does not, is a change WITHIN a field — a nested struct gaining a member, a type
+// widening — which moves the byte size without moving the member count.
+//
+// Once either one fires, a field was added/removed — the author must decide between three
 // dispositions: it belongs in RenderConfigResimFields above (participates in resim eligibility);
 // it is excluded outright, captured by nothing (like exposure_offset and the T-view fields); or it
 // is excluded from resim eligibility but still Revert-tracked through its own ConfigSnapshot slot

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -405,6 +405,7 @@ struct RenderConfig {
   int sim_resolution_index = 1;  // Index into kSimResolutions (default 1024)
   int visible = 2;               // Index into kVisibleNames (0=upper, 1=lower, 2=full)
   bool front = false;            // Independent front-hemisphere clip flag (AND with base)
+  bool probe_pad_field = false;  // TEMPORARY red-state probe
   float background[3] = { 0.0f, 0.0f, 0.0f };
   // Serialized only (file_io.cpp) — no editor registers it (field_editor_registry.cpp), so
   // nothing in the running GUI can change it. See the RenderConfigResimFields comment below.

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -405,7 +405,6 @@ struct RenderConfig {
   int sim_resolution_index = 1;  // Index into kSimResolutions (default 1024)
   int visible = 2;               // Index into kVisibleNames (0=upper, 1=lower, 2=full)
   bool front = false;            // Independent front-hemisphere clip flag (AND with base)
-  bool probe_pad_field = false;  // TEMPORARY red-state probe
   float background[3] = { 0.0f, 0.0f, 0.0f };
   // Serialized only (file_io.cpp) — no editor registers it (field_editor_registry.cpp), so
   // nothing in the running GUI can change it. See the RenderConfigResimFields comment below.


### PR DESCRIPTION
## 问题

四处 `static_assert(sizeof(...) == N)` 声称守的是 `RenderConfig`（及其 GUI 镜像、resim 子集）的**字段集**，但它们量的是**结构体尺寸**。两者在常见改动上同向变化，所以日常毫无破绽；而它工作的边缘区间恰恰是耦合断裂处——**字段落进对齐空隙**：删掉 `RenderConfig::opacity_`（一个 `float`）后 `sizeof` 仍然是 136（scrum-469 实测），四处哨兵一声不吭。

更重的一条：`gui_state.hpp` 的注释直接断言 *"Pinning the size is what turns that omission into a compile error."* —— 这句**不成立**。一个守不住的保证被写成了注释，读到它的人会停止怀疑（与 task-462「错误结论被写成注释禁令」同族）。

⛔ 本 PR 不是把哨兵的数字改大改小——今天四处的数字全都是对的。

## 裁定：加，不是换

新增基于**结构化绑定成员计数**的编译期探针 `RenderConfigFieldSetGuard`：结构化绑定按成员**声明**检查，padding 藏不住字段，且**无平台闸、每个平台都触发**。

与原有的 sizeof 哨兵**并存互补**，两者检出集交叠但互不包含：

- **guard** 抓字段增删（sizeof 对落进对齐空隙的那一类失明）；
- **sizeof tripwire** 抓**字段内部**的变化——嵌套结构体新增成员、类型变宽——成员数不动而字节数动，guard 对这一类失明。

sizeof 哨兵因此被如实降级为「布局位移哨兵」，四处过强注释同步改写。

## 验证

- **AC0 红态先行**：先证明今天四处哨兵对「在 padding 空隙里增删字段」**全部不报错**（施加前后都编译绿 = 检出力为零），再动手。
- **AC4 检出力自证**：同一个改动，旧判据绿 / 新判据红，逐位置实测（position 4 如实记录「今天没有可复现的 padding 空隙可做对照」，只证明探针本身有效，⛔ 不说成抓到了旧判据抓不到的东西）。
- `./scripts/test.sh quick` 全绿（ctest 7/7、fast-e2e、gui 357/357）；四道 diff-scoped 门禁 + `./scripts/format.sh --check` 全绿。
- code review：round 1 REQUEST_CHANGES → round 2 **APPROVE**，0 Critical / 0 Major。

## 最后一个 commit 的来历（披露）

`docs(config): say which tripwire fired...` 是**合并前由 owner 会话补的**，落地的是 round 2 两条 Minor 的原话：重写后的注释在三处都以「任一触发 = 字段被增删」收尾，而它们前一两句刚说清楚 sizeof 单独触发对应的是字段**内部**变宽——读者会去找一个不存在的新字段。这正是本任务要根除的缺陷形态换了个更隐蔽的位置，所以在合并前一并改掉，且三处一起改而不是只改 round 1 点名的那一处。

⚠️ 该 commit **未再跑第三轮 code-review**：它是注释文本改动，逐字落地 round 2 已经写明的修法，两个受影响 TU 重新编译干净、四道门禁与 format 均绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Dzk6oieAM7Px5CApP2JAp