### PR TITLE
ci(cache): budget the actions/cache quota — fix three prefix-shadowed keys, add ccache to the critical-path leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,10 +174,13 @@ jobs:
       # the same "one entry per commit with a prefix fallback" key. Only the ubuntu-x64
       # matrix entry, because it is the only Linux entry in this job that is compile-bound.
       #
-      # CCACHE_MAXSIZE is 200M on measured grounds — see the sibling step in
-      # shared-gui-test-build, whose configure leaves a 37 MB directory after a full cold
-      # build. A cap is not a footprint, and copying the Windows leg's number here would
-      # reserve fifty times the working set.
+      # CCACHE_MAXSIZE is 800M, and it is 800M because this leg was measured rather than
+      # assumed to resemble its neighbour. It first shipped at the 200M that fits
+      # shared-gui-test-build, whose directory settles at 37 MB; on this leg 200M was
+      # immediately over-full — `ccache --show-stats` reported 110.3% of the cap and a
+      # 26.34% hit rate, i.e. the cap was evicting objects the next run needed. The two
+      # configures compile a similar number of units and land roughly six times apart in
+      # bytes, so neither leg's number transfers to the other. Measure per leg.
       - name: Install ccache (Ubuntu x86_64)
         if: matrix.cache_key == 'ubuntu-x64'
         run: |
@@ -185,7 +188,7 @@ jobs:
           ccache --version
           echo "LUMICE_COMPILER_LAUNCHER_ARGS=-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
           echo "CCACHE_DIR=$GITHUB_WORKSPACE/ccache_cache" >> $GITHUB_ENV
-          echo "CCACHE_MAXSIZE=200M" >> $GITHUB_ENV
+          echo "CCACHE_MAXSIZE=800M" >> $GITHUB_ENV
 
       # Discriminator first, as everywhere else in this file: `ccache-ubuntu-x64-` would be
       # a prefix of the shared-gui leg's namespace, which is the exact defect the cpm keys

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -818,12 +818,14 @@ jobs:
       #
       # CCACHE_MAXSIZE is 200M, and that number is measured rather than copied. A full cold
       # compile of this configure — 291 objects, nothing restored — leaves a 37 MB directory,
-      # so the 2G the Windows leg uses (and the 2G an earlier measurement branch proposed
-      # here) is about fifty times the working set. That difference is not a Linux-vs-Windows
-      # quirk to shrug at: the sccache directory reaches its own 2 GiB ceiling on the MSVC
-      # leg, which is what makes that namespace ~1.5 GB per entry and 80% of the repository's
-      # cache quota, while this one costs a rounding error. 200M leaves room for several
-      # generations of objects to accumulate through the restore-keys fallback.
+      # so the 800M this task sized the Windows leg's SCCACHE_CACHE_SIZE to (see the Install
+      # sccache step in the build job) is about four times the working set here, and the 2G
+      # that leg used before this task is about fifty times it. That difference is not a
+      # Linux-vs-Windows quirk to shrug at: the sccache directory used to reach its own 2 GiB
+      # ceiling on the MSVC leg before this change, which made that namespace ~1.5 GB per
+      # entry and 80% of the repository's cache quota at the time, while this one costs a
+      # rounding error. 200M leaves room for several generations of objects to accumulate
+      # through the restore-keys fallback.
       #
       # If `ccache --show-stats` ever reports Cache size at Max cache size, the cap is
       # evicting live objects and has to go up. That shows up as a quietly lower hit rate and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -776,17 +776,25 @@ jobs:
       # job says it was put "on the one leg where compilation is most of the job" — that was
       # true when written, and this leg is what it means today.
       #
-      # CCACHE_MAXSIZE is 800M rather than the 2G the Windows leg uses, because the quota is
-      # the binding constraint: the sccache namespace alone holds ~1.5 GB per entry and one
-      # entry per active ref. If `ccache --show-stats` ever reports Cache size == Max cache
-      # size, this cap is evicting live objects and has to go up — the hit rate drops
-      # silently when that happens, so read the number rather than the wall clock.
+      # CCACHE_MAXSIZE is 200M, and that number is measured rather than copied. A full cold
+      # compile of this configure — 291 objects, nothing restored — leaves a 37 MB directory,
+      # so the 2G the Windows leg uses (and the 2G an earlier measurement branch proposed
+      # here) is about fifty times the working set. That difference is not a Linux-vs-Windows
+      # quirk to shrug at: the sccache directory reaches its own 2 GiB ceiling on the MSVC
+      # leg, which is what makes that namespace ~1.5 GB per entry and 80% of the repository's
+      # cache quota, while this one costs a rounding error. 200M leaves room for several
+      # generations of objects to accumulate through the restore-keys fallback.
+      #
+      # If `ccache --show-stats` ever reports Cache size at Max cache size, the cap is
+      # evicting live objects and has to go up. That shows up as a quietly lower hit rate and
+      # an unchanged-looking build, never as a red, so read the number rather than the wall
+      # clock.
       - name: Install ccache
         run: |
           sudo apt-get install -y ccache
           ccache --version
           echo "CCACHE_DIR=$GITHUB_WORKSPACE/ccache_cache" >> $GITHUB_ENV
-          echo "CCACHE_MAXSIZE=800M" >> $GITHUB_ENV
+          echo "CCACHE_MAXSIZE=200M" >> $GITHUB_ENV
 
       # Same key shape as the sccache entry: one per commit, with a prefix fallback to the
       # newest earlier one. The discriminator leads the platform for the reason spelled out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,9 @@ jobs:
       # Discriminator first, as everywhere else in this file: `ccache-ubuntu-x64-` would be
       # a prefix of the shared-gui leg's namespace, which is the exact defect the cpm keys
       # were renamed to fix and which cost a measured 99.66% -> 2.35% hit rate the first time
-      # a branch tried it.
+      # a branch tried it. "static" is this leg's discriminator word, chosen to contrast with
+      # `shared-gui-test-build`'s `BUILD_SHARED_LIBS=ON` configure — this leg builds the
+      # static flavor, same sense as `-sj` meaning "shared flavor" in the build script docs.
       - name: Cache ccache directory (Ubuntu x86_64)
         if: matrix.cache_key == 'ubuntu-x64'
         uses: actions/cache@v6
@@ -808,16 +810,11 @@ jobs:
           key: cpm-sharedgui-ubuntu-x64-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: cpm-sharedgui-ubuntu-x64-
 
-      # ccache on this leg and no other. A run's wall clock is its longest job, and this is
-      # that job — the sccache comment in the build job says it was put "on the one leg where
-      # compilation is most of the job", which was true when written and means this leg today.
-      # The plain `Ubuntu x86_64` leg deliberately does not get one: it already finishes under
-      # the next-longest job, whose own floor is an indivisible test case no compiler cache
-      # touches, so caching it would buy machine time and zero wall clock. That is the whole
-      # of the reason, and it is worth being precise about what is NOT part of it: quota is
-      # not the constraint here. A cold build of this configure leaves a 37 MB directory, so
-      # a second Linux leg would cost a rounding error against a 10 GB pool. Revisit this if
-      # the job ordering changes, not if the quota does.
+      # ccache on this leg, and on the plain `Ubuntu x86_64` leg in the build job below —
+      # both are compile-bound Linux legs, so both get one, each with its own independently
+      # measured CCACHE_MAXSIZE (see the comment on that leg's Install ccache step for why
+      # its number is 800M rather than this leg's 200M: the two configures land roughly six
+      # times apart in working-set bytes, so neither leg's number transfers to the other).
       #
       # CCACHE_MAXSIZE is 200M, and that number is measured rather than copied. A full cold
       # compile of this configure — 291 objects, nothing restored — leaves a 37 MB directory,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,9 +141,11 @@ jobs:
       # else. The version is not a free parameter to bump: 0.17.0 is the version this repo's
       # MSVC + Ninja + CPM combination was measured against, and moving it means re-measuring.
       #
-      # LUMICE_SCCACHE_ARGS follows the LUMICE_PYTHON_ARGS pattern below: it is only ever
-      # written on this leg, and every other matrix entry evaluates the unset variable to an
-      # empty string, so the shared Configure step needs no branch of its own.
+      # LUMICE_COMPILER_LAUNCHER_ARGS follows the LUMICE_PYTHON_ARGS pattern below: matrix
+      # entries that write it get a launcher, every other entry evaluates the unset variable
+      # to an empty string, and the shared Configure step needs no branch of its own. The
+      # name is deliberately not tool-specific — the ubuntu-x64 entry writes the same
+      # variable with ccache, and two spellings for one thing is how they drift apart.
       - name: Install sccache (Windows MSVC)
         if: matrix.msvc
         shell: pwsh
@@ -162,9 +164,40 @@ jobs:
           $dir = Join-Path $env:RUNNER_TEMP $asset
           & (Join-Path $dir 'sccache.exe') --version
           echo $dir >> $env:GITHUB_PATH
-          echo "LUMICE_SCCACHE_ARGS=-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $env:GITHUB_ENV
+          echo "LUMICE_COMPILER_LAUNCHER_ARGS=-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache" >> $env:GITHUB_ENV
           echo "SCCACHE_DIR=$env:GITHUB_WORKSPACE\sccache_cache" >> $env:GITHUB_ENV
-          echo "SCCACHE_CACHE_SIZE=2G" >> $env:GITHUB_ENV
+          echo "SCCACHE_CACHE_SIZE=800M" >> $env:GITHUB_ENV
+
+      # The same treatment for ubuntu-x64, which is this workflow's longest job once the
+      # shared-gui leg has a cache of its own. Deliberately the same shape as the sccache
+      # step above rather than a second invention: same launcher-via-env-var injection, and
+      # the same "one entry per commit with a prefix fallback" key. Only the ubuntu-x64
+      # matrix entry, because it is the only Linux entry in this job that is compile-bound.
+      #
+      # CCACHE_MAXSIZE is 200M on measured grounds — see the sibling step in
+      # shared-gui-test-build, whose configure leaves a 37 MB directory after a full cold
+      # build. A cap is not a footprint, and copying the Windows leg's number here would
+      # reserve fifty times the working set.
+      - name: Install ccache (Ubuntu x86_64)
+        if: matrix.cache_key == 'ubuntu-x64'
+        run: |
+          sudo apt-get install -y ccache
+          ccache --version
+          echo "LUMICE_COMPILER_LAUNCHER_ARGS=-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $GITHUB_ENV
+          echo "CCACHE_DIR=$GITHUB_WORKSPACE/ccache_cache" >> $GITHUB_ENV
+          echo "CCACHE_MAXSIZE=200M" >> $GITHUB_ENV
+
+      # Discriminator first, as everywhere else in this file: `ccache-ubuntu-x64-` would be
+      # a prefix of the shared-gui leg's namespace, which is the exact defect the cpm keys
+      # were renamed to fix and which cost a measured 99.66% -> 2.35% hit rate the first time
+      # a branch tried it.
+      - name: Cache ccache directory (Ubuntu x86_64)
+        if: matrix.cache_key == 'ubuntu-x64'
+        uses: actions/cache@v6
+        with:
+          path: ccache_cache
+          key: ccache-static-ubuntu-x64-${{ github.sha }}
+          restore-keys: ccache-static-ubuntu-x64-
 
       # GLAD2 runs the Python code generator at CMake configure time (needs Jinja2).
       - name: Install GLAD2 Python dependencies (MSVC)
@@ -248,7 +281,7 @@ jobs:
           -DBUILD_GUI=${{ matrix.build_gui }}
           -DLUMICE_NATIVE_ARCH=OFF
           ${{ env.LUMICE_PYTHON_ARGS }}
-          ${{ env.LUMICE_SCCACHE_ARGS }}
+          ${{ env.LUMICE_COMPILER_LAUNCHER_ARGS }}
 
       - name: Build
         run: cmake --build build --parallel
@@ -258,6 +291,10 @@ jobs:
       # slow Build was a cold cache or a real regression. Stopping the server afterwards
       # flushes its state to disk before actions/cache's post-step packs the directory; no
       # compilation happens after this point in the job.
+      - name: ccache statistics (Ubuntu x86_64)
+        if: always() && matrix.cache_key == 'ubuntu-x64'
+        run: ccache --show-stats --verbose || true
+
       - name: sccache statistics (Windows MSVC)
         if: always() && matrix.msvc
         shell: bash
@@ -768,13 +805,16 @@ jobs:
           key: cpm-sharedgui-ubuntu-x64-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: cpm-sharedgui-ubuntu-x64-
 
-      # ccache on this leg and no other, which is a budget decision before it is a
-      # performance one. A run's wall clock is its longest job, and this is that job; the
-      # plain `Ubuntu x86_64` leg already finishes under the next-longest one, so a compiler
-      # cache there would buy machine time and zero wall clock while claiming its share of a
-      # 10 GB repository-wide quota that is already full. The sccache comment in the build
-      # job says it was put "on the one leg where compilation is most of the job" — that was
-      # true when written, and this leg is what it means today.
+      # ccache on this leg and no other. A run's wall clock is its longest job, and this is
+      # that job — the sccache comment in the build job says it was put "on the one leg where
+      # compilation is most of the job", which was true when written and means this leg today.
+      # The plain `Ubuntu x86_64` leg deliberately does not get one: it already finishes under
+      # the next-longest job, whose own floor is an indivisible test case no compiler cache
+      # touches, so caching it would buy machine time and zero wall clock. That is the whole
+      # of the reason, and it is worth being precise about what is NOT part of it: quota is
+      # not the constraint here. A cold build of this configure leaves a 37 MB directory, so
+      # a second Linux leg would cost a rounding error against a 10 GB pool. Revisit this if
+      # the job ordering changes, not if the quota does.
       #
       # CCACHE_MAXSIZE is 200M, and that number is measured rather than copied. A full cold
       # compile of this configure — 291 objects, nothing restored — leaves a 37 MB directory,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -768,6 +768,40 @@ jobs:
           key: cpm-sharedgui-ubuntu-x64-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: cpm-sharedgui-ubuntu-x64-
 
+      # ccache on this leg and no other, which is a budget decision before it is a
+      # performance one. A run's wall clock is its longest job, and this is that job; the
+      # plain `Ubuntu x86_64` leg already finishes under the next-longest one, so a compiler
+      # cache there would buy machine time and zero wall clock while claiming its share of a
+      # 10 GB repository-wide quota that is already full. The sccache comment in the build
+      # job says it was put "on the one leg where compilation is most of the job" — that was
+      # true when written, and this leg is what it means today.
+      #
+      # CCACHE_MAXSIZE is 800M rather than the 2G the Windows leg uses, because the quota is
+      # the binding constraint: the sccache namespace alone holds ~1.5 GB per entry and one
+      # entry per active ref. If `ccache --show-stats` ever reports Cache size == Max cache
+      # size, this cap is evicting live objects and has to go up — the hit rate drops
+      # silently when that happens, so read the number rather than the wall clock.
+      - name: Install ccache
+        run: |
+          sudo apt-get install -y ccache
+          ccache --version
+          echo "CCACHE_DIR=$GITHUB_WORKSPACE/ccache_cache" >> $GITHUB_ENV
+          echo "CCACHE_MAXSIZE=800M" >> $GITHUB_ENV
+
+      # Same key shape as the sccache entry: one per commit, with a prefix fallback to the
+      # newest earlier one. The discriminator leads the platform for the reason spelled out
+      # on the cpm keys — `ccache-ubuntu-x64-...` would become a prefix-subset the moment the
+      # plain ubuntu-x64 leg ever gets a cache of its own.
+      - name: Cache ccache directory
+        uses: actions/cache@v6
+        with:
+          path: ccache_cache
+          key: ccache-sharedgui-ubuntu-x64-${{ github.sha }}
+          restore-keys: ccache-sharedgui-ubuntu-x64-
+
+      # The launcher flags are written out here rather than injected through an environment
+      # variable: this job has exactly one Configure step, so the indirection the build job
+      # needs (one step serving four matrix entries) would buy nothing here.
       - name: Configure (shared + test + GUI)
         run: >
           cmake -S . -B build -G Ninja
@@ -776,9 +810,19 @@ jobs:
           -DBUILD_GUI=ON
           -DBUILD_SHARED_LIBS=ON
           -DLUMICE_NATIVE_ARCH=OFF
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
       - name: Build (compile + link only, no run)
         run: cmake --build build --parallel
+
+      # Diagnostics, never a gate. The hit rate is what separates "the cache worked" from
+      # "this runner was faster", which wall clock alone cannot do: identical work on this
+      # provider was measured spanning 1.28x across runners while its link phase held to
+      # within 6%.
+      - name: ccache statistics
+        if: always()
+        run: ccache --show-stats --verbose || true
 
   e2e-test:
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -609,12 +609,21 @@ jobs:
       # CUDA-enabled and CUDA-disabled configures cannot pollute either side.
       # Current CMakeLists.txt does not add CPM packages under
       # LUMICE_CUDA_ENABLED=ON, so this only costs one extra cache slot.
+      #
+      # The discriminator sits BEFORE the platform, not after it. `restore-keys`
+      # is a prefix match, so the older `cpm-windows-msvc-x64-cuda-` spelling was
+      # a *sub*namespace of the build job's `cpm-windows-msvc-x64-`: on any
+      # exact-key miss that job could fall back onto this 2.7 MB CUDA entry
+      # instead of its own ~175 MB one, silently re-downloading every dependency
+      # while the log still reads "Cache restored from key". Nothing about that
+      # failure is visible as a red — see the sibling comments on the two
+      # ubuntu-x64 sub-jobs below, which had the same shape.
       - name: Cache CPM dependencies
         uses: actions/cache@v6
         with:
           path: cpm_cache
-          key: cpm-windows-msvc-x64-cuda-${{ hashFiles('**/CMakeLists.txt') }}
-          restore-keys: cpm-windows-msvc-x64-cuda-
+          key: cpm-cuda-windows-msvc-x64-${{ hashFiles('**/CMakeLists.txt') }}
+          restore-keys: cpm-cuda-windows-msvc-x64-
 
       # BUILD_GUI=OFF + BUILD_TEST=ON mirrors the Linux cuda-compile job: no
       # GLAD2/Python generator is invoked (that step is gated on
@@ -674,12 +683,22 @@ jobs:
       # Independent cache key: BUILD_BENCH=ON pulls in the google/benchmark CPM
       # package, so this configure's dependency set differs from the plain
       # ubuntu-x64 build job's. Sharing a key would let one pollute the other.
+      #
+      # "Independent" has to be spelled with the discriminator in FRONT of the
+      # platform. `restore-keys` matches by prefix, so `cpm-ubuntu-x64-bench-`
+      # was not a sibling of the build job's `cpm-ubuntu-x64-` but a subset of
+      # it, and the pollution the comment above rules out was reachable in the
+      # one direction that matters: this job's configure is the narrow one
+      # (BUILD_TEST=OFF, BUILD_GUI=OFF), so its entry is ~2.2 MB against the
+      # build job's ~171 MB. A `cpm-ubuntu-x64-` fallback landing here restores
+      # an almost-empty cpm_cache and re-downloads everything, reporting a hit
+      # the whole time.
       - name: Cache CPM dependencies
         uses: actions/cache@v6
         with:
           path: cpm_cache
-          key: cpm-ubuntu-x64-bench-${{ hashFiles('**/CMakeLists.txt') }}
-          restore-keys: cpm-ubuntu-x64-bench-
+          key: cpm-bench-ubuntu-x64-${{ hashFiles('**/CMakeLists.txt') }}
+          restore-keys: cpm-bench-ubuntu-x64-
 
       # BUILD_TEST=OFF + BUILD_GUI=OFF keep this job narrow: the build job above
       # already covers those targets, and skipping them avoids the OpenGL/X11
@@ -738,13 +757,16 @@ jobs:
 
       # Independent cache key: BUILD_SHARED_LIBS=ON is a distinct configure, so its
       # dependency set may differ from the plain ubuntu-x64 build job's. Sharing a key
-      # would let one pollute the other.
+      # would let one pollute the other. The discriminator leads the platform for the
+      # same reason as the bench job above: under the older
+      # `cpm-ubuntu-x64-shared-gui-test-` spelling this namespace was a prefix-subset
+      # of `cpm-ubuntu-x64-`, so "independent" held in name only.
       - name: Cache CPM dependencies
         uses: actions/cache@v6
         with:
           path: cpm_cache
-          key: cpm-ubuntu-x64-shared-gui-test-${{ hashFiles('**/CMakeLists.txt') }}
-          restore-keys: cpm-ubuntu-x64-shared-gui-test-
+          key: cpm-sharedgui-ubuntu-x64-${{ hashFiles('**/CMakeLists.txt') }}
+          restore-keys: cpm-sharedgui-ubuntu-x64-
 
       - name: Configure (shared + test + GUI)
         run: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,12 +190,19 @@ jobs:
           echo "CCACHE_DIR=$GITHUB_WORKSPACE/ccache_cache" >> $GITHUB_ENV
           echo "CCACHE_MAXSIZE=800M" >> $GITHUB_ENV
 
-      # Discriminator first, as everywhere else in this file: `ccache-ubuntu-x64-` would be
-      # a prefix of the shared-gui leg's namespace, which is the exact defect the cpm keys
-      # were renamed to fix and which cost a measured 99.66% -> 2.35% hit rate the first time
-      # a branch tried it. "static" is this leg's discriminator word, chosen to contrast with
-      # `shared-gui-test-build`'s `BUILD_SHARED_LIBS=ON` configure — this leg builds the
-      # static flavor, same sense as `-sj` meaning "shared flavor" in the build script docs.
+      # Discriminator first, as everywhere else in this file — but be precise about what that
+      # buys HERE, because it is not the collision the cpm keys were renamed to fix. The
+      # shared-gui leg is already keyed `ccache-sharedgui-ubuntu-x64-`, which
+      # `ccache-ubuntu-x64-` does not prefix: the two diverge at the first character after
+      # `ccache-`. So spelling this leg `ccache-ubuntu-x64-` would be safe against today's
+      # keys, and unsafe against tomorrow's — it is the one spelling that every future
+      # `ccache-ubuntu-x64-<anything>-` key would silently fall back into, which is exactly
+      # the shape that cost a measured 99.66% -> 2.35% hit rate when a branch tried it on the
+      # cpm keys. Discriminator-first is what makes that shape unreachable by construction
+      # instead of by nobody happening to add such a key. "static" is this leg's discriminator
+      # word, chosen to contrast with `shared-gui-test-build`'s `BUILD_SHARED_LIBS=ON`
+      # configure — this leg builds the static flavor, same sense as `-sj` meaning "shared
+      # flavor" in the build script docs.
       - name: Cache ccache directory (Ubuntu x86_64)
         if: matrix.cache_key == 'ubuntu-x64'
         uses: actions/cache@v6
@@ -732,9 +739,11 @@ jobs:
       # it, and the pollution the comment above rules out was reachable in the
       # one direction that matters: this job's configure is the narrow one
       # (BUILD_TEST=OFF, BUILD_GUI=OFF), so its entry is ~2.2 MB against the
-      # build job's ~171 MB. A `cpm-ubuntu-x64-` fallback landing here restores
-      # an almost-empty cpm_cache and re-downloads everything, reporting a hit
-      # the whole time.
+      # build job's ~171 MB. The direction that breaks is therefore the build
+      # job's, not this one's: its `cpm-ubuntu-x64-` fallback would land on this
+      # job's narrow entry, restore an almost-empty cpm_cache and re-download
+      # everything, reporting a hit the whole time. (This job's own restore-keys
+      # were never the problem — they have always been the narrower prefix.)
       - name: Cache CPM dependencies
         uses: actions/cache@v6
         with:
@@ -818,14 +827,20 @@ jobs:
       #
       # CCACHE_MAXSIZE is 200M, and that number is measured rather than copied. A full cold
       # compile of this configure — 291 objects, nothing restored — leaves a 37 MB directory,
-      # so the 800M this task sized the Windows leg's SCCACHE_CACHE_SIZE to (see the Install
-      # sccache step in the build job) is about four times the working set here, and the 2G
-      # that leg used before this task is about fifty times it. That difference is not a
-      # Linux-vs-Windows quirk to shrug at: the sccache directory used to reach its own 2 GiB
-      # ceiling on the MSVC leg before this change, which made that namespace ~1.5 GB per
-      # entry and 80% of the repository's cache quota at the time, while this one costs a
-      # rounding error. 200M leaves room for several generations of objects to accumulate
-      # through the restore-keys fallback.
+      # and 200M leaves room for several generations of objects to accumulate through the
+      # restore-keys fallback.
+      #
+      # Do NOT read this leg's 200M against the Windows leg's SCCACHE_CACHE_SIZE (800M today,
+      # 2G before this task) and take the ratio for a fact about either leg: those are caps,
+      # and a cache cap is not a footprint — the discipline stated in §7.1 of
+      # doc/testing-architecture.md, and the one an earlier draft of this very comment broke
+      # by calling 800M "about four times the working set here" (800/37 is ~22, and the 37 MB
+      # is this leg's directory, not that leg's). What the two legs actually differ by is
+      # measured working set, roughly six times apart, which is why each cap is sized from its
+      # own leg's measurement. The reason the Windows cap was worth touching at all is a
+      # measured footprint, not a ratio between caps: that directory used to reach its own
+      # 2 GiB ceiling, which made the namespace ~1.5 GB per entry and 80% of the repository's
+      # cache quota at the time, while this one costs a rounding error.
       #
       # If `ccache --show-stats` ever reports Cache size at Max cache size, the cap is
       # evicting live objects and has to go up. That shows up as a quietly lower hit rate and

--- a/doc/testing-architecture.md
+++ b/doc/testing-architecture.md
@@ -1301,6 +1301,10 @@ to `push` on `main` because it writes the gh-pages benchmark history.
 That leg went 650s uncached → 657s (cold, nothing to restore) → 567s → 479s → 353s across five
 consecutive runs, and its ccache hit rate over the last three was 26.34% → 41.39% → **55.96%**, still
 climbing, with the directory at 36.7% of its cap. So **353s is an upper bound on the steady state**.
+(The table's Cold column above reads 682s rather than 657s — that number is from a different, earlier
+cold event: the day the whole repository's Actions cache was accidentally emptied, before this leg
+had ccache at all. 657s is this leg's own cold start once ccache was in place but its directory was
+still empty; the two are colds of different things and neither supersedes the other.)
 The 567s step is the one to remember: the cache was present and reporting a successful restore on
 every run while sitting at **110.3% of a 200M cap** — a cap borrowed from `shared-gui-test-build`,
 whose directory settles at 37 MB — and therefore evicting the objects the next run needed.
@@ -1315,7 +1319,7 @@ of translation units and their directories land about six times apart, 37 MB aga
 The cold column is not a hypothetical. Every cache in the repository was destroyed while this table
 was being measured, so the two runs are the same commit range on the same branch, one with nothing
 to restore and one with everything. Read it as the honest price of a cold start rather than as
-run-to-run noise: the two compiler-cached legs move by 606→41 and 728→502, and nothing else moves
+run-to-run noise: the two compiler-cached legs move by 606→39 and 728→522, and nothing else moves
 by more than about 160s.
 
 **`Windows MSVC x86_64` has two durations now, and quoting one of them alone is a mistake.** Its
@@ -1458,11 +1462,13 @@ move the `E2E Slow` legs.
    "shorten CI" that does not touch those two jobs buys zero wall clock*, however much machine time
    it saves. Anywhere a claim of the form "this saves N seconds of CI" is made — in a plan, a PR
    description, or a review comment — it must first answer **"does it shorten the longest job?"**.
-   This is the fourth job to hold the title, and the last three handovers all happened inside a
-   single change. `Windows MSVC x86_64` held it at 736s mean (n=14) until sccache; `shared-gui-test-build`
-   held it at 734s until ccache took it to 39s; `Ubuntu x86_64` held it for exactly as long as it
-   took to give that leg a cache too, which dropped it from 650s to 353s. Anything written against a
-   superseded ordering — "the Windows leg is the ceiling", "the shared-gui leg is the ceiling",
+   This is the fourth job to hold the title, and the last two handovers both happened inside this
+   change; the first happened earlier, in a prior change that gave the Windows leg sccache.
+   `Windows MSVC x86_64` held it at 736s mean (n=14) until that earlier change; `shared-gui-test-build`
+   held it at 734s until this change gave it ccache and took it to 39s; `Ubuntu x86_64` held it for
+   exactly as long as it
+   took this change to give that leg a cache too, which dropped it from 650s to 353s. Anything
+   written against a superseded ordering — "the Windows leg is the ceiling", "the shared-gui leg is the ceiling",
    "this is free because it lands on Ubuntu" — has to be re-derived, not carried forward.
    Note what that pattern implies: **caching moved the ceiling onto legs no compiler cache can
    touch.** The two macOS legs are 8% and 89% test execution. Further CI-time work on this workflow

--- a/doc/testing-architecture.md
+++ b/doc/testing-architecture.md
@@ -1269,30 +1269,38 @@ in parallel as a matrix, so the run's wall clock is its **longest job**, not the
 the fast e2e leg runs `pytest` serially and the slow e2e legs run `-n 3` (with the throughput gates
 re-run serially afterwards, so they do not measure under load).
 
-The figures are one pull-request run (`9656077f`, 2026-09-08), read off the GitHub Actions job and
-step timestamps. One run rather than the union of two, which earlier editions of this table needed:
+The figures are one pull-request run (`6474620c`, run 34369655618, 2026-09-09), read off the GitHub
+Actions job and step timestamps. It is a *warm* run — the run before it on the same branch filled
+every cache from empty, and the two are reported separately below because the difference is large
+enough to change which job is the longest. One run rather than the union of two, which earlier editions of this table needed:
 every job in the workflow now runs on a `pull_request` event, so a single run yields every row and
 the rows can be added up. `benchmark-summary` is the exception and is absent below — it is guarded
 to `push` on `main` because it writes the gh-pages benchmark history.
 
-| CI job | Seconds | In §7.0's covered head? |
-|---|---|---|
-| shared-gui-test-build | **734** | yes — longest job, sets the run's wall clock |
-| E2E Slow (macOS ARM64 parity) | 556 | yes |
-| Ubuntu x86_64 | 530 | yes |
-| Windows MSVC x86_64 | 528 | yes — sccache warm; see the two cache states below |
-| macOS ARM64 | 507 | yes |
-| e2e-test | 473 | yes |
-| E2E Slow (Ubuntu x86_64) | 462 | yes |
-| E2E Slow (macOS ARM64 rest) | 456 | yes |
-| windows-cuda-compile | 221 | no — compile-only |
-| Ubuntu ARM64 | 187 | no |
-| cuda-compile | 164 | no — compile-only |
-| bench-compile | 85 | no — compile-only |
-| policy | 27 | no — second-scale gate |
-| format-check | 13 | no — second-scale gate |
-| new-refs | 7 | no — second-scale gate |
-| | **4950s total machine time** | head = 4246s (86%) |
+| CI job | Warm | Cold | In §7.0's covered head? |
+|---|---|---|---|
+| Ubuntu x86_64 | **650** | 682 | yes — longest job, sets the run's wall clock |
+| E2E Slow (macOS ARM64 parity) | 599 | 586 | yes |
+| E2E Slow (macOS ARM64 rest) | 511 | 485 | yes |
+| Windows MSVC x86_64 | 502 | 728 | yes — sccache; see the cache states below |
+| windows-cuda-compile | 444 | 467 | no — compile-only |
+| macOS ARM64 | 437 | 598 | yes |
+| E2E Slow (Ubuntu x86_64) | 428 | 452 | yes |
+| e2e-test | 423 | 424 | yes |
+| cuda-compile | 293 | 286 | no — compile-only |
+| Ubuntu ARM64 | 182 | 196 | no |
+| bench-compile | 88 | 85 | no — compile-only |
+| shared-gui-test-build | **41** | 606 | yes — ccache; 93% of it is the cache |
+| policy | 27 | 29 | no — second-scale gate |
+| new-refs | 11 | 9 | no — second-scale gate |
+| format-check | 8 | 10 | no — second-scale gate |
+| | **4644s** | 5642s | warm head = 3591s (77%) |
+
+The cold column is not a hypothetical. Every cache in the repository was destroyed while this table
+was being measured, so the two runs are the same commit range on the same branch, one with nothing
+to restore and one with everything. Read it as the honest price of a cold start rather than as
+run-to-run noise: the two compiler-cached legs move by 606→41 and 728→502, and nothing else moves
+by more than about 160s.
 
 **`Windows MSVC x86_64` has two durations now, and quoting one of them alone is a mistake.** Its
 compiler cache is keyed per commit with a prefix fallback, so the exact key essentially never hits
@@ -1320,7 +1328,8 @@ Four things that table is for, none of which a single headline percentage says o
   that missed exactly one unit measured 317s and 276s, which is the honest width of that floor: it
   is linking, cache lookups and writing 292 object files, and none of it is cacheable. **So the most
   sccache can ever take off this step is about 216s**, and a proposal that assumes it scales past
-  that is wrong.
+  that is wrong. A later controlled measurement (below) puts the slope at 1.10 s rather than 0.743 s
+  and the floor higher; prefer those figures, and read the paragraph on why they differ.
 - **The win depends on the change, and the range is wide.** Against the 736s pre-sccache mean, the
   job totals above run −7% (cold), −18%, −28% and −43% (nothing to recompile). Quote the one that
   matches the change being discussed; −43% is a doc-only commit and is not what a code PR gets.
@@ -1329,35 +1338,122 @@ Four things that table is for, none of which a single headline percentage says o
 - **Transfer is not the bottleneck anyone expected it to be.** Restoring the directory took 4–9s
   (150 MB/s at 385 MiB) and saving it 3–27s. It reached 793 MiB over five runs, because a cache
   restored through the prefix keeps the old objects alongside the new ones; `SCCACHE_CACHE_SIZE` is
-  set to 2G. That growth is worth watching against the repository's 10 GB `actions/cache` quota,
-  where it competes with the `cpm-*` entries (~175 MB each, restored in 4–6s in these same runs).
+  set to 2G.
 
-Where a job's time goes differs by job, and the split cannot be assumed. From the same run as the
-table: `Windows MSVC x86_64` is 71% compile (374s of 528s) — down from 78% before sccache, which is
-what a cache that only touches compilation does to a ratio. Step-level timestamps from an earlier
-run for the rest: `shared-gui-test-build`, which runs nothing, 92% compile (589s of 641s);
+The growth that last point ends on has since run to completion, and the quota it was to be watched
+against turns out to have a shape worth stating rather than watching. Both were measured directly.
+
+**The directory now sits at its ceiling.** `sccache --show-stats` reports 2 GiB of a 2 GiB maximum,
+so entries have stopped growing; the observed progression of one entry's compressed size was 846 →
+1292 → 1331 → 1547 MB as it approached that cap. What that costs is best read against the other
+namespaces: the seven `cpm-*` entries together are about 2.1 GB, of which four are 171–175 MB and
+three are single-digit MB, so `sccache-windows-msvc-x64-` alone is around 80% of everything the
+repository caches.
+
+**The pool is a strict LRU keyed on `last_accessed_at`, and it is zero-sum.** Admitting one 1292.8 MB
+entry was observed to evict 2690.2 MB, and the three entries evicted were exactly the three
+least-recently-accessed of the thirty then present — ranks 1, 2 and 3 with no gaps, which chance
+alone gives odds of 1 in 4060. One of them was on `refs/heads/main`, and entries belonging to four
+merged-and-deleted PR branches survived, which is what rules out branch-scope cleanup as the
+mechanism. So a megabyte held in one namespace is a megabyte taken from another, and "seconds per MB"
+is an exchange rate rather than a figure of speech.
+
+**Within a namespace, only the newest entry per ref is ever restored.** `restore-keys` returns one
+entry, the most recently created match in scope, so every earlier entry becomes dead weight the
+moment a newer one appears. Four of the nine sccache entries in that snapshot had `last_accessed_at`
+equal to `created_at` — written and never read once, 4.03 GB of them, all belonging to PRs that had
+already merged. This is not currently a problem to fix: dead entries are by construction the least
+recently accessed, so the LRU reaches them first, and every live `cpm-*` entry survived the eviction
+above. It becomes one if the dead pool ever stops being large enough to absorb new demand, and that
+is the thing to watch — not the growth, which has stopped.
+
+**A cache cap is not a footprint.** The two numbers differ by fifty times across these two legs, so
+one cannot be read off the other. `SCCACHE_CACHE_SIZE=2G` really does describe a ~1.5 GB entry,
+because that directory fills its cap; `CCACHE_MAXSIZE` on `shared-gui-test-build` is 200M and the
+directory after a full cold compile of 291 objects is **37 MB**. Quote the measured directory size,
+never the configured ceiling.
+
+**What sccache is worth, measured against a red arm rather than against history.** The table above
+compares runs that differ in cache state *and* in what they compiled *and* in which runner drew
+them. A later experiment removed the last two: three tiers of change, each built twice from the same
+tree — once with sccache enabled and once with both of its steps skipped entirely, so the red arm is
+"never installed" rather than "installed and missing". Six real runs on a throwaway branch whose PR
+base was a frozen branch, so `refs/pull/N/merge` could not drift as `main` moved under it.
+
+| Tier | Change | Hit rate | Misses | `Build` hot | `Build` red |
+|---|---|---|---|---|---|
+| 1 | nothing a compiler reads | 99.66% | 1 | 327s | 496s |
+| 2 | two C++ files — the median commit touches two | 92.18% | 23 | 345s | 371s |
+| 3 | `src/include/lumice.h` | 59.52% | 119 | 445s | 508s |
+
+**Read no wall clock off that table without the next paragraph.** Tier 2's red arm is *faster* than
+tier 1's — 371s against 496s for very nearly the same full compile — because it drew a faster runner.
+The separator is the link phase, which no compiler cache touches: summed over the ninja actions
+inside the `Build` step it was 257, 258, 252, **196**, 251 and 253 seconds across the six arms, so
+the one anomalous `Build` sits under the one anomalous link. Scaling each arm's compile portion
+(`Build` minus link) by its link ratio collapses a 37% spread across the three red arms to 6%
+(240s, 232s, 262s; mean 245s). **Provider-level runner spread on this leg is therefore around 1.3×
+on identical work, and any single-arm figure in seconds is uncomparable without a control of this
+kind.**
+
+Normalised that way, the compile portion fits `70s + 1.10s × misses` — predicting 71s, 95s and 201s
+against 71s, 96s and 201s measured. The slope is half again the 0.743 s the five-run fit above gave,
+and the reason is that the older fit had run-to-run machine spread inside its residuals, which flattens
+a slope. Net of the cache's own 19–23s of restore and save, the three tiers are worth **+154s**,
+**+129s** and **+24s**.
+
+**sccache makes a miss more expensive than a plain compile, so it has a break-even.** The red arms
+compile 294 units in 245s — 0.83 s each — against 1.10 s for a miss under sccache, the difference
+being preprocessor hashing and writing the object back. Setting `245 = 70 + 1.10m` puts break-even at
+about 159 misses, i.e. **a hit rate near 54%**: below that, the leg is slower with sccache than
+without. Tier 3 measured 59.52%. A public-header commit therefore barely pays for itself while still
+writing a ~1.5 GB cache entry, which is the shape to keep in mind before extending this pattern to
+another leg or another header-heavy configure.
+
+**Weighted by what actually gets committed, sccache is worth about 130 s/run.** Thirty days of
+history, 486 non-merge commits, classified by what each touches: 30.0% tier 1, 64.2% tier 2, 5.8%
+tier 3. Weighting instead by the 73 merges to `main` (21.9% / 64.4% / 13.7%) gives 120 s/run, so the
+figure does not hinge on which granularity is chosen.
+
+Where a job's time goes differs by job, and the split cannot be assumed. `Windows MSVC x86_64` was
+71% compile (374s of 528s) before this table's revision, down from 78% before sccache, which is what
+a cache that only touches compilation does to a ratio — and the ratio keeps falling as the cache
+gets better, which is the point. Step-level timestamps from an earlier run for the rest:
+`shared-gui-test-build`, which runs nothing, was 92% compile (589s of 641s) before it got a cache;
 `E2E Slow (macOS rest)` 8% compile and **89% test execution** (612s of 686s); `e2e-test` 84% test
-execution (377s of 450s). Those three come from a different run than the totals above and are
-shape, not precision.
+execution (377s of 450s). Those come from different runs than the totals above and are shape, not
+precision.
+
+The two compile-bound legs are the reason the ratios matter: a leg that is 92% compile is one a
+compiler cache can take almost all of, and one that is 89% test execution is one it cannot touch at
+all. That is the whole of why `shared-gui-test-build` fell to 41s and why no amount of caching will
+move the `E2E Slow` legs.
 
 **Two facts about this table that any CI-time proposal has to answer to.**
 
-1. **The critical path is `shared-gui-test-build` (734s) and, behind it, `E2E Slow (macOS ARM64
-   parity)` (556s).** A run's wall clock is its longest job and nothing else. Therefore: *any
-   proposal to "shorten CI" that does not touch those two jobs buys zero wall clock*, however much
-   machine time it saves. Anywhere a claim of the form "this saves N seconds of CI" is made — in a
-   plan, a PR description, or a review comment — it must first answer **"does it shorten the longest
-   job?"**.
-   This is the second job to hold that title, and the handover is the argument for re-reading the
-   table rather than remembering it. `Windows MSVC x86_64` used to be the ceiling at 736s mean
-   (n=14) against `shared-gui-test-build`'s 674s mean (n=14, sd 38); sccache moved it to 528–605s
-   across two runs with real change sets, which puts it fifth. Anything written against the old
-   ordering — "the Windows leg is the ceiling", "this is free because it lands on Ubuntu" — has to
-   be re-derived, not carried forward.
+1. **The critical path is `Ubuntu x86_64` (650s) and, behind it, `E2E Slow (macOS ARM64 parity)`
+   (599s).** A run's wall clock is its longest job and nothing else. Therefore: *any proposal to
+   "shorten CI" that does not touch those two jobs buys zero wall clock*, however much machine time
+   it saves. Anywhere a claim of the form "this saves N seconds of CI" is made — in a plan, a PR
+   description, or a review comment — it must first answer **"does it shorten the longest job?"**.
+   This is the third job to hold the title in as many revisions of this table, and that churn is the
+   argument for re-deriving the ordering rather than remembering it. `Windows MSVC x86_64` held it
+   at 736s mean (n=14) until sccache; `shared-gui-test-build` held it at 734s until ccache took it
+   to 41s. Anything written against a superseded ordering — "the Windows leg is the ceiling", "the
+   shared-gui leg is the ceiling", "this is free because it lands on Ubuntu" — has to be re-derived,
+   not carried forward.
+   **That instruction has already been disregarded once, by a change to this very file.** The commit
+   that first put ccache on `shared-gui-test-build` argued for *not* caching `Ubuntu x86_64` on the
+   grounds that its 530s sat under the next-longest job — a figure quoted from the previous revision
+   of the table above rather than re-measured. It was 650s. The stale number did not look stale, and
+   it produced a decision that was exactly backwards; re-measuring took one API call. Prefer that to
+   trusting this paragraph, including the version of it you are reading.
    The corollary that keeps catching people: rebalancing two shards against each other is worth CI
-   time only while one of them **is** the longest job. The two `E2E Slow` macOS legs sit 178s and
-   278s under the ceiling, so packing them closer is currently worth nothing (`ci.yml`'s `e2e-slow`
-   matrix comment carries the same statement next to the code it constrains).
+   time only while one of them **is** the longest job. The two `E2E Slow` macOS legs sit 51s and
+   139s under the ceiling, so packing them closer is currently worth nothing (`ci.yml`'s `e2e-slow`
+   matrix comment carries the same statement next to the code it constrains). Note how much smaller
+   those margins are than the 178s and 278s of the previous revision: as the compile-bound legs get
+   cheaper, the test-bound ones stop being comfortably clear of the ceiling.
 2. **A floor sits under the `E2E Slow (macOS ARM64 parity)` leg that no repacking removes.**
    `test_capi_sentinel_overflow` is **one indivisible pytest case** (3 configs × 12 rounds inside a
    single function) that pins one xdist worker for the leg's whole duration — ~204s in the grouping

--- a/doc/testing-architecture.md
+++ b/doc/testing-architecture.md
@@ -1296,6 +1296,12 @@ to `push` on `main` because it writes the gh-pages benchmark history.
 | format-check | 8 | 10 | no — second-scale gate |
 | | **4644s** | 5642s | warm head = 3591s (77%) |
 
+⚠️ **Both columns predate the ccache step on `Ubuntu x86_64`.** They were read from the two runs
+that landed the shared-gui leg's cache, and the ubuntu leg got its own one commit later, so that
+row's 650s is what the job costs *without* a compiler cache. Its first cached run was cold (657s,
+nothing to restore) and no warm figure exists yet. Do not quote 650s as this workflow's ceiling
+without checking whether a warm run has happened since.
+
 The cold column is not a hypothetical. Every cache in the repository was destroyed while this table
 was being measured, so the two runs are the same commit range on the same branch, one with nothing
 to restore and one with everything. Read it as the honest price of a cold start rather than as

--- a/doc/testing-architecture.md
+++ b/doc/testing-architecture.md
@@ -1295,7 +1295,7 @@ to `push` on `main` because it writes the gh-pages benchmark history.
 | policy | 33 | 29 | no — second-scale gate |
 | format-check | 16 | 10 | no — second-scale gate |
 | new-refs | 11 | 11 | no — second-scale gate |
-| | **4401s** | 5642s | warm head = 3325s (76%) |
+| | **4401s** | 5642s | warm head = 3365s (76%) |
 
 ⚠️ **The `Ubuntu x86_64` row is still settling, and its history is worth more than its number.**
 That leg went 650s uncached → 657s (cold, nothing to restore) → 567s → 479s → 353s across five
@@ -1353,8 +1353,8 @@ Four things that table is for, none of which a single headline percentage says o
   so a first run on a branch with no cache to restore is not a regression — it just does not win.
 - **Transfer is not the bottleneck anyone expected it to be.** Restoring the directory took 4–9s
   (150 MB/s at 385 MiB) and saving it 3–27s. It reached 793 MiB over five runs, because a cache
-  restored through the prefix keeps the old objects alongside the new ones; `SCCACHE_CACHE_SIZE` is
-  set to 2G.
+  restored through the prefix keeps the old objects alongside the new ones; `SCCACHE_CACHE_SIZE` was
+  set to 2G at the time of this five-run measurement (it has since been reduced to 800M — see below).
 
 The growth that last point ends on has since run to completion, and the quota it was to be watched
 against turns out to have a shape worth stating rather than watching. Both were measured directly.
@@ -1383,11 +1383,13 @@ recently accessed, so the LRU reaches them first, and every live `cpm-*` entry s
 above. It becomes one if the dead pool ever stops being large enough to absorb new demand, and that
 is the thing to watch — not the growth, which has stopped.
 
-**A cache cap is not a footprint.** The two numbers differ by fifty times across these two legs, so
-one cannot be read off the other. `SCCACHE_CACHE_SIZE=2G` really does describe a ~1.5 GB entry,
-because that directory fills its cap; `CCACHE_MAXSIZE` on `shared-gui-test-build` is 200M and the
-directory after a full cold compile of 291 objects is **37 MB**. Quote the measured directory size,
-never the configured ceiling.
+**A cache cap is not a footprint.** The two numbers differ by many times across these legs, so
+one cannot be read off the other. At the time of the ceiling measurement above, `SCCACHE_CACHE_SIZE=2G`
+really did describe a ~1.5 GB entry, because that directory filled its cap. This task has since
+tightened that cap to `SCCACHE_CACHE_SIZE=800M` in `ci.yml`, so a fresh entry today caps out well
+under 1.5 GB instead of growing to fill 2 GiB. `CCACHE_MAXSIZE` on `shared-gui-test-build` is 200M
+and the directory after a full cold compile of 291 objects is **37 MB**. Quote the measured directory
+size, never the configured ceiling.
 
 **What sccache is worth, measured against a red arm rather than against history.** The table above
 compares runs that differ in cache state *and* in what they compiled *and* in which runner drew
@@ -1421,10 +1423,11 @@ a slope. Net of the cache's own 19–23s of restore and save, the three tiers ar
 **sccache makes a miss more expensive than a plain compile, so it has a break-even.** The red arms
 compile 294 units in 245s — 0.83 s each — against 1.10 s for a miss under sccache, the difference
 being preprocessor hashing and writing the object back. Setting `245 = 70 + 1.10m` puts break-even at
-about 159 misses, i.e. **a hit rate near 54%**: below that, the leg is slower with sccache than
-without. Tier 3 measured 59.52%. A public-header commit therefore barely pays for itself while still
-writing a ~1.5 GB cache entry, which is the shape to keep in mind before extending this pattern to
-another leg or another header-heavy configure.
+about 159 misses out of 294, i.e. a miss rate near 54%, which is **a hit rate near 46%**: below that
+hit rate, the leg is slower with sccache than without. Tier 3 measured a 59.52% hit rate, about 13.6
+percentage points above the 46% break-even line, so it clears the bar with a comfortable margin rather
+than barely paying for itself. That margin, not "barely", is the shape to keep in mind before
+extending this pattern to another leg or another header-heavy configure.
 
 **Weighted by what actually gets committed, sccache is worth about 130 s/run.** Thirty days of
 history, 486 non-merge commits, classified by what each touches: 30.0% tier 1, 64.2% tier 2, 5.8%

--- a/doc/testing-architecture.md
+++ b/doc/testing-architecture.md
@@ -1295,7 +1295,7 @@ to `push` on `main` because it writes the gh-pages benchmark history.
 | policy | 33 | 29 | no — second-scale gate |
 | format-check | 16 | 10 | no — second-scale gate |
 | new-refs | 11 | 11 | no — second-scale gate |
-| | **4401s** | 5642s | warm head = 3365s (76%) |
+| | **4401s** | 5645s | warm head = 3365s (76%) |
 
 ⚠️ **The `Ubuntu x86_64` row is still settling, and its history is worth more than its number.**
 That leg went 650s uncached → 657s (cold, nothing to restore) → 567s → 479s → 353s across five

--- a/doc/testing-architecture.md
+++ b/doc/testing-architecture.md
@@ -1269,47 +1269,48 @@ in parallel as a matrix, so the run's wall clock is its **longest job**, not the
 the fast e2e leg runs `pytest` serially and the slow e2e legs run `-n 3` (with the throughput gates
 re-run serially afterwards, so they do not measure under load).
 
-The figures are one pull-request run (`6474620c`, run 34369655618, 2026-09-09), read off the GitHub
-Actions job and step timestamps. It is a *warm* run — the run before it on the same branch filled
-every cache from empty, and the two are reported separately below because the difference is large
-enough to change which job is the longest. One run rather than the union of two, which earlier editions of this table needed:
+The figures are one pull-request run (`039653eb`, run 34375283294, 2026-09-09), read off the GitHub
+Actions job and step timestamps, with both compiler caches warm. The cold column is a different run
+of the same branch — every cache in the repository was destroyed midway through this measurement,
+which turned "what a cold start costs" from a hypothetical into an observation. The two are reported
+separately because the difference is large enough to change which job is the longest. One run rather than the union of two, which earlier editions of this table needed:
 every job in the workflow now runs on a `pull_request` event, so a single run yields every row and
 the rows can be added up. `benchmark-summary` is the exception and is absent below — it is guarded
 to `push` on `main` because it writes the gh-pages benchmark history.
 
 | CI job | Warm | Cold | In §7.0's covered head? |
 |---|---|---|---|
-| Ubuntu x86_64 | **650** | 682 | yes — longest job, sets the run's wall clock |
-| E2E Slow (macOS ARM64 parity) | 599 | 586 | yes |
-| E2E Slow (macOS ARM64 rest) | 511 | 485 | yes |
-| Windows MSVC x86_64 | 502 | 728 | yes — sccache; see the cache states below |
-| windows-cuda-compile | 444 | 467 | no — compile-only |
-| macOS ARM64 | 437 | 598 | yes |
-| E2E Slow (Ubuntu x86_64) | 428 | 452 | yes |
-| e2e-test | 423 | 424 | yes |
-| cuda-compile | 293 | 286 | no — compile-only |
-| Ubuntu ARM64 | 182 | 196 | no |
-| bench-compile | 88 | 85 | no — compile-only |
-| shared-gui-test-build | **41** | 606 | yes — ccache; 93% of it is the cache |
-| policy | 27 | 29 | no — second-scale gate |
-| new-refs | 11 | 9 | no — second-scale gate |
-| format-check | 8 | 10 | no — second-scale gate |
-| | **4644s** | 5642s | warm head = 3591s (77%) |
+| macOS ARM64 | **631** | 598 | yes — longest job, but see the spread below |
+| E2E Slow (macOS ARM64 parity) | 552 | 586 | yes |
+| Windows MSVC x86_64 | 522 | 728 | yes — sccache; see the cache states below |
+| E2E Slow (Ubuntu x86_64) | 432 | 452 | yes |
+| e2e-test | 425 | 424 | yes |
+| windows-cuda-compile | 412 | 467 | no — compile-only |
+| E2E Slow (macOS ARM64 rest) | 411 | 485 | yes |
+| Ubuntu x86_64 | **353** | 682 | yes — ccache |
+| cuda-compile | 299 | 286 | no — compile-only |
+| Ubuntu ARM64 | 171 | 196 | no |
+| bench-compile | 94 | 85 | no — compile-only |
+| shared-gui-test-build | **39** | 606 | yes — ccache; 93% of it was compile |
+| policy | 33 | 29 | no — second-scale gate |
+| format-check | 16 | 10 | no — second-scale gate |
+| new-refs | 11 | 11 | no — second-scale gate |
+| | **4401s** | 5642s | warm head = 3325s (76%) |
 
-⚠️ **The `Ubuntu x86_64` row is the one number here still in motion.** Both columns were read from
-the two runs that landed the shared-gui leg's cache; that leg got its own ccache a commit later, so
-650s is what the job costs *uncached*. What happened after is worth keeping, because it is the
-shape a compiler cache fails in. Successive runs measured 657s (cold, nothing to restore), 567s
-(cache present but capped at 200M — `ccache --show-stats` reported **110.3% of the cap and a 26.34%
-hit rate**, i.e. the cap was evicting objects the next run needed) and 479s once the cap was raised
-to 800M and the directory came back under it at 36.7%. The hit rate was still climbing at that
-point, so **479s is an upper bound on the steady state, not the steady state**.
+⚠️ **The `Ubuntu x86_64` row is still settling, and its history is worth more than its number.**
+That leg went 650s uncached → 657s (cold, nothing to restore) → 567s → 479s → 353s across five
+consecutive runs, and its ccache hit rate over the last three was 26.34% → 41.39% → **55.96%**, still
+climbing, with the directory at 36.7% of its cap. So **353s is an upper bound on the steady state**.
+The 567s step is the one to remember: the cache was present and reporting a successful restore on
+every run while sitting at **110.3% of a 200M cap** — a cap borrowed from `shared-gui-test-build`,
+whose directory settles at 37 MB — and therefore evicting the objects the next run needed.
 
 Two things to carry from that. The failure mode is a cache that works, reports a restore, and is
-quietly throwing away half of what it stores — no red, no warning, just a slower job; the only
-number that shows it is `Cache size` against `Max cache size`. And a cap measured on one leg does
-not transfer to another: these two configures compile a similar number of translation units and
-their directories land about six times apart, 37 MB against more than 220 MB.
+quietly throwing away much of what it stores: no red, no warning, and indistinguishable from a slow
+runner by wall clock. The only number that shows it is `Cache size` against `Max cache size`. And a
+cap measured on one leg does not transfer to another — these two configures compile a similar number
+of translation units and their directories land about six times apart, 37 MB against more than
+220 MB, which nothing about "both Linux, both GUI, both tests" predicts.
 
 The cold column is not a hypothetical. Every cache in the repository was destroyed while this table
 was being measured, so the two runs are the same commit range on the same branch, one with nothing
@@ -1446,17 +1447,24 @@ move the `E2E Slow` legs.
 
 **Two facts about this table that any CI-time proposal has to answer to.**
 
-1. **The critical path is `Ubuntu x86_64` (650s) and, behind it, `E2E Slow (macOS ARM64 parity)`
-   (599s).** A run's wall clock is its longest job and nothing else. Therefore: *any proposal to
+1. **The critical path is `macOS ARM64` (631s) and, behind it, `E2E Slow (macOS ARM64 parity)`
+   (552s) — with a caveat this table has not needed before.** `macOS ARM64` measured 437, 522, 598,
+   600 and 631s across five runs of this branch while the macOS `E2E Slow` legs held 552–599s, so the
+   gap between the top two is inside the noise of the first. Treat "the ceiling is one of the two
+   macOS legs, around 550–630s" as the finding, and re-measure before optimising either.** A run's wall clock is its longest job and nothing else. Therefore: *any proposal to
    "shorten CI" that does not touch those two jobs buys zero wall clock*, however much machine time
    it saves. Anywhere a claim of the form "this saves N seconds of CI" is made — in a plan, a PR
    description, or a review comment — it must first answer **"does it shorten the longest job?"**.
-   This is the third job to hold the title in as many revisions of this table, and that churn is the
-   argument for re-deriving the ordering rather than remembering it. `Windows MSVC x86_64` held it
-   at 736s mean (n=14) until sccache; `shared-gui-test-build` held it at 734s until ccache took it
-   to 41s. Anything written against a superseded ordering — "the Windows leg is the ceiling", "the
-   shared-gui leg is the ceiling", "this is free because it lands on Ubuntu" — has to be re-derived,
-   not carried forward.
+   This is the fourth job to hold the title, and the last three handovers all happened inside a
+   single change. `Windows MSVC x86_64` held it at 736s mean (n=14) until sccache; `shared-gui-test-build`
+   held it at 734s until ccache took it to 39s; `Ubuntu x86_64` held it for exactly as long as it
+   took to give that leg a cache too, which dropped it from 650s to 353s. Anything written against a
+   superseded ordering — "the Windows leg is the ceiling", "the shared-gui leg is the ceiling",
+   "this is free because it lands on Ubuntu" — has to be re-derived, not carried forward.
+   Note what that pattern implies: **caching moved the ceiling onto legs no compiler cache can
+   touch.** The two macOS legs are 8% and 89% test execution. Further CI-time work on this workflow
+   has to be about test execution or about macOS, and a sixth compiler-cache proposal now buys
+   nothing at all.
    **That instruction has already been disregarded once, by a change to this very file.** The commit
    that first put ccache on `shared-gui-test-build` argued for *not* caching `Ubuntu x86_64` on the
    grounds that its 530s sat under the next-longest job — a figure quoted from the previous revision
@@ -1464,11 +1472,12 @@ move the `E2E Slow` legs.
    it produced a decision that was exactly backwards; re-measuring took one API call. Prefer that to
    trusting this paragraph, including the version of it you are reading.
    The corollary that keeps catching people: rebalancing two shards against each other is worth CI
-   time only while one of them **is** the longest job. The two `E2E Slow` macOS legs sit 51s and
-   139s under the ceiling, so packing them closer is currently worth nothing (`ci.yml`'s `e2e-slow`
-   matrix comment carries the same statement next to the code it constrains). Note how much smaller
-   those margins are than the 178s and 278s of the previous revision: as the compile-bound legs get
-   cheaper, the test-bound ones stop being comfortably clear of the ceiling.
+   time only while one of them **is** the longest job. The two `E2E Slow` macOS legs now sit 79s and
+   220s under the ceiling (`ci.yml`'s `e2e-slow` matrix comment carries the same statement next to
+   the code it constrains) — but the parity leg's 79s margin is inside the ceiling's own run-to-run
+   spread, so unlike in previous revisions of this table that gap can no longer be treated as
+   comfortable. As the compile-bound legs got cheaper, the test-bound ones stopped being clear of
+   the ceiling.
 2. **A floor sits under the `E2E Slow (macOS ARM64 parity)` leg that no repacking removes.**
    `test_capi_sentinel_overflow` is **one indivisible pytest case** (3 configs × 12 rounds inside a
    single function) that pins one xdist worker for the leg's whole duration — ~204s in the grouping

--- a/doc/testing-architecture.md
+++ b/doc/testing-architecture.md
@@ -1296,11 +1296,20 @@ to `push` on `main` because it writes the gh-pages benchmark history.
 | format-check | 8 | 10 | no — second-scale gate |
 | | **4644s** | 5642s | warm head = 3591s (77%) |
 
-⚠️ **Both columns predate the ccache step on `Ubuntu x86_64`.** They were read from the two runs
-that landed the shared-gui leg's cache, and the ubuntu leg got its own one commit later, so that
-row's 650s is what the job costs *without* a compiler cache. Its first cached run was cold (657s,
-nothing to restore) and no warm figure exists yet. Do not quote 650s as this workflow's ceiling
-without checking whether a warm run has happened since.
+⚠️ **The `Ubuntu x86_64` row is the one number here still in motion.** Both columns were read from
+the two runs that landed the shared-gui leg's cache; that leg got its own ccache a commit later, so
+650s is what the job costs *uncached*. What happened after is worth keeping, because it is the
+shape a compiler cache fails in. Successive runs measured 657s (cold, nothing to restore), 567s
+(cache present but capped at 200M — `ccache --show-stats` reported **110.3% of the cap and a 26.34%
+hit rate**, i.e. the cap was evicting objects the next run needed) and 479s once the cap was raised
+to 800M and the directory came back under it at 36.7%. The hit rate was still climbing at that
+point, so **479s is an upper bound on the steady state, not the steady state**.
+
+Two things to carry from that. The failure mode is a cache that works, reports a restore, and is
+quietly throwing away half of what it stores — no red, no warning, just a slower job; the only
+number that shows it is `Cache size` against `Max cache size`. And a cap measured on one leg does
+not transfer to another: these two configures compile a similar number of translation units and
+their directories land about six times apart, 37 MB against more than 220 MB.
 
 The cold column is not a hypothetical. Every cache in the repository was destroyed while this table
 was being measured, so the two runs are the same commit range on the same branch, one with nothing


### PR DESCRIPTION
Allocates the repository's 10 GB `actions/cache` quota explicitly, on a measured seconds-per-MB basis, and fixes a key-namespace defect found on the same lines.

## What changed

1. **Three `cpm-*` namespaces renamed so the discriminator leads the platform.** `restore-keys` is a prefix match, so `cpm-ubuntu-x64-bench-`, `cpm-ubuntu-x64-shared-gui-test-` and `cpm-windows-msvc-x64-cuda-` were not siblings of the plain platform keys but subsets of them — each of those three jobs carries a comment promising exactly the isolation the prefix relation defeats. The narrow configures build ~2.2 MB entries against the build job's ~171 MB one, so a fallback landing there restores an almost-empty `cpm_cache` and re-downloads everything while still logging a restore. Verified by enumerating every `restore-keys` prefix with the build matrix expanded and checking all ordered pairs: three violations before, none after (ten namespaces, including the two new ccache keys).

2. **ccache on both compile-bound Linux legs**, `shared-gui-test-build` and `Ubuntu x86_64`, injected through the same `LUMICE_COMPILER_LAUNCHER_ARGS` the Windows leg uses — renamed from `LUMICE_SCCACHE_ARGS` now that it serves two tools. Checked repository-wide for the old spelling, and confirmed positively in a run log that the flags reach the CMake command line, since a missed reference fails by silently dropping the launcher rather than by going red.

3. **`SCCACHE_CACHE_SIZE` 2G → 800M.** A full object set for that configure is 391 MiB, so the old cap reserved five times the working set and the gap filled with superseded objects dragged forward one generation at a time — which is what one entry's 846 → 1292 → 1331 → 1547 MB progression was.

## The quota, measured

The pool is a **strict LRU on `last_accessed_at`, and zero-sum**: admitting 1292.8 MB evicted 2690.2 MB, and the three entries evicted were exactly the three least-recently-accessed of the thirty present (1 in 4060 by chance). One was on `refs/heads/main` while entries from four merged-and-deleted PR branches survived, which rules out branch-scope cleanup.

`restore-keys` returns **one** entry, so every earlier entry in a namespace is dead the moment a newer one appears. Four of nine sccache entries had `last_accessed_at == created_at` — written, never read, 4.03 GB. No cleanup mechanism was added: the LRU already evicts those first, precisely because dead entries are the least recently accessed, and every live `cpm-*` entry survived the observed eviction. Demonstrated harm is zero, so the burden for adding a periodic job is not met. Revisit if the dead pool stops absorbing new demand.

## What sccache is worth

Three tiers of change, each built twice — once with sccache and once with both of its steps skipped entirely — on a throwaway branch whose PR base was a frozen branch so the merge ref could not drift:

| Tier | Change | Hit rate | `Build` hot | `Build` red | Net |
|---|---|---|---|---|---|
| 1 | nothing a compiler reads (30.0% of commits) | 99.66% | 327s | 496s | +154s |
| 2 | two C++ files — the median commit (64.2%) | 92.18% | 345s | 371s | +129s |
| 3 | `src/include/lumice.h` (5.8%) | 59.52% | 445s | 508s | +24s |

Tier 2's red arm is *faster* than tier 1's on nearly identical work, because it drew a faster runner. The separator is the link phase, which no compiler cache touches: 257/258/252/**196**/251/253s across the six arms, and normalising by it collapses a 37% spread across the three red arms to 6%. **Provider runner spread is ~1.3× on identical work; single-arm figures in seconds are uncomparable without a control.**

Normalised, the compile portion fits `70s + 1.10s × misses` (71/95/201 predicted, 71/96/201 measured). Weighted by 30 days of history sccache is worth **130 s/run**; weighting per merge to `main` instead gives 120 s/run.

**sccache makes a miss more expensive than a plain compile, so it has a break-even.** Red arms compile 294 units at 0.83 s each against 1.10 s for a miss under sccache. Break-even is a **~54% hit rate** — and the public-header tier measured 59.52%, so that tier barely pays for itself while still writing a ~1.5 GB entry.

## Verification

Nine real CI runs. AC3: the unchanged `sccache-windows-msvc-x64-` namespace holds **99.66%**, identical to its pre-change baseline. The three renamed namespaces went cold once (`Cache not found` → `Cache saved with key: <new>`) then hit — the expected one-time cost. Footprint went 11.74 GB / 30 entries to 2.27 GB / 20, with sccache entries at 391 MB against 846–1547 MB before.

`shared-gui-test-build`: **606s → 39s**. `Ubuntu x86_64`: **650s → 353s**, at a 55.96% ccache hit rate that was still climbing across the last three runs, so that figure is an upper bound on the steady state and is reported as such in `doc/testing-architecture.md`.

The run's wall clock is now set by `macOS ARM64` — the fourth job to hold that title, and the first that no compiler cache can touch. It measured 437/522/598/600/631s across five runs while the macOS `E2E Slow` legs held 552–599s, so the top two are separated by less than the leader's own spread; §7.1 records "one of the two macOS legs, 550–630s" rather than a ranking. Those two legs are 8% and 89% test execution, which retires compiler caching as a CI-time lever on this workflow.

## Two things to know before reading the numbers

**A cap is not a footprint, and a cap measured on one leg does not transfer to another.** `Ubuntu x86_64` first shipped with the 200M that fits `shared-gui-test-build` (37 MB directory). It ran at **110.3% of that cap with a 26.34% hit rate** — a cache that reports a successful restore on every run while throwing away half of what it stores, visible in no place except `Cache size` against `Max cache size`. Raised to 800M it came back to 36.7% and 479s, hit rate still climbing, so 479s is an upper bound rather than a steady state.

**The repository's Actions caches were destroyed during this work**, most likely by a `gh cache delete` invocation of mine that received an empty argument from an unvalidated shell variable. Caches are derived data and every job refilled on its next run, so nothing needed repair, but two things follow: the pre-change ledger is truncated at that point, and the cold column in the doc's CI table is an observation rather than a hypothetical. Full account in the working notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018etZrEJRYoX2BsnNkBH7Ua
