### PR TITLE
fix(gui): regroup the Display Rendering rows and pair the ground swatch with the mode

### DIFF
--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -604,7 +604,7 @@ void CancelPendingConfigJsonExport() {
 }
 
 bool BgPhotoOnScreen(const GuiState& state) {
-  return g_preview.HasBackground() && state.bg_show;
+  return g_preview.HasBackground() && state.bg_show && !IsPrintTone(state.renderer);
 }
 
 // The background photo lives in two places that must agree: the GL texture the shader samples and

--- a/src/gui/app.hpp
+++ b/src/gui/app.hpp
@@ -90,22 +90,24 @@ extern ServerPoller g_server_poller;
 extern PreviewViewport g_preview_vp;
 extern BgColorPickState g_bg_pick;
 
-// "There is a background photo on screen to act on" — a photo is loaded AND it is being shown.
-// The single owner of that judgement, asked by two different features: the eyedropper (button
-// disabled state, the preview panel's pick branch, the mid-mode bail-out) and the photo's own
-// drag/wheel gestures. Sharing is deliberate — both ask the same question — but note what that
-// makes this function: NOT "the eyedropper is available", which is why it is not named that.
+// "There is a background photo on screen to act on" — a photo is loaded AND it is being shown AND
+// the mode is one that composites it (Screen; Print keeps the photograph out of the frame,
+// doc/print-mode-subtractive-ink.md §7 instance 1). The single owner of that judgement, asked by
+// three features: the frame itself (`PreviewParams::bg.enabled` is this predicate, not a second
+// copy of it), the eyedropper (button disabled state, the preview panel's pick branch, the
+// mid-mode bail-out) and the photo's own drag/wheel gestures. Sharing is deliberate — all ask the
+// same question — but note what that makes this function: NOT "the eyedropper is available", which
+// is why it is not named that.
 //
-// ⚠️ The distinction is load-bearing for the next condition anyone adds here. A subtractive/print
-// rendering mode, in which the halo is laid on paper rather than composited over a photograph,
-// would make the background overlay mutually exclusive with the eyedropper. It is tempting to put
-// that condition in this predicate — do not do it without deciding, explicitly, whether it should
-// also stop the user dragging and scaling the photo, because writing it here decides both at once
-// and silently. If it gates only the eyedropper, it belongs at the eyedropper's own call sites.
-// One thing is settled either way: the paper colour is emphatically NOT a second thing this picker
-// may sample, because the whole reason sampling works is that `background` and the photo meet in
-// the same lerp. No condition is written today because the mode does not exist in this tree yet,
-// and a gate on a field nobody has defined is a gate that will be wrong by the time it matters.
+// The Print term was added here, and not at the eyedropper's call sites only, on a decided answer
+// to the question this comment used to leave open: yes, it also stops the user dragging and
+// scaling the photo. Under Print the photo is not in the frame at all, so a drag would pan an
+// image nobody can see and a pick would sample one the preview is not showing — the very thing
+// the "photo alone while picking" override exists to rule out. Making the frame read the same
+// predicate is what keeps that true by construction: whatever takes the photo off screen also
+// takes the gestures and the pick with it, through the existing mid-mode bail-out. One thing is
+// settled either way: the paper colour is emphatically NOT a second thing this picker may sample,
+// because the whole reason sampling works is that `background` and the photo meet in the same lerp.
 bool BgPhotoOnScreen(const GuiState& state);
 // The construction-time properties the live g_server was actually built with (see app.cpp):
 // whether it is a GPU backend (Metal/CUDA) vs CPU, and how many CPU workers it holds. Together

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -1432,11 +1432,16 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
     if (ImGui::IsItemHovered()) {
       ImGui::SetTooltip("Re-runs simulation; accumulated rays reset");
     }
-    // Exposure mode. Display-time only: it changes which anchor the client-side conversion in
+    // The exposure anchor. Display-time only: it changes which anchor the client-side conversion in
     // mono_exposure_scale.hpp divides by, so the picture re-lights on the next frame with no
     // commit and no re-run. Not rust-tinted like Resolution above for exactly that reason —
     // nothing is discarded.
-    ImGui::Combo("Mode##display", &r.ev_mode, kEvModeNames, kEvModeCount);
+    //
+    // Labelled "EV Anchor" rather than "Mode": this section now carries two combos that both
+    // select a mode, and a bare "Mode" on either would leave the other's meaning to be inferred
+    // from position. This one names what it anchors and sits directly above the EV slider it
+    // qualifies, so the two rows read as one pair.
+    ImGui::Combo("EV Anchor##display", &r.ev_mode, kEvModeNames, kEvModeCount);
     if (ImGui::IsItemHovered()) {
       ImGui::SetTooltip(
           "Which anchor display brightness is measured against.\n\n"
@@ -1476,64 +1481,18 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
             g_state.ev_auto, r.exposure_offset + g_state.ev_auto);
       }
     }
-    // The sky behind the halo, next to EV rather than anywhere else in the panel. The two are the
-    // same KIND of field, and that is the whole argument: gui_state.hpp's RenderConfigResimFields
-    // carves exactly these two sub-fields out of the re-sim projection while keeping them in the
-    // Revert baseline, and the PreviewParams build below pushes them through the same display-time
-    // channel (ShouldPushCompositeExposure; the sky no longer needs a push of its own — the
-    // preview shader adds it to every texture mode, see PreviewRenderer::TextureMode).
-    // A control that changes what the finished rays look like belongs beside the other one.
-    //
-    // Not in the Overlays table: those five rows share one data model (a line, an optional text
-    // label, an alpha, sometimes a radius) and are drawn ON TOP of the image. The sky is the image.
-    // Not in the "Background" block below either — that one is the loaded reference PHOTOGRAPH and
-    // its transform; two different things under one word in one screen is how the word stops
-    // meaning anything.
-    //
-    // ColorEdit3 with NoInputs, the same swatch form the overlay rows and the defaults table use.
-    // Its label sits beside the swatch rather than in the panel's right-hand label column, which is
-    // what every fixed-size widget here does (Checkbox included) — ImGui hardcodes that gap at
-    // ItemInnerSpacing.x inside the widget where no caller can reach it.
-    ImGui::ColorEdit3("Sky Color##display_sky_color", r.background, ImGuiColorEditFlags_NoInputs);
-    if (ImGui::IsItemHovered()) {
-      ImGui::SetTooltip(
-          "Colour of the empty sky, added to the halo in linear RGB before the\n"
-          "gamma curve — so an empty pixel renders exactly the colour picked here.\n"
-          "Only where the lens images something: outside the image circle, and\n"
-          "outside the visible hemisphere, stays black.");
-    }
-
-    // Eyedropper: take the sky colour off the imported photograph instead of dialling it. The
-    // point is not convenience alone — the shader composites the photo as
-    // `photo*(1-alpha) + render*alpha`, so where `background` already equals the photo's own sky
-    // that lerp is the identity and the halo arrives as a pure addition rather than washing the
-    // photo out. Which is why the tooltip says to sample SKY: a pixel off the treeline sets the
-    // whole empty sky to dark green.
-    ImGui::SameLine();
-    const bool bg_pick_ok = BgPhotoOnScreen(g_state);
-    ImGui::BeginDisabled(!bg_pick_ok);
-    if (ImGui::Button(ICON_FA_EYE_DROPPER "##display_sky_pick")) {
-      g_bg_pick.active = !g_bg_pick.active;
-    }
-    ImGui::EndDisabled();
-    // AllowWhenDisabled: the disabled case is the one that most needs to say why.
-    if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
-      if (!g_preview.HasBackground()) {
-        ImGui::SetTooltip("No background photo loaded — use Load Bg under Background first.");
-      } else if (!g_state.bg_show) {
-        ImGui::SetTooltip("The background photo is hidden. Tick Show under Background to sample it.");
-      } else {
-        ImGui::SetTooltip(
-            "Pick the sky colour off the background photo.\n"
-            "The preview shows the photo alone while picking; click a patch of\n"
-            "SKY (the halo is composited over the sky, not the ground), or press\n"
-            "Esc to cancel.");
-      }
-    }
 
     // Permanent readout, not a tooltip: exposure_offset is saved per document, so in absolute
     // mode two open files can sit at different heights on one shared scale. A single-document GUI
     // cannot compare them for the user, but it can refuse to leave the current height implicit.
+    //
+    // Directly under the EV slider, because it reports the EV slider and nothing else — the two
+    // numbers it prints are this row's value and the auto anchor. It used to sit one row further
+    // down, below the sky swatch, on the reading that the swatch belonged to an exposure trio of
+    // Anchor / EV / Sky and this line was that trio's footer. The swatch has since been paired
+    // with the ground control it alternates with instead (see below), which leaves nothing between
+    // a reading and the row it is a reading of.
+    //
     // Rendered as a disabled Selectable rather than TextDisabled because an ImGui::Text* submits
     // with id == 0 and never enters the test engine's item registry — "the value is on screen"
     // would then not be assertable at all. "##" rather than "###" on purpose: the double form
@@ -1547,19 +1506,29 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
         false, ImGuiSelectableFlags_Disabled);
     ImGui::PopStyleColor();
 
-    // The print mode, at the END of the display block rather than directly under the sky colour it
-    // is the counterpart of: the EV readout above belongs to the exposure trio (Mode / EV / Sky
-    // Color) and reads as a footer to it, so inserting between them would split a group. Two controls
-    // rather than one because a black ground under the subtractive operator renders an all-black
-    // page, so the tone switch alone would have no ground worth laying ink on
-    // (doc/print-mode-subtractive-ink.md decision D5).
+    // The tone-reproduction operator, and directly under it the ONE ground control that operator
+    // reads. Two rows, not three: `background` and `paper` are separate fields on purpose
+    // (doc/print-mode-subtractive-ink.md decision D5 — a single field would make "print onto the
+    // default black background" render an all-black page), but at any instant exactly one of them
+    // is live. render.cpp's `if (!print_mode)` at the background term means Screen alone reads the
+    // sky; the paper is read only by the kPrint colour branch and by FillZeroEnergyImage. So the
+    // panel shows the one the current operator reads, and the row's identity changes with the
+    // combo above it.
     //
-    // The paper swatch is NOT greyed out under Screen, and that is a decision rather than an
-    // omission: both fields are authored state that survives a tone switch, so greying the one the
-    // live operator is not reading would hide a value the user is about to need. The mutual
-    // exclusions the operator does impose are the colour-carrying fields of
-    // doc/print-mode-subtractive-ink.md §7, which are greyed where they live.
-    ImGui::Combo("Tone##display_tone", &r.tone, kToneNames, kToneCount);
+    // This REVERSES an earlier decision recorded here, which was that the paper swatch should not
+    // even be greyed out under Screen because "greying the one the live operator is not reading
+    // would hide a value the user is about to need". Hiding is the stronger form of that same move
+    // and the reversal is deliberate (owner, 2026-09-10). What made the earlier reasoning give way:
+    // nothing is hidden except the control — both fields stay authored state, survive the switch,
+    // go into the .lmc and the Revert baseline, and keep their own rows in the Settings panel — so
+    // the value the user is "about to need" is intact and one combo click away, at the moment they
+    // need it and can see its effect. What the old arrangement cost was paid every frame instead:
+    // two swatches of which one did nothing, with no indication of which.
+    //
+    // Labelled "Mode" now that the exposure combo above is "EV Anchor". Screen/Print is the pair
+    // the user thinks in, and the two entries say what they do without the word "tone", which is
+    // opaque to anyone who has not met tone mapping.
+    ImGui::Combo("Mode##display_tone", &r.tone, kToneNames, kToneCount);
     if (ImGui::IsItemHovered()) {
       ImGui::SetTooltip(
           "Which operator turns the simulated light into pixels.\n\n"
@@ -1569,12 +1538,73 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
           "Print: light is laid down as INK on the paper below, so the picture darkens where the "
           "halo is — the way it would come off a printer.");
     }
-    ImGui::ColorEdit3("Paper##display_paper_color", r.paper, ImGuiColorEditFlags_NoInputs);
-    if (ImGui::IsItemHovered()) {
-      ImGui::SetTooltip(
-          "Colour of the paper the ink is laid on under Print tone.\n\n"
-          "Separate from Sky Color, and white rather than black by default: ink only\n"
-          "ever darkens what is beneath it, so black paper would render a black page.");
+
+    // ColorEdit3 with NoInputs, the same swatch form the overlay rows and the defaults table use.
+    // Its label sits beside the swatch rather than in the panel's right-hand label column, which is
+    // what every fixed-size widget here does (Checkbox included) — ImGui hardcodes that gap at
+    // ItemInnerSpacing.x inside the widget where no caller can reach it.
+    //
+    // The two arms keep their own ids and their own labels rather than sharing one: the ids are
+    // what tests and the defaults panel address, and a single id serving two fields would make
+    // "which field did the user just edit" a question about a mode variable.
+    //
+    // Neither swatch belongs in the Overlays table: those five rows share one data model (a line,
+    // an optional text label, an alpha, sometimes a radius) and are drawn ON TOP of the image. The
+    // ground is the image. Nor in the "Background" block below — that one is the loaded reference
+    // PHOTOGRAPH and its transform; two different things under one word in one screen is how the
+    // word stops meaning anything.
+    if (!IsPrintTone(r)) {
+      ImGui::ColorEdit3("Sky Color##display_sky_color", r.background, ImGuiColorEditFlags_NoInputs);
+      if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip(
+            "Colour of the empty sky, added to the halo in linear RGB before the\n"
+            "gamma curve — so an empty pixel renders exactly the colour picked here.\n"
+            "Only where the lens images something: outside the image circle, and\n"
+            "outside the visible hemisphere, stays black.");
+      }
+
+      // Eyedropper: take the sky colour off the imported photograph instead of dialling it. The
+      // point is not convenience alone — the shader composites the photo as
+      // `photo*(1-alpha) + render*alpha`, so where `background` already equals the photo's own sky
+      // that lerp is the identity and the halo arrives as a pure addition rather than washing the
+      // photo out. Which is why the tooltip says to sample SKY: a pixel off the treeline sets the
+      // whole empty sky to dark green.
+      //
+      // Inside the Screen arm, and not by mere association with the swatch it follows: the photo it
+      // samples from is itself disabled under Print (doc/print-mode-subtractive-ink.md §7 instance
+      // 1), so under Print this button could only ever render disabled.
+      ImGui::SameLine();
+      const bool bg_pick_ok = BgPhotoOnScreen(g_state);
+      ImGui::BeginDisabled(!bg_pick_ok);
+      if (ImGui::Button(ICON_FA_EYE_DROPPER "##display_sky_pick")) {
+        g_bg_pick.active = !g_bg_pick.active;
+      }
+      ImGui::EndDisabled();
+      // AllowWhenDisabled: the disabled case is the one that most needs to say why.
+      if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {
+        if (!g_preview.HasBackground()) {
+          ImGui::SetTooltip("No background photo loaded — use Load Bg under Background first.");
+        } else if (!g_state.bg_show) {
+          ImGui::SetTooltip("The background photo is hidden. Tick Show under Background to sample it.");
+        } else {
+          ImGui::SetTooltip(
+              "Pick the sky colour off the background photo.\n"
+              "The preview shows the photo alone while picking; click a patch of\n"
+              "SKY (the halo is composited over the sky, not the ground), or press\n"
+              "Esc to cancel.");
+        }
+      }
+    } else {
+      // "Paper Color", not "Paper": it alternates in place with "Sky Color" and the pair reads as
+      // one row wearing two faces only if both name a colour.
+      ImGui::ColorEdit3("Paper Color##display_paper_color", r.paper, ImGuiColorEditFlags_NoInputs);
+      if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip(
+            "Colour of the paper the ink is laid on under Print mode.\n\n"
+            "A separate field from Sky Color, and white rather than black by default: ink\n"
+            "only ever darkens what is beneath it, so black paper would render a black page.\n"
+            "Switch Mode back to Screen to get the sky colour back — it is kept, not reset.");
+      }
     }
 
     // doc/print-mode-subtractive-ink.md §8 (owner decision D6), GUI half. Each operator has one
@@ -1603,13 +1633,13 @@ void RenderRightPanel(GLFWwindow* window, float window_width, float window_heigh
         ImGui::SetTooltip("%s", print_tone ?
                                     "Ink only ever darkens the paper, and never reaches black. With the paper "
                                     "this dark\nevery feature lands within a few 8-bit levels of the page, so "
-                                    "the image reads as blank.\n\nLighten the paper, or switch Tone back to "
+                                    "the image reads as blank.\n\nLighten the paper, or switch Mode back to "
                                     "Screen." :
                                     "Light is ADDED to the sky colour and clamps at white, so with the sky this "
                                     "bright a halo\nhas almost nowhere left to go. Grid and overlay lines are "
                                     "blended rather than added, so\nthey stay perfectly visible — which is why "
                                     "this looks like a failed simulation rather than\na colour choice.\n\nDarken "
-                                    "the sky, or switch Tone to Print, which lays ink ON a pale ground instead.");
+                                    "the sky, or switch Mode to Print, which lays ink ON a pale ground instead.");
       }
       ImGui::SameLine();
       // The repair itself lives in gui_state.hpp (ApplyHeadroomFix) rather than here, so that what

--- a/src/gui/app_panels.cpp
+++ b/src/gui/app_panels.cpp
@@ -1939,12 +1939,14 @@ void RenderPreviewPanel(GLFWwindow* window, float window_width, float window_hei
     lumice::SrgbToLinearRgb(rc.paper, pp.paper_color_linear);
     pp.tone = rc.tone;
 
-    // The third term is doc/print-mode-subtractive-ink.md §7 instance 1, and it is what makes the
-    // exclusion real rather than advisory: `bg_show` is left exactly as the user set it, so
-    // switching Tone back to Screen brings the photograph straight back. See the matching
+    // The predicate's Print term is doc/print-mode-subtractive-ink.md §7 instance 1, and it is
+    // what makes the exclusion real rather than advisory: `bg_show` is left exactly as the user
+    // set it, so switching Mode back to Screen brings the photograph straight back. Read through
+    // BgPhotoOnScreen rather than spelled out again here, so the eyedropper and the photo gestures
+    // cannot disagree with the frame about whether the photo is in it. See the matching
     // WhenBackgroundLoaded gate in field_editor_registry.cpp for why additive-over-subtractive is
     // wrong in kind and not merely in taste.
-    pp.bg.enabled = g_state.bg_show && g_preview.HasBackground() && !IsPrintTone(rc);
+    pp.bg.enabled = BgPhotoOnScreen(g_state);
     pp.bg.alpha = g_state.bg_alpha;
     pp.bg.aspect = g_preview.GetBgAspect();
     pp.bg.pan_x = g_state.bg_offset_x;

--- a/src/gui/color_window.hpp
+++ b/src/gui/color_window.hpp
@@ -161,8 +161,8 @@ bool NoVisibleMatchedColorClass(const GuiState& state, const std::vector<int>& s
 // themselves are untouched and come back with Screen.
 inline constexpr const char* kColorsDisabledPrintModeTooltip =
     "Print mode lays one neutral ink, so there is no hue left to tell the color classes apart.\n"
-    "The colored composite is not produced while Tone is Print. Your color classes are kept --\n"
-    "switch Tone back to Screen to see them again.";
+    "The colored composite is not produced while Mode is Print. Your color classes are kept --\n"
+    "switch Mode back to Screen to see them again.";
 
 inline constexpr const char* kColorsDisabledNoMatchTooltip =
     "No visible color class currently matches any rays -- the composite would be empty.\n"

--- a/src/gui/field_editor_registry.cpp
+++ b/src/gui/field_editor_registry.cpp
@@ -312,7 +312,7 @@ Applicability WhenBackgroundLoaded(const GuiState& state) {
   if (IsPrintTone(state.renderer)) {
     return { false,
              "A background photo is additive — the halo is drawn on top of the sky in it. Print lays "
-             "subtractive ink on paper, which can only darken it. Disabled while Tone is Print." };
+             "subtractive ink on paper, which can only darken it. Disabled while Mode is Print." };
   }
   if (!g_preview.HasBackground()) {
     return { false, "No background image is loaded." };

--- a/test/gui/functional/test_background_main_ui_control.cpp
+++ b/test/gui/functional/test_background_main_ui_control.cpp
@@ -75,7 +75,7 @@ ImGuiID SkySwatchID(ImGuiTestContext* ctx) {
     return 0;
   }
   const ImGuiID edit_id = ImGui::GetIDWithSeed("Sky Color##display_sky_color", nullptr, ev.Window->ID);
-  return ImGui::GetIDWithSeed("##ColorButton", nullptr, edit_id);
+  return ColorEditSwatchId(edit_id);
 }
 
 // Open the picker and drag across its saturation/value square, corner to corner. Two corners rather

--- a/test/gui/functional/test_bg_color_picker_mode.cpp
+++ b/test/gui/functional/test_bg_color_picker_mode.cpp
@@ -153,6 +153,41 @@ void RegisterBgColorPickerModeTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // Print takes the photo out of the frame (doc/print-mode-subtractive-ink.md §7 instance 1), and
+  // the eyedropper's button leaves the panel with it — it lives in the Screen arm of the ground
+  // row. So an armed pick has to be dropped by the mode switch itself, the same way it is dropped
+  // by hiding the photo: otherwise the mode stays armed with no visible way out, the photo
+  // gestures stay locked, and the next click samples a photo the preview is not showing. The
+  // frame, the gestures and the pick read one predicate, so one switch has to move all three.
+  {
+    ImGuiTest* t =
+        IM_REGISTER_TEST(engine, "bg_color_picker", "print_mode_takes_the_photo_off_screen_and_drops_an_armed_pick");
+    t->GuiFunc = ProbeGuiFunc;
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      InstallProbeBackground(ctx);
+      IM_CHECK_EQ(gui::g_preview_vp.params.bg.enabled, true);
+
+      ctx->ItemClick(kPickButton);
+      ctx->Yield(2);
+      IM_CHECK_EQ(gui::g_bg_pick.active, true);
+
+      gui::g_state.renderer.tone = LUMICE_TONE_PRINT;
+      ctx->Yield(2);
+      IM_CHECK_EQ(gui::BgPhotoOnScreen(gui::g_state), false);
+      IM_CHECK_EQ(gui::g_preview_vp.params.bg.enabled, false);
+      IM_CHECK_EQ(gui::g_bg_pick.active, false);
+      IM_CHECK_EQ(ctx->ItemExists(kPickButton), false);
+
+      // `bg_show` was never touched, so Screen brings the photo — and the button — straight back.
+      IM_CHECK_EQ(gui::g_state.bg_show, true);
+      gui::g_state.renderer.tone = LUMICE_TONE_SCREEN;
+      ctx->Yield(2);
+      IM_CHECK_EQ(gui::BgPhotoOnScreen(gui::g_state), true);
+      IM_CHECK_EQ(gui::g_preview_vp.params.bg.enabled, true);
+      IM_CHECK_EQ(ctx->ItemExists(kPickButton), true);
+    };
+  }
+
   // AC2 — while picking, the frame published to the renderer is the photo alone; leaving restores.
   {
     ImGuiTest* t = IM_REGISTER_TEST(engine, "bg_color_picker", "pick_mode_publishes_the_photo_alone");

--- a/test/gui/functional/test_defaults_panel.cpp
+++ b/test/gui/functional/test_defaults_panel.cpp
@@ -1908,7 +1908,7 @@ void RegisterDefaultsPanelTests(ImGuiTestEngine* engine) {
       // comment for why this has to be computed rather than found by a label search.
       const ImGuiID group_id = SettingsCellID(ctx, "##value_overlay_grid_color");
       IM_CHECK(group_id != 0);
-      const ImGuiID swatch_id = ImGui::GetIDWithSeed("##ColorButton", nullptr, group_id);
+      const ImGuiID swatch_id = ColorEditSwatchId(group_id);
       ctx->ItemClick(swatch_id);
       ctx->Yield(2);
 

--- a/test/gui/functional/test_marker_panel.cpp
+++ b/test/gui/functional/test_marker_panel.cpp
@@ -284,7 +284,7 @@ ImGuiID MarkerSwatchId(const ImGuiTestItemInfo& row_item, const char* serial_nam
   const ImGuiID table_id = ImGui::GetIDWithSeed("##MarkersTable", nullptr, row_item.Window->ID);
   const ImGuiID swatch_group =
       ImGui::GetIDWithSeed((std::string("##marker_color_") + serial_name).c_str(), nullptr, table_id);
-  return ImGui::GetIDWithSeed("##ColorButton", nullptr, swatch_group);
+  return ColorEditSwatchId(swatch_group);
 }
 
 }  // namespace

--- a/test/gui/functional/test_overlay_controls.cpp
+++ b/test/gui/functional/test_overlay_controls.cpp
@@ -131,7 +131,7 @@ void RegisterOverlayControlTests(ImGuiTestEngine* engine) {
           const ImGuiID table_id = ImGui::GetIDWithSeed("##OverlaysTable", nullptr, line.Window->ID);
           const ImGuiID swatch_group =
               ImGui::GetIDWithSeed(("##" + std::string(row) + "_color").c_str(), nullptr, table_id);
-          color_id = ImGui::GetIDWithSeed("##ColorButton", nullptr, swatch_group);
+          color_id = ColorEditSwatchId(swatch_group);
         }
         const ImGuiTestItemInfo color = ctx->ItemInfo(color_id, ImGuiTestOpFlags_NoError);
         if (line.ID == 0 || color.ID == 0) {
@@ -184,7 +184,7 @@ void RegisterOverlayControlTests(ImGuiTestEngine* engine) {
           // Same three-seed reconstruction as above, against the SECOND table's id.
           const ImGuiID table_id = ImGui::GetIDWithSeed("##MarkersTable", nullptr, line.Window->ID);
           const ImGuiID swatch_group = ImGui::GetIDWithSeed(("##marker_color_" + row).c_str(), nullptr, table_id);
-          color_id = ImGui::GetIDWithSeed("##ColorButton", nullptr, swatch_group);
+          color_id = ColorEditSwatchId(swatch_group);
         }
         const ImGuiTestItemInfo color = ctx->ItemInfo(color_id, ImGuiTestOpFlags_NoError);
         if (line.ID == 0 || color.ID == 0) {

--- a/test/gui/functional/test_view_display_controls.cpp
+++ b/test/gui/functional/test_view_display_controls.cpp
@@ -44,7 +44,8 @@
 #include <string>
 #include <vector>
 
-#include "gui/app.hpp"  // g_state / g_server / g_preview_vp / DoRun — the exposure-mode case
+#include "IconsFontAwesome6.h"  // the sky eyedropper's label is an icon glyph, and its "##" id folds it in
+#include "gui/app.hpp"          // g_state / g_server / g_preview_vp / DoRun — the exposure-mode case
 #include "gui/defaults_diff.hpp"
 #include "gui/file_io.hpp"
 #include "gui/gui_state.hpp"
@@ -62,7 +63,7 @@ namespace {
 // therefore NOT assertable here — that is a property of ImGui's item registry, not an omission.
 constexpr const char* kClampWarning = "**/Screen too small for this aspect";
 
-// Open the Display group's exposure Mode combo and pick an entry.
+// Open the Display group's EV Anchor combo and pick an entry.
 //
 // Hand-rolled rather than ctx->ComboClick() for the same two reasons the colour window's picker
 // is: ImGui::BeginCombo() never calls IMGUI_TEST_ENGINE_ITEM_INFO(), so the combo has no debug
@@ -70,10 +71,68 @@ constexpr const char* kClampWarning = "**/Screen too small for this aspect";
 // opens is a separate window, which only SetRef("//$FOCUSED") can point at — ImHashDecoratedPath
 // does not understand the $FOCUSED variable inside a longer path.
 void PickExposureMode(ImGuiTestContext* ctx, const char* entry) {
-  ctx->ItemClick("//##RightPanel/Mode##display");
+  ctx->ItemClick("//##RightPanel/EV Anchor##display");
   ctx->SetRef("//$FOCUSED");
   ctx->ItemClick((std::string("**/") + entry).c_str());
   ctx->SetRef("");
+}
+
+// The same hand-rolled shape for the Display group's other combo, the tone. Not folded into one
+// helper taking the combo path: the two pick from different entry sets, and a shared helper would
+// only be a path parameter away from being the ItemClick pair it wraps.
+void PickTone(ImGuiTestContext* ctx, const char* entry) {
+  ctx->ItemClick("//##RightPanel/Mode##display_tone");
+  ctx->SetRef("//$FOCUSED");
+  ctx->ItemClick((std::string("**/") + entry).c_str());
+  ctx->SetRef("");
+}
+
+// The two faces of the ground swatch, and the eyedropper that belongs to one of them.
+constexpr const char* kSkySwatchLabel = "Sky Color##display_sky_color";
+constexpr const char* kPaperSwatchLabel = "Paper Color##display_paper_color";
+constexpr const char* kSkyPick = "**/" ICON_FA_EYE_DROPPER "##display_sky_pick";
+
+// A ground swatch's addressable item: the panel window's id (taken from a sibling item that is
+// always on screen, not derived), the label ColorEdit3 pushes for itself, and ImGui's own
+// "##ColorButton" under that — the last step via test_gui_shared.hpp's ColorEditSwatchId, which
+// says why a "//##RightPanel/<label>" lookup would find nothing.
+//
+// Returns the id unconditionally — GetIDWithSeed hashes whether or not anything was submitted — so
+// existence is a question for ItemInfo's ID, which is 0 when the frame did not draw it. That is the
+// whole point here: this suite needs to assert one swatch's ABSENCE, and an id that reported it
+// would be reporting the hash, not the frame.
+ImGuiID GroundSwatchId(ImGuiTestContext* ctx, const char* label) {
+  const ImGuiTestItemInfo ev = ctx->ItemInfo("//##RightPanel/##EV##display_input");
+  if (ev.Window == nullptr) {
+    return 0;
+  }
+  return ColorEditSwatchId(ImGui::GetIDWithSeed(label, nullptr, ev.Window->ID));
+}
+
+bool SwatchOnScreen(ImGuiTestContext* ctx, const char* label) {
+  const ImGuiID id = GroundSwatchId(ctx, label);
+  return id != 0 && ctx->ItemInfo(id, ImGuiTestOpFlags_NoError).ID != 0;
+}
+
+// Both ground fields, component by component, against the values the case installed. A helper
+// rather than a loop of IM_CHECK_EQ in the case body: a fatal check inside a `for` returns out
+// of the whole case on its first miss and silently skips every channel after it
+// (scripts/check_loop_fatal_asserts.py), whereas this reports the first miss with its field,
+// channel and both values and lets the caller's single IM_CHECK decide fatality.
+bool GroundValuesHeld(const float* sky, const float* paper, const char* stage) {
+  const float* fields[2] = { gui::g_state.renderer.background, gui::g_state.renderer.paper };
+  const float* wants[2] = { sky, paper };
+  const char* names[2] = { "renderer.background", "renderer.paper" };
+  for (int f = 0; f < 2; f++) {
+    for (int j = 0; j < 3; j++) {
+      if (fields[f][j] != wants[f][j]) {
+        IM_ERRORF("%s: %s[%d] is %.4f, expected %.4f — the hidden field did not survive the switch", stage, names[f], j,
+                  fields[f][j], wants[f][j]);
+        return false;
+      }
+    }
+  }
+  return true;
 }
 
 // Install a clamp signal without going through ApplyAspectRatio.
@@ -909,7 +968,12 @@ void RegisterViewDisplayControlTests(ImGuiTestEngine* engine) {
 
       std::vector<LabelColumnRow> display;
       display.push_back(MeasureComboRow(ctx, "Resolution", "Resolution##display"));
-      display.push_back(MeasureComboRow(ctx, "Mode", "Mode##display"));
+      display.push_back(MeasureComboRow(ctx, "EV Anchor", "EV Anchor##display"));
+      // The tone combo joins the measured rows here because this change renamed it: it has
+      // always sat inside the same PushLabelColumnItemWidth block and read CalcItemWidth like
+      // the three above, so it was always in the alignment family — it was simply never
+      // measured. Renaming a row whose alignment nothing asserts is how a label column drifts.
+      display.push_back(MeasureComboRow(ctx, "Mode", "Mode##display_tone"));
       display.push_back(MeasureWidgetRow(ctx, "EV", "##EV##display_input", "##EV##display_label"));
       display.push_back(MeasureComboRow(ctx, "Preset", "Preset##display_aspect"));
       display.push_back(MeasureWidgetRow(ctx, "Alpha", "##Alpha##display_input", "##Alpha##display_label"));
@@ -1043,6 +1107,65 @@ void RegisterViewDisplayControlTests(ImGuiTestEngine* engine) {
     };
   }
 
+  // The ground swatch: one row, two faces.
+  //
+  // Screen reads `background` and Print reads `paper` — render.cpp's `if (!print_mode)` at the
+  // background term and the kPrint colour branch are the two halves of that — so at any instant one
+  // of the two fields is not read at all. The panel shows the swatch for the live one only, and the
+  // row's identity changes with the Mode combo above it.
+  //
+  // This replaced an arrangement in which both swatches were always drawn. The claim that matters
+  // is the third: hiding a control is defensible only while the value behind it survives untouched.
+  // The first two are the visible behaviour and would be caught by the fullframe reference anyway;
+  // the third is the promise that made the change safe to make, and nothing else in the suite is
+  // looking at it.
+  {
+    ImGuiTest* t = IM_REGISTER_TEST(engine, "view_display_controls",
+                                    "the_ground_swatch_alternates_with_the_mode_and_keeps_both_values");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      // Both grounds carry a value no default holds, so "the value survived" cannot be satisfied by
+      // a field that was reset to what it already was. Both are well clear of the headroom
+      // predicate's two ends (a near-white sky, a near-black paper), because the notice row appears
+      // between the swatch and the rest of the panel and this case is not about it.
+      const float sky[3] = { 0.13f, 0.24f, 0.35f };
+      const float paper[3] = { 0.86f, 0.82f, 0.71f };
+      gui::g_state.renderer.tone = LUMICE_TONE_SCREEN;
+      for (int j = 0; j < 3; j++) {
+        gui::g_state.renderer.background[j] = sky[j];
+        gui::g_state.renderer.paper[j] = paper[j];
+      }
+      ctx->Yield(3);
+
+      // (1) Under Screen: the sky swatch and its eyedropper, and no paper swatch. The eyedropper is
+      //     part of the claim rather than a neighbour that happens to be there — it samples the
+      //     background photo, which Print disables outright, so it belongs to this arm and would
+      //     otherwise sit under Print as a button that can only ever render greyed.
+      IM_CHECK(SwatchOnScreen(ctx, kSkySwatchLabel));
+      IM_CHECK(ctx->ItemExists(kSkyPick));
+      IM_CHECK(!SwatchOnScreen(ctx, kPaperSwatchLabel));
+
+      // (2) One combo pick and the row changes face. Through the combo rather than by writing the
+      //     field, because what is under test is the panel reading the live tone every frame.
+      PickTone(ctx, "Print");
+      ctx->Yield(3);
+      IM_CHECK_EQ(gui::g_state.renderer.tone, LUMICE_TONE_PRINT);
+      IM_CHECK(SwatchOnScreen(ctx, kPaperSwatchLabel));
+      IM_CHECK(!SwatchOnScreen(ctx, kSkySwatchLabel));
+      IM_CHECK(!ctx->ItemExists(kSkyPick));
+
+      // (3) Neither value moved — not while its swatch was off screen, and not on the way back.
+      //     Asserted on both fields at both ends: a swap that clobbered the hidden field with the
+      //     visible one would satisfy any one-sided version of this.
+      IM_CHECK(GroundValuesHeld(sky, paper, "under Print"));
+      PickTone(ctx, "Screen");
+      ctx->Yield(3);
+      IM_CHECK_EQ(gui::g_state.renderer.tone, LUMICE_TONE_SCREEN);
+      IM_CHECK(SwatchOnScreen(ctx, kSkySwatchLabel));
+      IM_CHECK(!SwatchOnScreen(ctx, kPaperSwatchLabel));
+      IM_CHECK(GroundValuesHeld(sky, paper, "back under Screen"));
+    };
+  }
   // The permanent EV readout under the slider.
   //
   // It is the answer to a mismatch this GUI structurally cannot detect: exposure_offset is saved

--- a/test/gui/functional/test_view_display_controls.cpp
+++ b/test/gui/functional/test_view_display_controls.cpp
@@ -119,6 +119,11 @@ bool SwatchOnScreen(ImGuiTestContext* ctx, const char* label) {
 // of the whole case on its first miss and silently skips every channel after it
 // (scripts/check_loop_fatal_asserts.py), whereas this reports the first miss with its field,
 // channel and both values and lets the caller's single IM_CHECK decide fatality.
+//
+// Exact float comparison, on purpose and with a precondition: between the install and the check
+// the two fields are only ever shown by a ColorEdit3 or hidden, never passed through arithmetic,
+// so a single ulp of drift would itself be a defect. Do not reuse this on a path that converts
+// colour spaces or otherwise computes on the values — there the strict `!=` reads as a false red.
 bool GroundValuesHeld(const float* sky, const float* paper, const char* stage) {
   const float* fields[2] = { gui::g_state.renderer.background, gui::g_state.renderer.paper };
   const float* wants[2] = { sky, paper };

--- a/test/gui/references/_thresholds.json
+++ b/test/gui/references/_thresholds.json
@@ -1,7 +1,7 @@
 {
   "groups": {
     "capture_harness": {
-      "generated_at": "2026-09-10T00:29:48",
+      "generated_at": "2026-09-10T12:03:46",
       "n_ref_runs": 10,
       "n_calib_runs": 10,
       "scenes": {

--- a/test/gui/references/smoke_fullframe.png
+++ b/test/gui/references/smoke_fullframe.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b1d8a6ac2fea2ed0e69e4df3da179501230f291bdbef03f2f4dbc5211e0ee4e4
-size 105870
+oid sha256:0241b48666d9c8d885759ebed8950388fea877de7e94e6ad03e73d7fac1a7e03
+size 109784

--- a/test/gui/test_gui_shared.hpp
+++ b/test/gui/test_gui_shared.hpp
@@ -208,6 +208,19 @@ inline unsigned long long ExpectedSimRayNum(float ray_num_millions) {
 // (still "<tmp_prefix><key>.png", so the GROUPS table's meaning is unchanged).
 std::filesystem::path GuiTestTempPath(const std::string& filename);
 
+// The addressable item of a ColorEdit3/ColorEdit4 swatch, given the id the widget pushed for
+// itself. ColorEdit PushID()s its own label and submits ImGui's "##ColorButton" underneath, so
+// the label is a SEED rather than a path segment: a "//<window>/<label>" lookup finds nothing,
+// and the button has to be reached by reproducing that one hash step. Callers still own the seed
+// chain above it — a window id, a table's override id, a group id — because that part differs
+// per host; what is shared is only the "##ColorButton" layer, which is ImGui's and not ours.
+//
+// GetIDWithSeed hashes whether or not anything was submitted this frame, so a non-zero return
+// says nothing about presence. Existence is a question for ItemInfo(id, NoError).ID.
+inline ImGuiID ColorEditSwatchId(ImGuiID edit_id) {
+  return ImGui::GetIDWithSeed("##ColorButton", nullptr, edit_id);
+}
+
 // ========== Shared functions (defined in test_gui_main.cpp) ==========
 
 void ResetTestState();


### PR DESCRIPTION
右面板 `Display > Rendering` 一节在辅助线与 print/screen 两轮改动之后行序按落地时间排列、
标签左右横跳四次、Sky Color 与 Paper 两个严格互斥的字段同时常驻且都无提示。本 PR 在
**不动面板组织形态、不动标签左右形态**的前提下收拾这一节。

## 改了什么

1. **行序按语义重排**：`Resolution ‖ EV Anchor / EV / readout ‖ Mode / 地色行 / warning`。
   EV 的只读读数原先被 Sky Color 隔在 EV 两行之外，现在紧跟它所报告的那一行。
2. **地色控件合并为一行两面孔**：Screen 下是 `Sky Color`（+吸管），Print 下是 `Paper Color`。
   `render.cpp` 的 `if (!print_mode)` 让 Screen 只读 `background`、Print 只读 `paper`，
   所以任何时刻都有一个控件是死的。两个字段照旧各自存在、各自进 `.lmc` 与 Revert baseline、
   各自在 Settings 面板有自己的行——合并的是控件行，不是字段（`doc/print-mode-subtractive-ink.md` D5 不受影响）。
3. **三处文案改名**：`Tone` → `Mode`（Screen/Print 这对词自足）；`ev_mode` 的 `Mode` → `EV Anchor`
   （给上一条让位，且与 `anchor_l99_sky` 同词）；`Paper` → `Paper Color`（与 Sky Color 对称）。
   全仓 grep 补齐了 `color_window.hpp` / `field_editor_registry.cpp` 里另外两处 "switch Tone …"。
4. **顺带修一个 print mode 落地时遗留的缺陷**（code-review 揪出）：`BgPhotoOnScreen` 在 Print 下
   仍报告"照片在屏上"，于是拖拽/缩放手势对一张画面里根本没有的照片生效。`app.hpp` 里原有的注释
   预言过这个缺陷并要求"决定它是否也该停掉拖拽缩放"——本 PR 给出了决定（是），并让
   `PreviewParams::bg.enabled` 读同一个谓词，把三处各判一次收敛成单一权威。

## 验证

- `./scripts/test.sh pr` → `RESULT: PASS`（ctest 37s / fast-e2e 72s / gui-correctness 57s /
  gui-real-timing 12s / shared-lib 16s / slow-e2e 487s：88 passed，30 skipped）
- 四道门禁（`check_policies` / `check_new_refs` / `check_new_gui_tests` / `check_loop_fatal_asserts`）+ `format.sh --check` 全绿
- 新增 gui_test 用例 `the_ground_swatch_alternates_with_the_mode_and_keeps_both_values`，
  三条命题中最关键的一条是**切换模式来回一趟后两个字段逐分量不变**——隐藏一个控件只有在它背后的值
  原封不动时才站得住。该用例做过双重红态自证（先 commit 再手工回退实现，跑红后还原并重建绿态二进制复核）。
- `smoke_fullframe` 参考图已重拍（这一节少一行、三处改名）
- 两轮独立 code-review：round 1 `REQUEST_CHANGES`（Major 1，已修）→ round 2 `APPROVE`（0 Critical / 0 Major）

## 已知遗留（与本 PR 无关，供参考）

`defaults_panel_layout` 的 `presets_expanded` / `presets_warning` 两场景本次实测 53.45 dB 而非校准时的 `inf`。
已用 base 二进制（`7a4c5260` clean）做对照，同样读 53.45 dB ⇒ 是 base 上已有的漂移。因高于 40 dB
地板故仍全绿。整组重拍已单独立项。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Dzk6oieAM7Px5CApP2JAp