### PR TITLE
[THROWAWAY] AC1 evidence only — do not review, do not merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
       # written on this leg, and every other matrix entry evaluates the unset variable to an
       # empty string, so the shared Configure step needs no branch of its own.
       - name: Install sccache (Windows MSVC)
-        if: matrix.msvc
+        if: matrix.msvc && true
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -204,7 +204,7 @@ jobs:
       # restore-keys then supplies the previous commit's directory, where the objects for
       # every file this commit did not touch still hit.
       - name: Cache sccache directory (Windows MSVC)
-        if: matrix.msvc
+        if: matrix.msvc && true
         uses: actions/cache@v6
         with:
           path: sccache_cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
       # written on this leg, and every other matrix entry evaluates the unset variable to an
       # empty string, so the shared Configure step needs no branch of its own.
       - name: Install sccache (Windows MSVC)
-        if: matrix.msvc && true
+        if: matrix.msvc && false
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -204,7 +204,7 @@ jobs:
       # restore-keys then supplies the previous commit's directory, where the objects for
       # every file this commit did not touch still hit.
       - name: Cache sccache directory (Windows MSVC)
-        if: matrix.msvc && true
+        if: matrix.msvc && false
         uses: actions/cache@v6
         with:
           path: sccache_cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
       # written on this leg, and every other matrix entry evaluates the unset variable to an
       # empty string, so the shared Configure step needs no branch of its own.
       - name: Install sccache (Windows MSVC)
-        if: matrix.msvc && false
+        if: matrix.msvc && true
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -204,7 +204,7 @@ jobs:
       # restore-keys then supplies the previous commit's directory, where the objects for
       # every file this commit did not touch still hit.
       - name: Cache sccache directory (Windows MSVC)
-        if: matrix.msvc && false
+        if: matrix.msvc && true
         uses: actions/cache@v6
         with:
           path: sccache_cache

--- a/src/core/color_util.hpp
+++ b/src/core/color_util.hpp
@@ -78,6 +78,9 @@ inline void SpectrumToXyzPerRay(const float* wl_per_ray, const float* v, const i
   }
 }
 
+// Throwaway probe symbol: changes this header's preprocessor output.
+constexpr int kProbeTier2ColorUtil = 20260909;
+
 }  // namespace lumice
 
 #endif  // CORE_COLOR_UTIL_H_

--- a/src/core/optics.cpp
+++ b/src/core/optics.cpp
@@ -197,4 +197,7 @@ double IceRefractiveIndex::Get(double wave_length) {
   return std::sqrt(n);
 }
 
+// Throwaway probe symbol: changes this TU's preprocessor output.
+constexpr int kProbeTier2Optics = 20260909;
+
 }  // namespace lumice

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -505,6 +505,8 @@ void LUMICE_SetLogCallback(LUMICE_LogCallback callback);
 #define LUMICE_MAX_CONFIG_RENDERERS 4
 #define LUMICE_MAX_CONFIG_SCATTER_LAYERS 8
 #define LUMICE_MAX_CONFIG_SCATTER_ENTRIES 256
+/* Throwaway probe macro: changes this public header's preprocessor output. */
+#define LUMICE_PROBE_TIER3 20260909
 #define LUMICE_MAX_CONFIG_RAYPATH_LEN 32
 // Discrete-spectrum entry cap. Mirrors core wl_pool.hpp::kWlPoolSizeMax (255).
 #define LUMICE_MAX_CONFIG_SPECTRUM_ENTRIES 255


### PR DESCRIPTION
仅用于 task-ci-cache-budget AC1 取证（sccache 三档收益 × 红热两态）。

base 指向冻结分支 `ci-cache-budget-frozen-base`（创建后永不前进），使 `refs/pull/<N>/merge`
恒等于本分支 HEAD 的树，消除 base 漂移对测量的静默污染。

完成后关闭本 PR 并删除两条分支（`ci-cache-budget-probe` + `ci-cache-budget-frozen-base`）。
不触发正常 review 流程。