### PR TITLE
test: liblumice_testapi, a test-only export surface beside the product C API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,6 +302,19 @@ before downloading into it).
     `-g`/`-t` alone never produce it, see "Build trees..." above) and are excluded from CI's fast
     leg. Run them locally with `pytest -v -m slow` before opening a PR that touches the simulator
     core, query filter, or C API surface.
+    That build produces **two** shared libraries, and pytest loads the second one. `liblumice` is
+    the product export surface: `src/include/lumice.h`, `LUMICE_*` only, and nothing that exists
+    for a test's sake. `liblumice_testapi` (root `CMakeLists.txt`, target `lumice_testapi`; header
+    `test/support/lumice_test_api.h`) is built from the **same `lumice_obj` objects** — so every
+    product call behaves identically in it — and additionally exports the `LUMICE_TEST_*` hooks
+    a pytest fixture needs and `lumice.h` must never carry (today: the lens imaging-domain mask).
+    It is a superset stand-in, not a companion library: `-fvisibility=hidden` leaves a side library
+    nothing to link against, so the hooks ship with their own copy of the engine, and a test
+    process loads exactly one of the two. `test/e2e/capi_runner.py::lib_candidates` is the single
+    authority on which file that is; `scripts/check_policies.py`'s `no-test-symbol-in-src` rule
+    keeps the `LUMICE_TEST_` prefix out of `src/` so the two surfaces cannot grow back together.
+    Existing pytest calls to product symbols are deliberately **not** migrated to the test header:
+    their subject is the product C API contract itself, and wrapping them would test the wrapper.
     - `test/regression-sentinel/test_capi_sentinel_overflow.py` — sentinel-overflow regression: 3-config × 12 rounds = 36 server lifecycles via `LUMICE_AcquireResultFrame` + `LUMICE_FrameGetRawXyz(max_count=1)`; guards against reintroduction of the c_api.cpp off-by-one sentinel write (fix: 5287efe)
     - `test/regression-sentinel/test_ms_filter_leak.py` — Design A filter-fail termination regression: confirms filter-fail rays do not propagate across MS layers
   - **Test-scope table** — which command fits a given situation:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -781,6 +781,37 @@ if(BUILD_SHARED_LIBS)
   install(TARGETS lumice LIBRARY DESTINATION lib)
 endif()
 
+# Test-only export surface: the same lumice_obj objects liblumice is made of, plus the handful of
+# LUMICE_TEST_* hooks pytest needs and lumice.h must never carry (a test-only entry point in the
+# product ABI is the shape the owner rejected). It is a SUPERSET STAND-IN for liblumice, not a
+# companion: -fvisibility=hidden leaves nothing for a side library to link against, so the hooks
+# must ship with their own copy of the engine, and the ctypes harness loads this one library
+# instead of liblumice — two copies in one process would be two engines and two sets of statics.
+# Gated on BUILD_SHARED_LIBS alone (NOT BUILD_TEST) so CI's e2e-slow leg, configured with
+# -DBUILD_TEST=OFF -DBUILD_GUI=OFF -DBUILD_SHARED_LIBS=ON, still produces it; the static flavor
+# has no shared library at all, so the target simply does not exist there. The hooks' sources
+# live under test/, and scripts/check_policies.py's no-test-symbol-in-src rule keeps the
+# LUMICE_TEST_ prefix out of src/ so the two surfaces cannot grow back together.
+if(BUILD_SHARED_LIBS)
+  add_library(lumice_testapi SHARED
+    "${PROJ_TEST_DIR}/support/lumice_test_api.cpp")
+  # PRIVATE: nothing links against this target — it is only ever dlopen'ed by ctypes.
+  target_link_libraries(lumice_testapi PRIVATE lumice_obj)
+  if(NOT MSVC)
+    # Same export discipline as lumice_obj: only the #pragma GCC visibility block in
+    # lumice_test_api.h (and, through lumice_obj's own objects, lumice.h) is exported.
+    target_compile_options(lumice_testapi PRIVATE
+      $<$<CONFIG:Release>:-fvisibility=hidden>
+      $<$<CONFIG:MinSizeRel>:-fvisibility=hidden>)
+  endif()
+  if(WIN32)
+    # Mirrors the `lumice` target's Windows block above: the pragma is a GCC/Clang mechanism, so
+    # MSVC needs the auto-export escape hatch to produce a loadable DLL at all.
+    set_target_properties(lumice_testapi PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+  endif()
+  install(TARGETS lumice_testapi LIBRARY DESTINATION lib)
+endif()
+
 
 # ==================================================================================================
 # Add subdirectory

--- a/doc/developer-guide.md
+++ b/doc/developer-guide.md
@@ -110,7 +110,7 @@ Lumice uses a small number of environment variables for build scripts and test t
 |----------|-------|---------|
 | `LUMICE_SKIP_GUI_TESTS` | `scripts/build.sh` | Set to `1` to skip GUI test compilation and execution. CI auto-detects headless environments via the `CI` variable. |
 | `LUMICE_BIN` | `test/e2e/runner.py` | Override the CLI binary path for E2E subprocess tests. Defaults to `build/cmake_install/static/Lumice`. |
-| `LUMICE_LIB` | `test/e2e/capi_runner.py` | Override the shared library path for E2E C API tests. Defaults to the first existing shared-flavor candidate, starting with `build/Release/shared/lib/liblumice.dylib` (macOS) or `.so` (Linux). |
+| `LUMICE_LIB` | `test/e2e/capi_runner.py` | Override the shared library path for E2E C API tests. Defaults to the first existing shared-flavor candidate, starting with `build/Release/shared/lib/liblumice_testapi.dylib` (macOS) or `.so` (Linux) — the test-only superset of `liblumice` (same objects plus the `LUMICE_TEST_*` hooks of `test/support/lumice_test_api.h`), never `liblumice` itself. |
 
 **Design principle**: Deterministic simulation seeds are passed via the C API (`LUMICE_ServerConfig.sim_seed`) rather than environment variables, to keep program behavior explicit and reproducible. See the [C API documentation](c_api.md) for details.
 

--- a/doc/developer-guide_zh.md
+++ b/doc/developer-guide_zh.md
@@ -109,7 +109,7 @@ Lumice 仅在构建脚本和测试工具中使用少量环境变量。产品代�
 |------|------|------|
 | `LUMICE_SKIP_GUI_TESTS` | `scripts/build.sh` | 设为 `1` 可跳过 GUI 测试的编译和执行。CI 通过 `CI` 变量自动检测无头环境。 |
 | `LUMICE_BIN` | `test/e2e/runner.py` | 覆盖 E2E 子进程测试使用的 CLI 可执行文件路径。默认为 `build/cmake_install/static/Lumice`。 |
-| `LUMICE_LIB` | `test/e2e/capi_runner.py` | 覆盖 E2E C API 测试使用的共享库路径。默认为第一个存在的 shared flavor 候选，首选 `build/Release/shared/lib/liblumice.dylib`（macOS）或 `.so`（Linux）。 |
+| `LUMICE_LIB` | `test/e2e/capi_runner.py` | 覆盖 E2E C API 测试使用的共享库路径。默认为第一个存在的 shared flavor 候选，首选 `build/Release/shared/lib/liblumice_testapi.dylib`（macOS）或 `.so`（Linux）——即 `liblumice` 的测试专用超集（同一份对象文件，外加 `test/support/lumice_test_api.h` 的 `LUMICE_TEST_*` 钩子），而不是 `liblumice` 本身。 |
 
 **设计原则**：确定性模拟种子通过 C API（`LUMICE_ServerConfig.sim_seed`）传递，而非环境变量，以确保程序行为显式且可复现。详见 [C 接口文档](c_api_zh.md)。
 

--- a/doc/gpu-remote-cuda-build-testing.md
+++ b/doc/gpu-remote-cuda-build-testing.md
@@ -72,7 +72,9 @@
   ```bash
   source $ENVSH
   export LUMICE_HAS_CUDA=1 LUMICE_CUDA_ENABLED=1
-  export LUMICE_LIB=$REPO/build/Release/shared/lib/liblumice.so
+  # liblumice_testapi, not liblumice: the ctypes harness loads the test-only superset
+  # (same objects + LUMICE_TEST_* hooks; see test/e2e/capi_runner.py).
+  export LUMICE_LIB=$REPO/build/Release/shared/lib/liblumice_testapi.so
   export LD_LIBRARY_PATH=$REPO/build/Release/shared/lib:$LD_LIBRARY_PATH
   python -m pytest -v -m slow \
     test/parity-cross-backend/backend/test_cuda_{exit_seam,filter,multi_ms}_parity.py

--- a/doc/testing-architecture.md
+++ b/doc/testing-architecture.md
@@ -1520,9 +1520,17 @@ right. The increment costs 11s — about 6% on top of
 `pyproject.toml`'s `addopts = ["-m", "not slow"]` — the cross-backend parity batteries, the
 throughput gates, and the issue-repro sentinels (§6's "do not touch" list) are all in there. *(b)*
 More importantly, `pr` is the **only** local scope in which the library is loaded as a library:
-those tests drive `liblumice` through `ctypes` (`test/e2e/capi_runner.py`), so the export surface,
+those tests drive the library through `ctypes` (`test/e2e/capi_runner.py`), so the export surface,
 the dynamic-symbol resolution, the rpath and the C API's cross-boundary object lifetimes are
-exercised here and nowhere else. `quick` and `full` link the same sources into a test binary, which
+exercised here and nowhere else. The file loaded is `liblumice_testapi`, not `liblumice`: the shared
+build produces both, from the same `lumice_obj` objects, and the test library is the product one
+plus the `LUMICE_TEST_*` hooks of `test/support/lumice_test_api.h` — test-only entry points (the
+lens imaging-domain mask, today) that `lumice.h` carries no product reason to export. Because
+`-fvisibility=hidden` gives a side library nothing to link to, the hooks ship with their own copy
+of the engine, and a test process loads exactly one of the two; every product `LUMICE_*` call
+behaves identically in either, which is what makes the stand-in honest. `lib_candidates()` is the
+one authority on which file that is, and `scripts/check_policies.py`'s `no-test-symbol-in-src`
+rule keeps the prefix out of `src/`. `quick` and `full` link the same sources into a test binary, which
 cannot see a defect in how the code is *packaged*. The scope carries a freshness layer for exactly
 this reason: a stale `.dylib` silently tests old code and reports green, so `pr` refuses to trust a
 library it cannot prove is newer than its sources.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -107,8 +107,8 @@ help() {
   echo "               (keep dependency cache). -k cleans static, -ks cleans shared."
   echo "               NOTE: this removes build/cmake_build/<flavor> and"
   echo "               build/cmake_install/<flavor>, but NOT the compiler output tree"
-  echo "               build/<BUILD_TYPE>/<flavor>/. A liblumice there survives -k, and"
-  echo "               it is the first thing the e2e C API loader looks for — so after"
+  echo "               build/<BUILD_TYPE>/<flavor>/. A liblumice_testapi there survives -k,"
+  echo "               and it is the first thing the e2e C API loader looks for — so after"
   echo "               -k it can still load a pre-clean library. Use -x to wipe build/."
   echo "  -x:          Wipe build/ entirely — both flavors, plus the compiler output"
   echo "               tree that -k leaves behind. It does NOT clear the CPM"
@@ -116,7 +116,11 @@ help() {
   echo "               directory outside build/ (\$HOME/.cache/lumice-cpm) shared with"
   echo "               every other clone and worktree; delete that directory by hand if"
   echo "               you really want the sources re-downloaded."
-  echo "  -s:          Build shared library (default: static)."
+  echo "  -s:          Build shared library (default: static). Produces TWO"
+  echo "               libraries: liblumice (the product C API, lumice.h) and"
+  echo "               liblumice_testapi (the same objects plus the LUMICE_TEST_*"
+  echo "               hooks of test/support/lumice_test_api.h). The pytest ctypes"
+  echo "               harness loads the latter; see test/e2e/capi_runner.py."
   echo "  -h:          Show this message."
 }
 

--- a/scripts/check_policies.py
+++ b/scripts/check_policies.py
@@ -131,6 +131,13 @@ Checks:
      test because putting the defect back was *measured* to move CPU wall time
      by 1.01x and Metal by 0.88x — no wall-clock oracle in this repo can see it,
      while "did the pass acquire a frame at all" is answerable without a run.
+  17. no-test-symbol-in-src — the LUMICE_TEST_ prefix must not appear in any
+     source under src/, src/include/lumice.h included. It names the test-only
+     export surface (test/support/lumice_test_api.h, built into the
+     liblumice_testapi shared library for the pytest ctypes harness), which is
+     kept apart from the product C API on purpose: a test-only entry point in
+     the product ABI is the shape the owner rejected. Comments are blanked
+     first, so prose that names the prefix to explain this rule is not a hit.
 
 Add a new check as a function returning a list of Violation and append it to
 CHECKS, and add a numbered entry above. Keep each check deterministic and
@@ -1834,6 +1841,49 @@ def check_no_render_in_benchmark_poll() -> list[Violation]:
     return out
 
 
+# --- no-test-symbol-in-src ----------------------------------------------------
+#
+# The test-only export surface is spelled LUMICE_TEST_* and lives under test/
+# (test/support/lumice_test_api.h). Its whole reason to exist is that the product
+# ABI (src/include/lumice.h, liblumice) carries no test-only entry point; the
+# prefix showing up anywhere under src/ means a hook is migrating into the
+# product surface, which is exactly the merge this split was made to prevent.
+# A bare prefix match rather than a symbol pattern: a declaration, a call, a
+# forward reference and a macro all count, and a test-only name has no
+# legitimate spelling under src/ at all.
+TEST_SYMBOL_PREFIX = re.compile(r"\bLUMICE_TEST_")
+
+
+def check_no_test_symbol_in_src() -> list[Violation]:
+    """No LUMICE_TEST_ identifier under src/ — the test surface stays in test/.
+
+    Reads code_lines(), so a comment naming the prefix (this file's own rule
+    text, or a note in lumice.h pointing at the test header) is not a hit; a
+    string literal containing it would be, which fails toward a false positive
+    someone investigates rather than toward green.
+
+    Known limitation, stated rather than papered over: a hook that reaches src/
+    under a different prefix is invisible here. The rule pins the one spelling
+    the test surface is committed to, not "anything test-shaped".
+    """
+    out: list[Violation] = []
+    for path in cxx_sources(SRC):
+        for lineno, _orig, code in code_lines(path):
+            if TEST_SYMBOL_PREFIX.search(code):
+                out.append(
+                    Violation(
+                        path,
+                        lineno,
+                        "no-test-symbol-in-src",
+                        "LUMICE_TEST_* is the test-only export surface "
+                        "(test/support/lumice_test_api.h, liblumice_testapi) and must not "
+                        "appear under src/. A hook a test needs goes in that header; the "
+                        "product C API carries no test-only entry point.",
+                    )
+                )
+    return out
+
+
 CHECKS = [
     check_getenv_centralization,
     check_env_knob_registration,
@@ -1851,6 +1901,7 @@ CHECKS = [
     check_user_defaults_single_write_path,
     check_pytest_invocation_marker,
     check_no_render_in_benchmark_poll,
+    check_no_test_symbol_in_src,
 ]
 
 
@@ -1876,7 +1927,7 @@ def main() -> int:
         "gui-state-field-tier-registration, no-msvc-unsafe-builtin, "
         "no-default-constructed-crystal-slots, gui-test-suite-args-sync, no-bare-print, "
         "msvc-string-literal-limit, user-defaults-single-write-path, "
-        "pytest-invocation-marker, no-render-in-benchmark-poll)."
+        "pytest-invocation-marker, no-render-in-benchmark-poll, no-test-symbol-in-src)."
     )
     return 0
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -28,7 +28,8 @@
 # This script runs tests; it does not build the static flavor. `quick`/`full`
 # expect `./scripts/build.sh -tgj <type>` to have been run already, and say so
 # when it has not. `pr` is the one scope that may build, and only the shared
-# flavor, because the slow e2e layer loads liblumice through ctypes.
+# flavor, because the slow e2e layer loads liblumice_testapi (the test-only
+# superset of liblumice, see test/e2e/capi_runner.py) through ctypes.
 
 set -u
 set -o pipefail
@@ -53,7 +54,7 @@ usage() {
   echo ""
   echo "ENVIRONMENT:"
   echo "  LUMICE_SKIP_GUI_TESTS / CI:  skip the gui_test layers (as build.sh does)."
-  echo "  LUMICE_LIB:                  absolute path to liblumice; when set, the"
+  echo "  LUMICE_LIB:                  absolute path to liblumice_testapi; when set, the"
   echo "                               pr scope trusts it and never rebuilds."
   echo ""
   echo "Builds the static flavor? No — run ./scripts/build.sh -tgj <type> first."
@@ -317,7 +318,7 @@ for p in lib_candidates(Path("."), sys.argv[1]):
   # point of reading it from the loader), but it does catch a refactor that
   # leaves the function importable while returning something that is no longer
   # a list of library paths.
-  bad=$(printf '%s\n' "${out}" | grep -vE 'liblumice\.(dylib|so)$')
+  bad=$(printf '%s\n' "${out}" | grep -vE 'liblumice_testapi\.(dylib|so)$')
   [[ -z ${bad} ]] || die "shared-lib candidates: capi_runner.py::lib_candidates returned a non-library path:
 ${bad}"
   printf '%s' "${out}"
@@ -410,7 +411,7 @@ ensure_shared_lib() {
     if find_shared_lib > /dev/null; then
       : > "${SHARED_STAMP}" || printf 'test.sh: warning: could not write %s\n' "${SHARED_STAMP}" >&2
     else
-      annotate_last_layer "build succeeded but no liblumice found in any candidate path"
+      annotate_last_layer "build succeeded but no liblumice_testapi found in any candidate path"
       rc=1
       LAYER_STATUS[$(( ${#LAYER_STATUS[@]} - 1 ))]=FAIL
     fi

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -3677,6 +3677,28 @@ bool ReadMarkerIdList(const int* data, int count, std::vector<lumice::annotation
 }  // namespace
 
 
+// Single owner of the LUMICE_AnnotationView -> lumice::annotation::ViewSnapshot field mapping
+// (a56). Declared in c_api_internal.hpp so test/support/lumice_test_api.cpp's
+// LUMICE_TEST_ComputeRenderDomainMask can call it too instead of carrying a second hand-copied
+// translation.
+lumice::annotation::ViewSnapshot ToAnnotationViewSnapshot(const LUMICE_AnnotationView& v) {
+  ns::annotation::ViewSnapshot view;
+  view.width = v.width;
+  view.height = v.height;
+  view.lens_type = static_cast<ns::LensParam::LensType>(v.lens_type);
+  view.fov_deg = v.lens_fov;
+  view.lens_shift[0] = v.lens_shift[0];
+  view.lens_shift[1] = v.lens_shift[1];
+  view.overlap = v.overlap;
+  view.az_deg = v.view_azimuth;
+  view.el_deg = v.view_elevation;
+  view.roll_deg = v.view_roll;
+  view.visible = static_cast<ns::RenderConfig::VisibleRange>(v.visible);
+  view.front = v.front != 0;
+  return view;
+}
+
+
 LUMICE_ErrorCode LUMICE_ComputeAnnotationOverlay(const LUMICE_AnnotationRequest* request,
                                                  LUMICE_AnnotationOverlay* out) {
   if (!request || !out) {
@@ -3691,18 +3713,7 @@ LUMICE_ErrorCode LUMICE_ComputeAnnotationOverlay(const LUMICE_AnnotationRequest*
   }
 
   lumice::annotation::Request req;
-  req.view.width = v.width;
-  req.view.height = v.height;
-  req.view.lens_type = static_cast<ns::LensParam::LensType>(v.lens_type);
-  req.view.fov_deg = v.lens_fov;
-  req.view.lens_shift[0] = v.lens_shift[0];
-  req.view.lens_shift[1] = v.lens_shift[1];
-  req.view.overlap = v.overlap;
-  req.view.az_deg = v.view_azimuth;
-  req.view.el_deg = v.view_elevation;
-  req.view.roll_deg = v.view_roll;
-  req.view.visible = static_cast<ns::RenderConfig::VisibleRange>(v.visible);
-  req.view.front = v.front != 0;
+  req.view = ToAnnotationViewSnapshot(v);
   req.horizon = request->horizon != 0;
   req.zenith_nadir = request->zenith_nadir != 0;
   req.labels = request->want_labels != 0;

--- a/src/server/c_api_internal.hpp
+++ b/src/server/c_api_internal.hpp
@@ -7,6 +7,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "core/annotation_overlay.hpp"
 #include "include/lumice.h"
 
 // Test-only exposure of a LUMICE_Scene handle's internal JSON representation. NOT part of the
@@ -155,5 +156,12 @@ nlohmann::json ConfigToJson(const ConfigScratch& c);
 // out of "id"/"axis" on purpose — those are meaningless for a stateless mesh preview;
 // a dedicated test asserts they are absent so the boundary cannot silently drift.
 nlohmann::json CrystalShapeToJson(const LUMICE_CrystalParam& cr);
+
+// Translate the public LUMICE_AnnotationView into core's internal
+// lumice::annotation::ViewSnapshot. This is the single implementation of that field mapping
+// (a56: same semantics, one owner) — shared by LUMICE_ComputeAnnotationOverlay (c_api.cpp) and
+// the test-only lumice_test_api.cpp LUMICE_TEST_ComputeRenderDomainMask hook, which otherwise
+// carried a hand-copied second translation of the same struct.
+lumice::annotation::ViewSnapshot ToAnnotationViewSnapshot(const LUMICE_AnnotationView& v);
 
 #endif  // SERVER_C_API_INTERNAL_H_

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -79,6 +79,15 @@ add_executable(unit_correctness_test
   "${PROJ_TEST_DIR}/unit-correctness/config/test_color_class_table.cpp"
   # server/
   "${PROJ_TEST_DIR}/unit-correctness/server/test_c_api.cpp"
+  # The test-only export surface (LUMICE_TEST_* hooks), compiled here a second time so the parity
+  # test below can call it: its other home is the `lumice_testapi` shared library (root
+  # CMakeLists.txt, BUILD_SHARED_LIBS only), which this static-flavor binary never links. Two
+  # binaries, two compilations of one source, no shared object between them — the same pattern
+  # every other .cpp listed in more than one target here follows. If a THIRD consumer of these
+  # symbols appears, split the source into an OBJECT library instead of listing it again.
+  "${PROJ_TEST_DIR}/support/lumice_test_api.cpp"
+  # Holds LUMICE_TEST_ComputeRenderDomainMask byte-for-byte to the product API's drawable mask.
+  "${PROJ_TEST_DIR}/unit-correctness/server/test_render_domain_mask_parity.cpp"
   "${PROJ_TEST_DIR}/unit-correctness/server/test_c_api_scene.cpp"
   "${PROJ_TEST_DIR}/unit-correctness/server/test_json_parser_parity.cpp"
   "${PROJ_TEST_DIR}/unit-correctness/server/test_stats_consumer.cpp"

--- a/test/e2e-correctness/test_ev_mode_relative_gui_parity.py
+++ b/test/e2e-correctness/test_ev_mode_relative_gui_parity.py
@@ -56,11 +56,13 @@ predicate (any direction landing in a pixel deposits energy there, so a pixel st
 collects some) while the mask is a POINT predicate on the pixel centre. Both are correct and the
 product agrees with itself: the preview shader discards that ring too. What did not carry the
 mask was this fixture's simplified GUI arm, so the mask is applied here, read from core's own
-answer -- ``LUMICE_ComputeAnnotationOverlay``'s ``drawable``, which is built from the same
-``mask_detail::PixelToWorld`` + ``VisibleByRange`` + ``FrontVisible`` predicate as the
-``BuildVisibleMask`` the renderer bakes with. Mirroring the geometry in Python instead would put a
-second authority on which pixels the lens images, which is the class of defect this suite exists
-to catch rather than to add.
+answer -- ``LUMICE_TEST_ComputeRenderDomainMask``'s ``imaged`` (``test/support/lumice_test_api.h``),
+which is built from the same ``mask_detail::PixelToWorld`` + ``VisibleByRange`` + ``FrontVisible``
+predicate as the ``BuildVisibleMask`` the renderer bakes with. Mirroring the geometry in Python
+instead would put a second authority on which pixels the lens images, which is the class of defect
+this suite exists to catch rather than to add. It is read through a test-only hook rather than the
+product annotation API because a mask a test wants is not a reason for ``lumice.h`` to export
+anything; the hook lives in ``liblumice_testapi``, the superset of ``liblumice`` this harness loads.
 
 Not necessarily byte-identical, and the residual is understood rather than tolerated: the GUI
 path routes its scale through ``2^log2(x)`` while the CLI computes the ratio directly, so the two
@@ -125,12 +127,13 @@ _CONTROL_MIN_DIFFERING_FRACTION = 1e-2
 # The render-domain mask, read from core rather than re-derived. See the fifth item in the module
 # docstring for why the GUI arm needs it at all.
 #
-# These four ctypes structs mirror lumice.h field for field. The mirror matters more here than for
-# a read-only result struct: the CALLER allocates LUMICE_AnnotationOverlay and core fills it, so a
-# mirror short by one field is not a wrong number but a write past the end of Python's storage.
-# _assert_mirrors_match_header() below reads the header and checks the field NAMES, which is the
-# same guard capi_runner.py puts on LUMICE_StatsResult and for the same reason: a size assertion
-# compares this file to a number typed in this file.
+# These two ctypes structs mirror their headers field for field: _AnnotationView is a product type
+# (lumice.h), _RenderDomainMask a test-only one (test/support/lumice_test_api.h). The mirror
+# matters more here than for a read-only result struct: the CALLER allocates the mask struct and
+# core fills it, so a mirror short by one field is not a wrong number but a write past the end of
+# Python's storage. _assert_mirrors_match_header() below reads each header and checks the field
+# NAMES, which is the same guard capi_runner.py puts on LUMICE_StatsResult and for the same reason:
+# a size assertion compares this file to a number typed in this file.
 # ---------------------------------------------------------------------------------------------
 
 
@@ -150,66 +153,29 @@ class _AnnotationView(ctypes.Structure):
     ]
 
 
-class _AnnotationRequest(ctypes.Structure):
-    _fields_ = [
-        ("view", _AnnotationView),
-        ("horizon", ctypes.c_int),
-        ("elevation_deg", ctypes.POINTER(ctypes.c_float)),
-        ("elevation_count", ctypes.c_int),
-        ("longitude_deg", ctypes.POINTER(ctypes.c_float)),
-        ("longitude_count", ctypes.c_int),
-        ("angular_dist_deg", ctypes.POINTER(ctypes.c_float)),
-        ("angular_dist_count", ctypes.c_int),
-        ("reference_dir", ctypes.c_float * 3),
-        ("zenith_nadir", ctypes.c_int),
-        ("want_labels", ctypes.c_int),
-        # Named reference directions. This fixture asks for none, so the pair stays NULL/0 --
-        # they are mirrored because the struct is allocated HERE and read by core, which makes a
-        # short mirror a wrong size rather than a missing feature.
-        ("marker_ids", ctypes.POINTER(ctypes.c_int)),
-        ("marker_count", ctypes.c_int),
-    ]
-
-
-class _AnnotationOverlay(ctypes.Structure):
+class _RenderDomainMask(ctypes.Structure):
     _fields_ = [
         ("width", ctypes.c_int),
         ("height", ctypes.c_int),
-        ("drawable", ctypes.POINTER(ctypes.c_ubyte)),
-        ("horizon", ctypes.POINTER(ctypes.c_ubyte)),
-        ("elevation", ctypes.POINTER(ctypes.c_ubyte)),
-        ("longitude", ctypes.POINTER(ctypes.c_ubyte)),
-        ("angular_dist", ctypes.POINTER(ctypes.c_ubyte)),
-        ("zenith_px", ctypes.c_float),
-        ("zenith_py", ctypes.c_float),
-        ("zenith_valid", ctypes.c_int),
-        ("nadir_px", ctypes.c_float),
-        ("nadir_py", ctypes.c_float),
-        ("nadir_valid", ctypes.c_int),
-        ("labels", ctypes.c_void_p),
-        ("label_count", ctypes.c_int),
+        ("imaged", ctypes.POINTER(ctypes.c_ubyte)),
         ("storage", ctypes.c_void_p),
-        # Appended after `storage` in the header so every field above keeps its published offset.
-        # Opaque here for the same reason `labels` is: this fixture reads neither, and a second
-        # mirror of the point struct would be one more thing to keep in step for no use.
-        ("marker_points", ctypes.c_void_p),
-        ("marker_count", ctypes.c_int),
     ]
 
 
 _HEADER = get_project_root() / "src" / "include" / "lumice.h"
+_TEST_API_HEADER = get_project_root() / "test" / "support" / "lumice_test_api.h"
 
 
-def _header_struct_fields(tag: str) -> list[str] | None:
-    """Field names of one `typedef struct <tag>_ { ... } <tag>;` in lumice.h, in order."""
-    if not _HEADER.is_file():  # source tree not available (e.g. installed wheel)
+def _header_struct_fields(tag: str, header: Path = _HEADER) -> list[str] | None:
+    """Field names of one `typedef struct <tag>_ { ... } <tag>;` in `header`, in order."""
+    if not header.is_file():  # source tree not available (e.g. installed wheel)
         return None
     body = re.search(
         rf"typedef struct {tag}_\s*\{{(.*?)\}}\s*{tag};",
-        _HEADER.read_text(encoding="utf-8"),
+        header.read_text(encoding="utf-8"),
         re.DOTALL,
     )
-    assert body is not None, f"could not locate {tag} in lumice.h"
+    assert body is not None, f"could not locate {tag} in {header.name}"
     decls = re.sub(r"//.*", "", body.group(1))
     names = []
     for decl in decls.split(";"):
@@ -220,17 +186,16 @@ def _header_struct_fields(tag: str) -> list[str] | None:
 
 
 def _assert_mirrors_match_header() -> None:
-    for tag, mirror in (
-        ("LUMICE_AnnotationView", _AnnotationView),
-        ("LUMICE_AnnotationRequest", _AnnotationRequest),
-        ("LUMICE_AnnotationOverlay", _AnnotationOverlay),
+    for tag, mirror, header in (
+        ("LUMICE_AnnotationView", _AnnotationView, _HEADER),
+        ("LUMICE_TEST_RenderDomainMask", _RenderDomainMask, _TEST_API_HEADER),
     ):
-        header_fields = _header_struct_fields(tag)
+        header_fields = _header_struct_fields(tag, header)
         if header_fields is None:
             return
         mirror_fields = [name for name, *_ in mirror._fields_]
         assert header_fields == mirror_fields, (
-            f"{tag} drift -- lumice.h has {header_fields}, this mirror has {mirror_fields}. "
+            f"{tag} drift -- {header.name} has {header_fields}, this mirror has {mirror_fields}. "
             "Core writes this struct through a pointer Python sized from the mirror, so fix the "
             "mirror before running anything else"
         )
@@ -260,9 +225,9 @@ def _header_enum_map(prefix: str) -> dict[str, int]:
 def _render_domain_mask(doc: dict) -> np.ndarray:
     """The pixels the renderer bakes, as core answers it: True where the lens images sky.
 
-    One `LUMICE_ComputeAnnotationOverlay` call with no annotation family requested, which makes it
-    the `drawable` sweep and nothing else (the header's own note: "The masks alone are several
-    times cheaper than masks plus anchors").
+    One `LUMICE_TEST_ComputeRenderDomainMask` call: the render-domain sweep and nothing else, no
+    curve masks and no label walk (the product API's own note on the cost of the latter: "The
+    masks alone are several times cheaper than masks plus anchors").
     """
     render = doc["render"][0]
     width, height = (int(v) for v in render["resolution"])
@@ -279,29 +244,28 @@ def _render_domain_mask(doc: dict) -> np.ndarray:
         visible=_header_enum_map("LUMICE_VISIBLE_")[render.get("visible", "full")],
         front=1 if render.get("front", False) else 0,
     )
-    request = _AnnotationRequest(view=view)
-    overlay = _AnnotationOverlay()
+    mask = _RenderDomainMask()
 
     lib = ctypes.CDLL(str(_find_lib()))
-    lib.LUMICE_ComputeAnnotationOverlay.restype = ctypes.c_int
-    lib.LUMICE_ComputeAnnotationOverlay.argtypes = [
-        ctypes.POINTER(_AnnotationRequest),
-        ctypes.POINTER(_AnnotationOverlay),
+    lib.LUMICE_TEST_ComputeRenderDomainMask.restype = ctypes.c_int
+    lib.LUMICE_TEST_ComputeRenderDomainMask.argtypes = [
+        ctypes.POINTER(_AnnotationView),
+        ctypes.POINTER(_RenderDomainMask),
     ]
-    lib.LUMICE_ReleaseAnnotationOverlay.restype = None
-    lib.LUMICE_ReleaseAnnotationOverlay.argtypes = [ctypes.POINTER(_AnnotationOverlay)]
+    lib.LUMICE_TEST_ReleaseRenderDomainMask.restype = None
+    lib.LUMICE_TEST_ReleaseRenderDomainMask.argtypes = [ctypes.POINTER(_RenderDomainMask)]
 
     try:
-        err = lib.LUMICE_ComputeAnnotationOverlay(ctypes.byref(request), ctypes.byref(overlay))
-        assert err == 0, f"LUMICE_ComputeAnnotationOverlay failed err={err}"
-        assert (overlay.width, overlay.height) == (width, height), (
-            f"overlay canvas {overlay.width}x{overlay.height} != config {width}x{height}"
+        err = lib.LUMICE_TEST_ComputeRenderDomainMask(ctypes.byref(view), ctypes.byref(mask))
+        assert err == 0, f"LUMICE_TEST_ComputeRenderDomainMask failed err={err}"
+        assert (mask.width, mask.height) == (width, height), (
+            f"mask canvas {mask.width}x{mask.height} != config {width}x{height}"
         )
-        assert overlay.drawable, "core returned a NULL drawable mask for a non-degenerate view"
+        assert mask.imaged, "core returned a NULL render-domain mask for a non-degenerate view"
         # Copied, not viewed: the buffer belongs to core and dies at Release below.
-        flat = np.ctypeslib.as_array(overlay.drawable, shape=(height * width,)).copy()
+        flat = np.ctypeslib.as_array(mask.imaged, shape=(height * width,)).copy()
     finally:
-        lib.LUMICE_ReleaseAnnotationOverlay(ctypes.byref(overlay))
+        lib.LUMICE_TEST_ReleaseRenderDomainMask(ctypes.byref(mask))
     return flat.reshape(height, width) != 0
 
 

--- a/test/e2e/capi_runner.py
+++ b/test/e2e/capi_runner.py
@@ -10,14 +10,28 @@ commits the requested config, polls until the server returns to IDLE with
 valid data (or the timeout fires), reads the scalar result, and destroys
 the server.
 
+Which library. This runner loads ``liblumice_testapi``, not ``liblumice``. The
+two are built from the same ``lumice_obj`` objects, so every ``LUMICE_*`` call
+behaves identically; the test library additionally exports the ``LUMICE_TEST_*``
+hooks declared in ``test/support/lumice_test_api.h`` -- test-only entry points
+that the product ABI (``src/include/lumice.h``) must never carry. It is a
+superset stand-in rather than a companion: ``-fvisibility=hidden`` leaves a side
+library nothing to link against, so the hooks ship with their own copy of the
+engine, and a test process loads exactly ONE of the two (two would be two engines
+with two sets of statics). Nothing in this module calls a hook itself; the tests
+that need one reach it through the same handle.
+
 Library lookup order:
     1. ``LUMICE_LIB`` environment variable (full path to the shared library).
-    2. ``build/Release/shared/lib/liblumice.{dylib,so}``
-    3. ``build/cmake_install/shared/{liblumice.{dylib,so}, lib/liblumice.{dylib,so}}``
-    4. ``build/cmake_build/shared/liblumice.{dylib,so}``
+    2. ``build/Release/shared/lib/liblumice_testapi.{dylib,so}``
+    3. ``build/cmake_install/shared/{liblumice_testapi.{dylib,so}, lib/liblumice_testapi.{dylib,so}}``
+    4. ``build/cmake_build/shared/liblumice_testapi.{dylib,so}``
 
-The library must be built with ``BUILD_SHARED_LIBS=ON`` (the default release
-recipe). If lookup fails, raises :class:`FileNotFoundError`.
+The library must be built with ``BUILD_SHARED_LIBS=ON`` (``./scripts/build.sh -s``),
+which produces both shared libraries side by side. On Windows the file is
+``lumice_testapi.dll`` (no ``lib`` prefix); there is no automatic candidate for
+it, as there was none for ``lumice.dll`` -- point ``LUMICE_LIB`` at it. If lookup
+fails, raises :class:`FileNotFoundError`.
 
 **Test-only module**: the first call to :func:`run_scene_capi_buffered` installs
 a process-level log callback into the C library (``LUMICE_SetLogCallback``).
@@ -306,14 +320,17 @@ def lib_candidates(root: Path, build_type: str = "Release") -> List[Path]:
         # Every candidate is under the "shared" flavor: this runner loads the
         # dylib through ctypes, which only exists in a BUILD_SHARED_LIBS=ON build.
         # A static build writes to .../static/ and is correctly not found here.
-        root / "build" / build_type / "shared" / "lib" / "liblumice.dylib",
-        root / "build" / build_type / "shared" / "lib" / "liblumice.so",
-        root / "build" / "cmake_install" / "shared" / "liblumice.dylib",
-        root / "build" / "cmake_install" / "shared" / "liblumice.so",
-        root / "build" / "cmake_install" / "shared" / "lib" / "liblumice.dylib",
-        root / "build" / "cmake_install" / "shared" / "lib" / "liblumice.so",
-        root / "build" / "cmake_build" / "shared" / "liblumice.dylib",
-        root / "build" / "cmake_build" / "shared" / "liblumice.so",
+        # And every candidate is the TEST library, never liblumice -- see the
+        # module docstring for why the two are not interchangeable in a test
+        # process even though every product call behaves the same in both.
+        root / "build" / build_type / "shared" / "lib" / "liblumice_testapi.dylib",
+        root / "build" / build_type / "shared" / "lib" / "liblumice_testapi.so",
+        root / "build" / "cmake_install" / "shared" / "liblumice_testapi.dylib",
+        root / "build" / "cmake_install" / "shared" / "liblumice_testapi.so",
+        root / "build" / "cmake_install" / "shared" / "lib" / "liblumice_testapi.dylib",
+        root / "build" / "cmake_install" / "shared" / "lib" / "liblumice_testapi.so",
+        root / "build" / "cmake_build" / "shared" / "liblumice_testapi.dylib",
+        root / "build" / "cmake_build" / "shared" / "liblumice_testapi.so",
     ]
 
 
@@ -322,7 +339,7 @@ def _announce_chosen_lib(path: Path) -> None:
 
     `scripts/build.sh -k` deletes `build/cmake_build/<flavor>` and
     `build/cmake_install/<flavor>` but NOT the compiler output tree
-    `build/<BUILD_TYPE>/<flavor>/` — and `build/Release/shared/lib/liblumice.dylib`
+    `build/<BUILD_TYPE>/<flavor>/` — and `build/Release/shared/lib/liblumice_testapi.dylib`
     is the FIRST candidate `lib_candidates` returns. So "I cleaned" can be followed
     by ctypes loading a dylib from before the clean, with nothing on screen saying
     so: a stale library produces a coherent-looking pass or a failure blamed on the
@@ -359,8 +376,10 @@ def _find_lib() -> Path:
             _announce_chosen_lib(c)
             return c
     raise FileNotFoundError(
-        "liblumice shared library not found. Build with BUILD_SHARED_LIBS=ON "
-        "(./scripts/build.sh -j release), or set LUMICE_LIB to the absolute path."
+        "liblumice_testapi shared library not found (the test-only superset of liblumice; "
+        "liblumice itself is deliberately not a candidate). Build the shared flavor with "
+        "./scripts/build.sh -sj release, or set LUMICE_LIB to the absolute path "
+        "(lumice_testapi.dll on Windows)."
     )
 
 

--- a/test/parity-cross-backend/backend/test_metal_batch_invariance.py
+++ b/test/parity-cross-backend/backend/test_metal_batch_invariance.py
@@ -111,7 +111,7 @@ def _spawn_run(config_name: str, batch: int):
     env["LUMICE_DISPATCH_RAY_NUM"] = str(batch)
     env["LUMICE_COMMIT_RAY_NUM"] = str(batch)
     env.setdefault(
-        "LUMICE_LIB", str(root / "build" / "Release" / "shared" / "lib" / "liblumice.dylib")
+        "LUMICE_LIB", str(root / "build" / "Release" / "shared" / "lib" / "liblumice_testapi.dylib")
     )
     env["PYTHONPATH"] = str(root) + os.pathsep + env.get("PYTHONPATH", "")
     # Invoke this file by absolute path (not `-m module`): after the 270.4 reorg

--- a/test/support/lumice_test_api.cpp
+++ b/test/support/lumice_test_api.cpp
@@ -1,0 +1,84 @@
+// Implementation of the test-only export surface (lumice_test_api.h). Compiled twice, into two
+// binaries that never link each other: the `lumice_testapi` shared library (root CMakeLists.txt,
+// what pytest dlopens) and `unit_correctness_test` (test/CMakeLists.txt, where the parity test
+// against the product API lives). If a THIRD consumer of these symbols ever appears, that is the
+// point to split this file into an OBJECT library rather than list it a third time.
+#include "lumice_test_api.h"
+
+#include <memory>
+
+#include "core/annotation_overlay.hpp"
+
+namespace {
+
+// Everything `imaged` points into, owned through the struct's opaque `storage` handle so a single
+// Release frees it and the released state (NULL pointer) is expressible.
+struct RenderDomainMaskStorage {
+  lumice::annotation::Overlay overlay;
+};
+
+}  // namespace
+
+
+LUMICE_ErrorCode LUMICE_TEST_ComputeRenderDomainMask(const LUMICE_AnnotationView* view,
+                                                     LUMICE_TEST_RenderDomainMask* out) {
+  if (!view || !out) {
+    return LUMICE_ERR_NULL_ARG;
+  }
+  if (view->lens_type < 0 || view->lens_type > LUMICE_LENS_TYPE_GLOBE) {
+    return LUMICE_ERR_INVALID_VALUE;
+  }
+  if (view->visible != LUMICE_VISIBLE_UPPER && view->visible != LUMICE_VISIBLE_LOWER &&
+      view->visible != LUMICE_VISIBLE_FULL) {
+    return LUMICE_ERR_INVALID_VALUE;
+  }
+
+  // The same view translation LUMICE_ComputeAnnotationOverlay performs, feeding the same core
+  // sweep. No line list, no markers, and no label walk: every other Request field keeps its
+  // default (empty lists, zenith_nadir = false), and `labels` is switched off explicitly because
+  // its default is on. The drawable sweep is independent of all of them — the parity test in
+  // test/unit-correctness/server/ is what holds that claim to the product API's output.
+  lumice::annotation::Request req;
+  req.view.width = view->width;
+  req.view.height = view->height;
+  req.view.lens_type = static_cast<lumice::LensParam::LensType>(view->lens_type);
+  req.view.fov_deg = view->lens_fov;
+  req.view.lens_shift[0] = view->lens_shift[0];
+  req.view.lens_shift[1] = view->lens_shift[1];
+  req.view.overlap = view->overlap;
+  req.view.az_deg = view->view_azimuth;
+  req.view.el_deg = view->view_elevation;
+  req.view.roll_deg = view->view_roll;
+  req.view.visible = static_cast<lumice::RenderConfig::VisibleRange>(view->visible);
+  req.view.front = view->front != 0;
+  req.labels = false;
+
+  std::unique_ptr<RenderDomainMaskStorage> storage;
+  try {
+    storage = std::make_unique<RenderDomainMaskStorage>();
+    storage->overlay = lumice::annotation::ComputeOverlay(req);
+  } catch (...) {
+    return LUMICE_ERR_UNKNOWN;
+  }
+
+  const lumice::annotation::Overlay& o = storage->overlay;
+  out->width = o.width;
+  out->height = o.height;
+  out->imaged = o.drawable.empty() ? nullptr : o.drawable.data();
+  out->storage = storage.release();
+  return LUMICE_OK;
+}
+
+
+void LUMICE_TEST_ReleaseRenderDomainMask(LUMICE_TEST_RenderDomainMask* mask) {
+  if (!mask || !mask->storage) {
+    return;  // NULL-safe, and idempotent on an already-released or zero-initialized struct
+  }
+  const std::unique_ptr<RenderDomainMaskStorage> owned(static_cast<RenderDomainMaskStorage*>(mask->storage));
+  mask->storage = nullptr;
+  // Leave no dangling view of freed memory behind, so a caller that keeps reading the struct after
+  // Release sees "nothing here" rather than a use-after-free.
+  mask->imaged = nullptr;
+  mask->width = 0;
+  mask->height = 0;
+}

--- a/test/support/lumice_test_api.cpp
+++ b/test/support/lumice_test_api.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "core/annotation_overlay.hpp"
+#include "server/c_api_internal.hpp"  // ToAnnotationViewSnapshot (a56: single translation owner)
 
 namespace {
 
@@ -33,24 +34,14 @@ LUMICE_ErrorCode LUMICE_TEST_ComputeRenderDomainMask(const LUMICE_AnnotationView
     return LUMICE_ERR_INVALID_VALUE;
   }
 
-  // The same view translation LUMICE_ComputeAnnotationOverlay performs, feeding the same core
-  // sweep. No line list, no markers, and no label walk: every other Request field keeps its
-  // default (empty lists, zenith_nadir = false), and `labels` is switched off explicitly because
-  // its default is on. The drawable sweep is independent of all of them — the parity test in
+  // Same view translation LUMICE_ComputeAnnotationOverlay performs (ToAnnotationViewSnapshot,
+  // server/c_api_internal.hpp — a56: single owner), feeding the same core sweep. No line list, no
+  // markers, and no label walk: every other Request field keeps its default (empty lists,
+  // zenith_nadir = false), and `labels` is switched off explicitly because its default is on. The
+  // drawable sweep is independent of all of them — the parity test in
   // test/unit-correctness/server/ is what holds that claim to the product API's output.
   lumice::annotation::Request req;
-  req.view.width = view->width;
-  req.view.height = view->height;
-  req.view.lens_type = static_cast<lumice::LensParam::LensType>(view->lens_type);
-  req.view.fov_deg = view->lens_fov;
-  req.view.lens_shift[0] = view->lens_shift[0];
-  req.view.lens_shift[1] = view->lens_shift[1];
-  req.view.overlap = view->overlap;
-  req.view.az_deg = view->view_azimuth;
-  req.view.el_deg = view->view_elevation;
-  req.view.roll_deg = view->view_roll;
-  req.view.visible = static_cast<lumice::RenderConfig::VisibleRange>(view->visible);
-  req.view.front = view->front != 0;
+  req.view = ToAnnotationViewSnapshot(*view);
   req.labels = false;
 
   std::unique_ptr<RenderDomainMaskStorage> storage;

--- a/test/support/lumice_test_api.h
+++ b/test/support/lumice_test_api.h
@@ -1,0 +1,75 @@
+#ifndef LUMICE_TEST_API_H_
+#define LUMICE_TEST_API_H_
+
+// The TEST-ONLY export surface of liblumice_testapi: lumice.h plus a handful of LUMICE_TEST_*
+// hooks the pytest (ctypes) harness needs and the product ABI must never carry. Everything a test
+// can do through the product C API it still does through the product C API — the hooks here
+// exist only for what has no product-facing reason to be exported at all.
+//
+// liblumice_testapi is a SUPERSET STAND-IN for liblumice, not a companion library: it is built
+// from the same lumice_obj objects (so every LUMICE_* call behaves identically) and additionally
+// exports the symbols declared below. A test process loads this ONE library and never liblumice
+// beside it — two copies would be two engines with two sets of statics. Only the shared flavor
+// builds it (root CMakeLists.txt, target `lumice_testapi`); the file names are
+// liblumice_testapi.dylib / liblumice_testapi.so / lumice_testapi.dll.
+//
+// The header lives under test/ on purpose, and scripts/check_policies.py's no-test-symbol-in-src
+// rule keeps the LUMICE_TEST_ prefix out of src/, so a hook cannot migrate into the product
+// surface by accident.
+
+#include "lumice.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Same export mechanism as lumice.h: with -fvisibility=hidden on the target, only this block is
+// exported from the shared library. MSVC has no equivalent pragma and the target is built with
+// WINDOWS_EXPORT_ALL_SYMBOLS instead.
+#if !defined(_MSC_VER)
+#pragma GCC visibility push(default)
+#endif
+
+// The render-domain mask of one view: row-major width*height, indexed py * width + px, 1 where the
+// lens images a piece of sky the view is allowed to draw — imaged, inside `visible`, and inside
+// the front hemisphere when `front` is set. Byte-identical to LUMICE_AnnotationOverlay::drawable
+// for the same LUMICE_AnnotationView: both come from one lumice::annotation::ComputeOverlay sweep
+// and the same mask_detail::PixelToWorld + VisibleByRange + FrontVisible predicate the renderer
+// bakes with. `imaged` is NULL only for a degenerate view (width or height <= 0).
+typedef struct LUMICE_TEST_RenderDomainMask_ {
+  int width;
+  int height;
+  const unsigned char* imaged;
+  // Opaque handle to the storage `imaged` points into. Do not read, write, copy or free it; pass
+  // this struct to LUMICE_TEST_ReleaseRenderDomainMask exactly once instead — the same
+  // acquire/release discipline LUMICE_Scene / LUMICE_ResultFrame / LUMICE_AnnotationOverlay use.
+  // Copying the struct copies the handle, so only ONE copy may be released.
+  void* storage;
+} LUMICE_TEST_RenderDomainMask;
+
+// Compute ONLY the render-domain mask of one view — no curve masks, no label anchors, no markers.
+// Exists so a test fixture that needs the mask never has to reach for the product annotation API,
+// which lumice.h carries for the GUI and the CLI renderer, not for tests. Pure, deterministic and
+// thread-safe like LUMICE_ComputeAnnotationOverlay. `*out` is fully overwritten on success and
+// left untouched on failure. A degenerate view (width or height <= 0) is not an error: it yields
+// width = height = 0 and imaged = NULL, and still must be Released.
+//
+// Returns LUMICE_ERR_NULL_ARG if `view` or `out` is NULL; LUMICE_ERR_INVALID_VALUE for an unknown
+// lens_type / visible; LUMICE_ERR_UNKNOWN on allocation failure.
+LUMICE_ErrorCode LUMICE_TEST_ComputeRenderDomainMask(const LUMICE_AnnotationView* view,
+                                                     LUMICE_TEST_RenderDomainMask* out);
+
+// Release the storage a successful LUMICE_TEST_ComputeRenderDomainMask allocated, and NULL out the
+// pointer so a double release is a no-op rather than a double free. NULL-safe, and safe on a
+// zero-initialized or already-released struct.
+void LUMICE_TEST_ReleaseRenderDomainMask(LUMICE_TEST_RenderDomainMask* mask);
+
+#if !defined(_MSC_VER)
+#pragma GCC visibility pop
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // LUMICE_TEST_API_H_

--- a/test/unit-correctness/scripts/test_check_policies_no_test_symbol_in_src.py
+++ b/test/unit-correctness/scripts/test_check_policies_no_test_symbol_in_src.py
@@ -1,0 +1,136 @@
+"""Regression net for `check_no_test_symbol_in_src` in `scripts/check_policies.py`.
+
+The rule is one prefix regex run line-by-line over `code_lines()`, so by the
+criterion at the top of `test_check_new_refs.py` it is on the untested side.
+It is pinned anyway, and for the same reason `test_check_policies_bare_print.py`
+is: the rule's interesting behaviour lives in a helper it borrows rather than in
+its own text. That a comment naming `LUMICE_TEST_` (the rule's own explanation,
+a header note pointing at the test surface) is not a hit comes entirely from
+`strip_comments()`; a change made for another check's benefit reaches here
+silently, and a false positive on the prose that documents the rule would be
+the first thing a reader saw.
+
+The other reason is the one the issue named: a policy gate's red state has to be
+demonstrated, not assumed. The temporary "write a `LUMICE_TEST_` line into
+lumice.h and watch the checker go red" probe is done once by hand and then
+undone; this file is that probe made permanent.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
+
+import check_policies  # noqa: E402
+
+RULE = "no-test-symbol-in-src"
+
+
+@pytest.fixture
+def src_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    src = tmp_path / "src"
+    src.mkdir()
+    monkeypatch.setattr(check_policies, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(check_policies, "SRC", src)
+    return src
+
+
+def _violations(src_root: Path, body: str, name: str = "scratch.cpp") -> list:
+    path = src_root / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return check_policies.check_no_test_symbol_in_src()
+
+
+# --- must stay red: the test surface leaking into src/ ----------------------
+
+
+def test_declaration_in_public_header_is_flagged(src_root: Path) -> None:
+    """The exact shape the rule exists for: a hook declared in lumice.h."""
+    out = _violations(
+        src_root,
+        "#ifndef LUMICE_H_\nvoid LUMICE_TEST_ComputeRenderDomainMask(void);\n#endif\n",
+        name="include/lumice.h",
+    )
+    assert len(out) == 1
+    assert out[0].rule == RULE
+    assert out[0].line == 2
+
+
+def test_call_in_implementation_is_flagged(src_root: Path) -> None:
+    out = _violations(src_root, "void F() {\n  LUMICE_TEST_ReleaseRenderDomainMask(0);\n}\n")
+    assert len(out) == 1
+
+
+def test_struct_tag_is_flagged(src_root: Path) -> None:
+    """The prefix, not a function shape: a mirrored struct is as much a leak as a call."""
+    out = _violations(src_root, "struct LUMICE_TEST_RenderDomainMask_ {\n  int width;\n};\n")
+    assert len(out) == 1
+
+
+def test_every_hit_line_is_reported(src_root: Path) -> None:
+    out = _violations(
+        src_root,
+        "int a = LUMICE_TEST_A;\nint b = 1;\nint c = LUMICE_TEST_C;\n",
+    )
+    assert [v.line for v in out] == [1, 3]
+
+
+# --- must stay green: prose about the rule is not a violation of it --------
+
+
+def test_prefix_in_comment_is_not_flagged(src_root: Path) -> None:
+    """Comes from `strip_comments()`, which this check borrows and does not own."""
+    out = _violations(
+        src_root,
+        "// LUMICE_TEST_* hooks live in test/support/lumice_test_api.h, never here.\n"
+        "/* see LUMICE_TEST_ComputeRenderDomainMask */\n"
+        "int x = 0;\n",
+    )
+    assert out == []
+
+
+def test_product_prefix_is_not_flagged(src_root: Path) -> None:
+    """LUMICE_* without the TEST_ segment is the product surface and is the point."""
+    out = _violations(
+        src_root,
+        "LUMICE_ErrorCode LUMICE_ComputeAnnotationOverlay(const LUMICE_AnnotationRequest* r,\n"
+        "                                                 LUMICE_AnnotationOverlay* o);\n"
+        "#define LUMICE_TESTING_MODE 1\n",
+    )
+    assert out == []
+
+
+def test_prefix_inside_a_longer_identifier_is_not_flagged(src_root: Path) -> None:
+    """`\\b` ahead of the prefix: MY_LUMICE_TEST_X is not the test surface's spelling."""
+    assert _violations(src_root, "int MY_LUMICE_TEST_X = 0;\n") == []
+
+
+# --- scope: which files are read at all -------------------------------------
+
+
+@pytest.mark.parametrize("suffix", sorted(check_policies.CXX_SUFFIXES))
+def test_every_cxx_suffix_is_scanned(src_root: Path, suffix: str) -> None:
+    out = _violations(src_root, "int v = LUMICE_TEST_V;\n", name=f"leak{suffix}")
+    assert len(out) == 1, f"{suffix} not scanned"
+
+
+def test_non_source_suffix_is_not_scanned(src_root: Path) -> None:
+    assert _violations(src_root, "LUMICE_TEST_ is documented here\n", name="notes.md") == []
+
+
+def test_files_outside_src_are_not_scanned(src_root: Path) -> None:
+    """The test surface's own header must not trip the rule that protects it."""
+    outside = src_root.parent / "test" / "support"
+    outside.mkdir(parents=True)
+    (outside / "lumice_test_api.h").write_text(
+        "void LUMICE_TEST_ComputeRenderDomainMask(void);\n", encoding="utf-8"
+    )
+    assert check_policies.check_no_test_symbol_in_src() == []
+
+
+def test_check_is_registered_in_checks(src_root: Path) -> None:
+    assert check_policies.check_no_test_symbol_in_src in check_policies.CHECKS

--- a/test/unit-correctness/server/test_render_domain_mask_parity.cpp
+++ b/test/unit-correctness/server/test_render_domain_mask_parity.cpp
@@ -1,0 +1,187 @@
+// LUMICE_TEST_ComputeRenderDomainMask (test/support/lumice_test_api.h, the test-only export
+// surface) must hand out the SAME bytes as LUMICE_AnnotationOverlay::drawable, the product API's
+// answer to the same view. The two are meant to be one computation behind two doors — the hook
+// exists so pytest can read the render-domain mask without the product ABI carrying a test-only
+// reason to export anything — and this file is what makes "same computation" a checked claim
+// rather than a comment.
+//
+// It is also the direct refutation path for the one shortcut the hook takes: it feeds the core
+// sweep a Request with every line list empty and `labels = false`, on the assumption that the
+// drawable sweep does not depend on any of them. If ComputeOverlay ever couples the drawable to
+// the label walk or to a requested line family, this test goes red before any downstream consumer
+// notices a shifted mask.
+//
+// The product API is the oracle here rather than lumice::annotation::ComputeOverlay itself,
+// because the hook calls ComputeOverlay directly — comparing against that would be the hook
+// checking its own homework. This is the only window in which the product API can serve as that
+// oracle: should LUMICE_ComputeAnnotationOverlay ever be removed from lumice.h, the change that
+// removes it must either re-point this test at core's ComputeOverlay (accepting the weaker,
+// self-referential comparison) or delete the test — that decision belongs to that change.
+//
+// Flavor note: unit_correctness_test compiles lumice_test_api.cpp into a static, test-flavor
+// binary, while pytest loads the same source compiled into the shared-flavor liblumice_testapi.
+// The two differ only in export options (-fvisibility=hidden / WINDOWS_EXPORT_ALL_SYMBOLS), which
+// govern which symbols a dlopen can see and not what a function body computes; the parity pinned
+// here is taken to hold for the shared build on that basis.
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "include/lumice.h"
+#include "support/lumice_test_api.h"
+
+namespace {
+
+struct Scene {
+  const char* name;
+  LUMICE_AnnotationView view;
+};
+
+// One all-sky lens and one single lens, each under a `visible` / `front` combination the other
+// does not use, so the mask carries every predicate the hook is supposed to reproduce (imaged,
+// VisibleByRange, FrontVisible) at least once. Odd canvas sizes so a row-stride mistake cannot hide
+// behind a power of two; a lens shift and a roll so the view is not the all-defaults one either.
+LUMICE_AnnotationView MakeView(int width, int height, int lens_type, float fov, int shift_x, int shift_y, float overlap,
+                               float az, float el, float roll, int visible, int front) {
+  LUMICE_AnnotationView v{};
+  v.width = width;
+  v.height = height;
+  v.lens_type = lens_type;
+  v.lens_fov = fov;
+  v.lens_shift[0] = shift_x;
+  v.lens_shift[1] = shift_y;
+  v.overlap = overlap;
+  v.view_azimuth = az;
+  v.view_elevation = el;
+  v.view_roll = roll;
+  v.visible = visible;
+  v.front = front;
+  return v;
+}
+
+const Scene kScenes[] = {
+  { "dual_fisheye_equal_area_full_nofront", MakeView(257, 131, LUMICE_LENS_TYPE_DUAL_FISHEYE_EQUAL_AREA, 180.0f, 0, 0,
+                                                     0.0f, 0.0f, 0.0f, 0.0f, LUMICE_VISIBLE_FULL, 0) },
+  { "linear_upper_front",
+    MakeView(193, 121, LUMICE_LENS_TYPE_LINEAR, 60.0f, 3, -2, 0.0f, 30.0f, 12.0f, 5.0f, LUMICE_VISIBLE_UPPER, 1) },
+  { "fisheye_equal_area_lower_front", MakeView(171, 171, LUMICE_LENS_TYPE_FISHEYE_EQUAL_AREA, 150.0f, 0, 0, 0.0f,
+                                               200.0f, -35.0f, 0.0f, LUMICE_VISIBLE_LOWER, 1) },
+  { "dual_fisheye_equal_area_upper_front_overlap", MakeView(255, 129, LUMICE_LENS_TYPE_DUAL_FISHEYE_EQUAL_AREA, 180.0f,
+                                                            0, 0, 0.1f, 90.0f, 20.0f, 0.0f, LUMICE_VISIBLE_UPPER, 1) },
+};
+
+// The product API's answer for a view, with nothing but the view filled in — the same shape of
+// request the pytest fixture used to send before it switched to the hook.
+struct ProductOverlay {
+  LUMICE_AnnotationOverlay overlay{};
+  explicit ProductOverlay(const LUMICE_AnnotationView& view) {
+    LUMICE_AnnotationRequest request{};
+    request.view = view;
+    EXPECT_EQ(LUMICE_ComputeAnnotationOverlay(&request, &overlay), LUMICE_OK);
+  }
+  ~ProductOverlay() { LUMICE_ReleaseAnnotationOverlay(&overlay); }
+  ProductOverlay(const ProductOverlay&) = delete;
+  ProductOverlay& operator=(const ProductOverlay&) = delete;
+};
+
+struct HookMask {
+  LUMICE_TEST_RenderDomainMask mask{};
+  explicit HookMask(const LUMICE_AnnotationView& view) {
+    EXPECT_EQ(LUMICE_TEST_ComputeRenderDomainMask(&view, &mask), LUMICE_OK);
+  }
+  ~HookMask() { LUMICE_TEST_ReleaseRenderDomainMask(&mask); }
+  HookMask(const HookMask&) = delete;
+  HookMask& operator=(const HookMask&) = delete;
+};
+
+// One scene's comparison, in its own function so a fatal assert ends THIS scene and not the loop
+// that drives the others (scripts/check_loop_fatal_asserts.py pins that shape).
+void ExpectHookMatchesProduct(const Scene& scene) {
+  SCOPED_TRACE(scene.name);
+  const ProductOverlay product(scene.view);
+  const HookMask hook(scene.view);
+  const LUMICE_AnnotationOverlay& o = product.overlay;
+  const LUMICE_TEST_RenderDomainMask& m = hook.mask;
+
+  EXPECT_EQ(m.width, o.width);
+  EXPECT_EQ(m.height, o.height);
+  EXPECT_EQ(m.width, scene.view.width);
+  EXPECT_EQ(m.height, scene.view.height);
+  ASSERT_NE(o.drawable, nullptr);
+  ASSERT_NE(m.imaged, nullptr);
+  // Distinct allocations: the hook owns its own storage, it does not alias the product's.
+  EXPECT_NE(m.imaged, o.drawable);
+
+  const size_t n = static_cast<size_t>(o.width) * static_cast<size_t>(o.height);
+  EXPECT_EQ(std::memcmp(m.imaged, o.drawable, n), 0);
+
+  // A mask that is all-0 or all-1 would satisfy memcmp without exercising the predicate; every
+  // scene here is built to have both inside and outside pixels.
+  size_t ones = 0;
+  for (size_t i = 0; i < n; ++i) {
+    ones += m.imaged[i] != 0;
+  }
+  EXPECT_GT(ones, 0u);
+  EXPECT_LT(ones, n);
+}
+
+}  // namespace
+
+
+TEST(RenderDomainMaskParity, HookMatchesProductDrawableByteForByte) {
+  for (const Scene& scene : kScenes) {
+    ExpectHookMatchesProduct(scene);
+  }
+}
+
+
+TEST(RenderDomainMaskParity, DegenerateViewIsNotAnErrorAndStillReleases) {
+  LUMICE_AnnotationView view = kScenes[0].view;
+  view.width = 0;
+  LUMICE_TEST_RenderDomainMask mask{};
+  ASSERT_EQ(LUMICE_TEST_ComputeRenderDomainMask(&view, &mask), LUMICE_OK);
+  EXPECT_EQ(mask.width, 0);
+  EXPECT_EQ(mask.height, 0);
+  EXPECT_EQ(mask.imaged, nullptr);
+  EXPECT_NE(mask.storage, nullptr);
+  LUMICE_TEST_ReleaseRenderDomainMask(&mask);
+  EXPECT_EQ(mask.storage, nullptr);
+}
+
+
+TEST(RenderDomainMaskParity, ArgumentValidationMirrorsProductApi) {
+  LUMICE_TEST_RenderDomainMask mask{};
+  EXPECT_EQ(LUMICE_TEST_ComputeRenderDomainMask(nullptr, &mask), LUMICE_ERR_NULL_ARG);
+  EXPECT_EQ(LUMICE_TEST_ComputeRenderDomainMask(&kScenes[0].view, nullptr), LUMICE_ERR_NULL_ARG);
+
+  LUMICE_AnnotationView bad_lens = kScenes[0].view;
+  bad_lens.lens_type = LUMICE_LENS_TYPE_GLOBE + 1;
+  EXPECT_EQ(LUMICE_TEST_ComputeRenderDomainMask(&bad_lens, &mask), LUMICE_ERR_INVALID_VALUE);
+
+  LUMICE_AnnotationView bad_visible = kScenes[0].view;
+  bad_visible.visible = 7;
+  EXPECT_EQ(LUMICE_TEST_ComputeRenderDomainMask(&bad_visible, &mask), LUMICE_ERR_INVALID_VALUE);
+
+  // A failed call leaves `*out` untouched, so there is nothing to release — and releasing the
+  // untouched zero struct is a no-op rather than a fault.
+  EXPECT_EQ(mask.storage, nullptr);
+  EXPECT_EQ(mask.imaged, nullptr);
+  LUMICE_TEST_ReleaseRenderDomainMask(&mask);
+  LUMICE_TEST_ReleaseRenderDomainMask(nullptr);
+}
+
+
+TEST(RenderDomainMaskParity, ReleaseIsIdempotentAndNullsTheView) {
+  LUMICE_TEST_RenderDomainMask mask{};
+  ASSERT_EQ(LUMICE_TEST_ComputeRenderDomainMask(&kScenes[1].view, &mask), LUMICE_OK);
+  ASSERT_NE(mask.storage, nullptr);
+  LUMICE_TEST_ReleaseRenderDomainMask(&mask);
+  EXPECT_EQ(mask.storage, nullptr);
+  EXPECT_EQ(mask.imaged, nullptr);
+  EXPECT_EQ(mask.width, 0);
+  EXPECT_EQ(mask.height, 0);
+  LUMICE_TEST_ReleaseRenderDomainMask(&mask);  // second release: no-op, no double free
+  EXPECT_EQ(mask.storage, nullptr);
+}


### PR DESCRIPTION
## What

A second shared library, `liblumice_testapi`, that is the test-only export surface: `lumice.h` ⊕ `LUMICE_TEST_*` hooks, linked from the same `lumice_obj` objects as `liblumice`. pytest's ctypes loader now opens it instead of `liblumice`; every existing product-API call stays byte-for-byte the same (same objects, different link product).

First hook: `LUMICE_TEST_ComputeRenderDomainMask`, which takes over the one test-only consumer the product API had grown — `test_ev_mode_relative_gui_parity.py` reading `LUMICE_ComputeAnnotationOverlay`'s `drawable` as its "which pixels does the lens image" oracle.

## Why

`src/include/lumice.h` carries zero test-oriented entries today. The follow-up task (replace the mask-producing annotation API with a per-frame anchor query) would have had to keep a mask-only function alive purely for that pytest oracle — the first test-only symbol in the product surface. This PR gives such hooks a home outside `src/` before that need arrives, and gates the boundary (`check_policies.py` `no-test-symbol-in-src`: `LUMICE_TEST_` may not appear as a code token under `src/`).

Why a superset replica rather than a side-by-side hook library: `liblumice` is `-fvisibility=hidden` and exports only `LUMICE_*`, so a hook that needs core internals cannot link against it — it has to carry the objects, so pytest loads exactly one engine.

## Notes

- Target is gated on `BUILD_SHARED_LIBS`, not `BUILD_TEST`: CI's `e2e-slow` configures with `-DBUILD_TEST=OFF` and still needs the library.
- `lumice.h`, `LUMICE_API_VERSION`, and the `lumice` target are untouched.
- The byte-parity unit test uses the old `drawable` as its oracle while the old API still exists; the follow-up swaps the oracle to core's `annotation::ComputeOverlay` when it removes that API.
- Independently re-verified after rebase onto #338: `./scripts/test.sh pr` → `RESULT: PASS` (ctest / fast-e2e / gui-correctness / gui-real-timing / slow-e2e); `liblumice.dylib` exports 0 `LUMICE_TEST_` symbols, `liblumice_testapi.dylib` exports the 66 product symbols + 2 hooks; gate red/green probed by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYgz38dZ5gzXUA2oyuKkpQ
