### PR TITLE
ci: stop depending on a vendor apt source nothing here installs from

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,13 +179,29 @@ jobs:
       # leg does a single apt-get update. They are what turns "gui_test needs a display" from a
       # blocker into a dependency: llvmpipe advertises a core profile well past the 3.3 core
       # context test_gui_main.cpp asks for, and no scene in the CI set needs a real GPU.
+      # `apt-get update` fails as a whole — exit 100 — if any single configured source is
+      # broken, and the runner image preinstalls third-party sources this repository never
+      # installs anything from. On 2026-09-09 Google's Chrome repo served a `Packages.gz`
+      # whose hash disagreed with its own Release file ("Hash Sum mismatch"), and that alone
+      # turned every apt-using job on this workflow red for hours, on three separate reruns,
+      # with a diff that touched none of them. Dropping the list is subtraction: nothing here
+      # has ever installed a Google package, so the only thing that source contributed was a
+      # dependency on a third party's index being self-consistent.
+      #
+      # Scoped to the one vendor that has actually cost us a red, not to every list in the
+      # directory. `ubuntu.sources` (the distro archive, deb822 on noble) and anything a step
+      # installs for itself — the CUDA keyring below, for instance — must survive. If a second
+      # vendor repo ever breaks a run the same way, add it here by name; do not widen this to
+      # a glob, which would take the archive with it.
       - name: Install Linux GUI dependencies
         if: runner.os == 'Linux' && matrix.build_gui == 'ON'
-        run: >
-          sudo apt-get update && sudo apt-get install -y
-          libgl-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
-          libgtk-3-dev
-          xvfb libgl1-mesa-dri libglx-mesa0
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgl-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
+            libgtk-3-dev \
+            xvfb libgl1-mesa-dri libglx-mesa0
 
       - name: Cache CPM dependencies
         uses: actions/cache@v6
@@ -403,6 +419,7 @@ jobs:
           wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb \
             -O cuda-keyring.deb
           sudo dpkg -i cuda-keyring.deb
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
           sudo apt-get update -qq
           sudo apt-get install -y cuda-nvcc-12-6 cuda-cudart-dev-12-6
           echo "/usr/local/cuda/bin" >> $GITHUB_PATH
@@ -691,11 +708,16 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # Drop the unused vendor source first — see the comment on the build job's
+      # "Install Linux GUI dependencies" step for why one broken third-party index fails
+      # the whole `apt-get update`.
       - name: Install Linux GUI dependencies
-        run: >
-          sudo apt-get update && sudo apt-get install -y
-          libgl-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
-          libgtk-3-dev
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgl-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
+            libgtk-3-dev
 
       # Independent cache key: BUILD_SHARED_LIBS=ON is a distinct configure, so its
       # dependency set may differ from the plain ubuntu-x64 build job's. Sharing a key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,15 +188,28 @@ jobs:
       # has ever installed a Google package, so the only thing that source contributed was a
       # dependency on a third party's index being self-consistent.
       #
-      # Scoped to the one vendor that has actually cost us a red, not to every list in the
-      # directory. `ubuntu.sources` (the distro archive, deb822 on noble) and anything a step
-      # installs for itself — the CUDA keyring below, for instance — must survive. If a second
-      # vendor repo ever breaks a run the same way, add it here by name; do not widen this to
-      # a glob, which would take the archive with it.
+      # Selected by CONTENT, not by filename. The first attempt at this removed
+      # `google-chrome.list` by name and changed nothing — the `rm` ran, the source was still
+      # configured, and the job failed on the identical error. The image spells that source
+      # some other way (noble ships deb822 `.sources` files alongside `.list` ones), so a
+      # guessed filename is a gate that silently does nothing. Grepping for the host removes
+      # whatever file actually declares it.
+      #
+      # Scoped to the one vendor that has actually cost us a red, not to every file in the
+      # directory: `ubuntu.sources` (the distro archive itself, which lives there on noble)
+      # and anything a step installs for itself — the CUDA keyring below, for instance — must
+      # survive, and a glob would take them with it. If a second vendor repo ever breaks a run
+      # the same way, add its host to the pattern.
+      #
+      # The listing and the post-check are deliberate: this step is the only place that knows
+      # what the image actually ships, and without them a future recurrence starts again from
+      # a guess.
       - name: Install Linux GUI dependencies
         if: runner.os == 'Linux' && matrix.build_gui == 'ON'
         run: |
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          ls -la /etc/apt/sources.list.d/ || true
+          sudo grep -rl 'dl\.google\.com' /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -r rm -f
+          grep -rn 'dl\.google\.com' /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null || echo 'google source gone'
           sudo apt-get update
           sudo apt-get install -y \
             libgl-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
@@ -419,7 +432,9 @@ jobs:
           wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb \
             -O cuda-keyring.deb
           sudo dpkg -i cuda-keyring.deb
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          ls -la /etc/apt/sources.list.d/ || true
+          sudo grep -rl 'dl\.google\.com' /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -r rm -f
+          grep -rn 'dl\.google\.com' /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null || echo 'google source gone'
           sudo apt-get update -qq
           sudo apt-get install -y cuda-nvcc-12-6 cuda-cudart-dev-12-6
           echo "/usr/local/cuda/bin" >> $GITHUB_PATH
@@ -713,7 +728,9 @@ jobs:
       # the whole `apt-get update`.
       - name: Install Linux GUI dependencies
         run: |
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          ls -la /etc/apt/sources.list.d/ || true
+          sudo grep -rl 'dl\.google\.com' /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -r rm -f
+          grep -rn 'dl\.google\.com' /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null || echo 'google source gone'
           sudo apt-get update
           sudo apt-get install -y \
             libgl-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,9 @@ jobs:
       - name: Install Linux GUI dependencies
         if: runner.os == 'Linux' && matrix.build_gui == 'ON'
         run: |
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          ls -la /etc/apt/sources.list.d/ || true
+          sudo grep -rl 'dl\.google\.com' /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -r rm -f
+          grep -rn 'dl\.google\.com' /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null || echo 'google source gone'
           sudo apt-get update
           sudo apt-get install -y \
             libgl-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,12 +99,16 @@ jobs:
           $pythonDir = Split-Path (Get-Command python).Source
           echo "LUMICE_PYTHON_ARGS=-DPython_EXECUTABLE=$(Get-Command python | Select-Object -ExpandProperty Source)" >> $env:GITHUB_ENV
 
+      # Same as ci.yml: one broken third-party index fails the whole `apt-get update`, and
+      # nothing here installs a Google package. See ci.yml's build job for the incident.
       - name: Install Linux GUI dependencies
         if: runner.os == 'Linux' && matrix.build_gui == 'ON'
-        run: >
-          sudo apt-get update && sudo apt-get install -y
-          libgl-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
-          libgtk-3-dev
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgl-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev \
+            libgtk-3-dev
 
       # CUDA toolkit for the CUDA-enabled Windows artifact (nvcc + cudart).
       # Pinned to 12.6.3 to match ci.yml's windows-cuda-compile gate; supports


### PR DESCRIPTION
## 症状

今天 `shared-gui-test-build` / `Ubuntu x86_64` / `cuda-compile` 三个 job 在一条与它们无关的分支上全红，每次都停在 13–22 秒：

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz
   Hash Sum mismatch
E: Some index files failed to download.
##[error]Process completed with exit code 100
```

三次重跑（约一小时跨度）同样三个 job、同样这条错。不跑 apt 的 job（`E2E Slow`、`Ubuntu ARM64`、Windows/macOS 全部）一路绿——这个分布本身就说明红因不在被测代码里。

## 机制

`apt-get update` 只要**任何一个**已配置源坏掉就整体 exit 100，而 runner 镜像预装了本仓库从不安装任何包的第三方源。Google 那边发布的 Release 文件与实际服务的 `Packages.gz` 哈希对不上，于是每一条跑 apt 的腿都被它拖红。

## 修法

在 `apt-get update` 之前删掉这条用不到的源。这是**减法而不是绕行**：两个 workflow 里从来没有装过任何 Google 的包，那条源唯一贡献的东西就是"依赖第三方的索引保持自洽"这一条隐藏依赖。

四个调用点（`ci.yml` 三处 + `release.yml` 一处）。

**只删这一个厂商，不是目录下所有 list，也刻意不用 glob**：noble 上发行版自己的源就住在同一个目录里（`ubuntu.sources`），而 `cuda-compile` 在上一行刚给自己装了 CUDA 的 list。将来若第二个厂商源以同样方式弄红一次，按名字加进去——门槛是已证实的真实代价，不是想象中的风险。

## 红绿两态

红态已由 PR #333 上的三次重跑坐实（同三个 job、同一条错）。绿态就是本 PR 自己的 CI：改动只碰 workflow，那三个 job 转绿即为证据。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Dzk6oieAM7Px5CApP2JAp