### PR TITLE
build/release: ship ISA- and GPU-matched binaries behind CPUID launchers (x86-64-v4 Linux, x86-64-v3 clang-cl Windows, sm_120 fatbin)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -498,9 +498,13 @@ jobs:
       # Install only the compiler + cudart dev headers/stubs (~400 MB) rather
       # than the full ~2 GB toolkit. This is enough for nvcc to compile .cu
       # files and for CMake's find_package(CUDAToolkit) / CUDA::cudart link
-      # target to resolve. Pinned to CUDA 12.6 (a recent stable release that
-      # still supports compute_61 PTX); if 12-6 packages drift, bump to a
-      # nearby 12.x or switch to Jimver/cuda-toolkit action.
+      # target to resolve. Pinned to CUDA 12.9 — the last 12.x minor, the same
+      # toolkit both CUDA reference boxes (doc/machines.md) build and validate
+      # with, and the first minor after 12.8 introduced sm_120, so the fatbin
+      # gains native Blackwell SASS (CMakeLists.txt gates `120-real` on
+      # toolkit >= 12.8). apt resolves the newest 12.9 patch on its own. Stay
+      # on the 12 major: CUDA 13 drops compute_61, our PTX floor. Expect one
+      # compute_61 deprecation warning from nvcc (accepted, see CMakeLists.txt).
       - name: Install CUDA toolkit (nvcc + cudart)
         run: |
           wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb \
@@ -510,7 +514,7 @@ jobs:
           sudo grep -rl 'dl\.google\.com' /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -r rm -f
           grep -rn 'dl\.google\.com' /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null || echo 'google source gone'
           sudo apt-get update -qq
-          sudo apt-get install -y cuda-nvcc-12-6 cuda-cudart-dev-12-6
+          sudo apt-get install -y cuda-nvcc-12-9 cuda-cudart-dev-12-9
           echo "/usr/local/cuda/bin" >> $GITHUB_PATH
 
       # Share the CPM cache with the Ubuntu x64 build job: same OS, same
@@ -579,9 +583,10 @@ jobs:
   #     `windows-2025` image has rolled its ONLY Visual Studio install forward
   #     to VS 2026 (MSVC 14.51, `_MSC_VER` 1951; `vswhere` finds only
   #     `...\Microsoft Visual Studio\18\Enterprise`, no VS 2022 fallback).
-  #     Every current CUDA release rejects MSVC > VS 2022 (CUDA 12.6's
-  #     `crt/host_config.h`: "Only the versions between 2017 and 2022 are
-  #     supported"), so the CUDA job MUST run on an image that still ships a
+  #     Every current CUDA release rejects MSVC > VS 2022 (CUDA 12.9's
+  #     `crt/host_config.h` line 168: `#error` when `_MSC_VER >= 1950`, "Only
+  #     the versions between 2017 and 2022 (inclusive) are supported"; 12.6
+  #     said the same), so the CUDA job MUST run on an image that still ships a
   #     CUDA-compatible MSVC. windows-2022 ships VS 2022 (MSVC 14.4x).
   #     Verified first-hand in CI run 28439410508 (the windows-2025 attempt
   #     that failed at Configure).
@@ -594,16 +599,35 @@ jobs:
   #   - MSVC: windows-2022 runner default (VS 2022; `_MSC_VER` surfaced by the
   #     "Diagnose toolchain versions" step below — kept permanently so future
   #     image drift is debuggable from any run).
-  #   - CUDA: 12.6.3 — latest 12.6 patch, matches the Linux `cuda-compile`
-  #     job above (one CUDA major across all CI legs) and supports VS 2022.
+  #   - CUDA: 12.9.2 — latest 12.x patch (12.9 is the last 12.x minor; 12.9.2
+  #     ships the same nvcc 12.9.86 / cudart 12.9.79 as 12.9.1, the version
+  #     the CUDA reference boxes in doc/machines.md validated compute_61 on),
+  #     matches the Linux `cuda-compile` job above (one CUDA major across all
+  #     CI legs) and supports VS 2022.
   #     Do NOT use CUDA 11.x — its `_MSC_VER` ceiling (~1930) is below recent
   #     VS 2022 17.x (scrum-309 hit exactly this).
+  #   - WHY THE CUDA MAJOR IS 12, and why that fixes the other two pins: the
+  #     chain starts at `compute_61`. The owner keeps the Pascal PTX floor
+  #     (CMakeLists.txt `61-virtual`); CUDA 13 removed compute_61, so the
+  #     major stays at 12. CUDA 12.x's `crt/host_config.h` accepts host MSVC
+  #     up to VS 2022, so the runner must be an image that still ships VS
+  #     2022 — `windows-2022`. Break the first link (drop compute_61) and the
+  #     other two are free to move; until then they are consequences, not
+  #     independent choices.
+  #     The CUDA toolkit VERSION itself is written in three places that move
+  #     as one: this job's `cuda:` input, release.yml's windows-x64 `cuda:`
+  #     input, and the Linux `cuda-compile` job's apt package suffix
+  #     (`cuda-nvcc-12-9` / `cuda-cudart-dev-12-9`). A repo variable was
+  #     considered and not adopted: the apt suffix is `12-9` not `12.9.2`, so
+  #     one value could not feed all three without derivation logic, and a
+  #     drift between them fails loudly at install time rather than silently.
   #   - MAINTENANCE: when GitHub eventually retires windows-2022, either move
   #     to whatever hosted image still carries a CUDA-supported VS, or bump
   #     CUDA to a version that supports the then-current MSVC. Do NOT "fix" a
   #     future break by pinning a stale MSVC toolset onto windows-2025 — that
-  #     image dropped VS 2022 entirely. THREE pins move together or the
-  #     build-mirrors-release property breaks again: this job, the
+  #     image dropped VS 2022 entirely. THREE pins (VS 2022 / windows-2022 /
+  #     CUDA major 12) move together or the build-mirrors-release property
+  #     breaks again, across three places: this job, the
   #     `Windows MSVC x86_64` matrix entry above, and release.yml's
   #     windows-x64 row.
   #
@@ -659,7 +683,7 @@ jobs:
       - name: Install CUDA toolkit (nvcc + cudart_dev)
         uses: Jimver/cuda-toolkit@v0.2.36
         with:
-          cuda: '12.6.3'
+          cuda: '12.9.2'
           method: 'network'
           sub-packages: '["nvcc", "cudart"]'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=Release
           -DBUILD_TEST=ON
           -DBUILD_GUI=${{ matrix.build_gui }}
-          -DLUMICE_NATIVE_ARCH=OFF
+          -DLUMICE_ISA_LEVEL=baseline
           ${{ env.LUMICE_PYTHON_ARGS }}
           ${{ env.LUMICE_COMPILER_LAUNCHER_ARGS }}
 
@@ -528,7 +528,7 @@ jobs:
           key: cpm-ubuntu-x64-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: cpm-ubuntu-x64-
 
-      # BUILD_GUI=OFF avoids OpenGL/X11 deps. LUMICE_NATIVE_ARCH=OFF matches the
+      # BUILD_GUI=OFF avoids OpenGL/X11 deps. LUMICE_ISA_LEVEL=baseline matches the
       # rest of CI.
       #
       # BUILD_TEST=ON, not OFF, and the reason is not "more coverage is nicer".
@@ -557,7 +557,7 @@ jobs:
           -DBUILD_TEST=ON
           -DBUILD_GUI=OFF
           -DLUMICE_CUDA_ENABLED=ON
-          -DLUMICE_NATIVE_ARCH=OFF
+          -DLUMICE_ISA_LEVEL=baseline
 
       # Builds the Lumice CLI plus the test binaries; this drives nvcc through
       # cuda_trace_backend.cu and links CUDA::cudart, exercising both compile and
@@ -733,7 +733,7 @@ jobs:
       # This leg is the one that matters most for that gap: the historical
       # escapes it would have caught were MSVC-only source incompatibilities
       # (POSIX setenv/unsetenv, M_PI) in test code, which no other job compiles
-      # with CUDA on. LUMICE_NATIVE_ARCH=OFF matches the rest of CI.
+      # with CUDA on. LUMICE_ISA_LEVEL=baseline matches the rest of CI.
       - name: Configure (CUDA compile-only)
         run: >
           cmake -S . -B build -G Ninja
@@ -741,7 +741,7 @@ jobs:
           -DBUILD_TEST=ON
           -DBUILD_GUI=OFF
           -DLUMICE_CUDA_ENABLED=ON
-          -DLUMICE_NATIVE_ARCH=OFF
+          -DLUMICE_ISA_LEVEL=baseline
 
       # Build the Lumice CLI plus the test binaries; this drives nvcc through
       # cuda_trace_backend.cu and links CUDA::cudart, exercising both compile and
@@ -802,7 +802,7 @@ jobs:
 
       # BUILD_TEST=OFF + BUILD_GUI=OFF keep this job narrow: the build job above
       # already covers those targets, and skipping them avoids the OpenGL/X11
-      # deps and the GLAD2 Python generator. LUMICE_NATIVE_ARCH=OFF matches the
+      # deps and the GLAD2 Python generator. LUMICE_ISA_LEVEL=baseline matches the
       # rest of CI.
       - name: Configure (bench compile-only)
         run: >
@@ -811,7 +811,7 @@ jobs:
           -DBUILD_TEST=OFF
           -DBUILD_GUI=OFF
           -DBUILD_BENCH=ON
-          -DLUMICE_NATIVE_ARCH=OFF
+          -DLUMICE_ISA_LEVEL=baseline
 
       # Target-scoped on purpose: `lumice_bench` pulls in lumice_obj, so this
       # compiles every bench translation unit plus the core it links against,
@@ -923,7 +923,7 @@ jobs:
           -DBUILD_TEST=ON
           -DBUILD_GUI=ON
           -DBUILD_SHARED_LIBS=ON
-          -DLUMICE_NATIVE_ARCH=OFF
+          -DLUMICE_ISA_LEVEL=baseline
           -DCMAKE_C_COMPILER_LAUNCHER=ccache
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
@@ -960,7 +960,7 @@ jobs:
           -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/build/cmake_install/static
           -DBUILD_TEST=OFF
           -DBUILD_GUI=OFF
-          -DLUMICE_NATIVE_ARCH=OFF
+          -DLUMICE_ISA_LEVEL=baseline
 
       - name: Build
         run: cmake --build build --parallel
@@ -1136,7 +1136,7 @@ jobs:
           -DBUILD_TEST=OFF
           -DBUILD_GUI=OFF
           -DBUILD_SHARED_LIBS=ON
-          -DLUMICE_NATIVE_ARCH=OFF
+          -DLUMICE_ISA_LEVEL=baseline
 
       - name: Build
         run: cmake --build build --parallel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -899,11 +899,12 @@ jobs:
       - name: Set up MSVC
         uses: ilammy/msvc-dev-cmd@v1
 
+      # Not put on PATH, same as release.yml: the compiler is named by full path below, so
+      # nothing else in this job can pick LLVM up by accident.
       - name: Install clang-cl (LLVM, pinned)
         shell: pwsh
         run: |
           choco install llvm --version=20.1.0 -y --no-progress --allow-downgrade
-          echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           & "C:\Program Files\LLVM\bin\clang-cl.exe" --version
 
       - name: Install CUDA toolkit (nvcc + cudart_dev)
@@ -928,8 +929,8 @@ jobs:
           -DBUILD_GUI=OFF
           -DLUMICE_ISA_LEVEL=x86-64-v3
           -DLUMICE_CUDA_ENABLED=ON
-          -DCMAKE_CXX_COMPILER=clang-cl
-          -DCMAKE_C_COMPILER=clang-cl
+          -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe"
+          -DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe"
           -DCMAKE_CUDA_HOST_COMPILER=cl
 
       # The whole default graph: the CLI (lumice_obj at v3 under clang-cl, the .cu TU under

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -819,6 +819,52 @@ jobs:
       - name: Build lumice_bench (compile + link only, no run)
         run: cmake --build build --target lumice_bench --parallel
 
+  # x86-64-v4 compile-only. The Linux release ships a second, AVX-512 build of the engine
+  # (release.yml, linux-x64 row: two configures at LUMICE_ISA_LEVEL=baseline and =x86-64-v4,
+  # merged behind a CPUID launcher). Every other job here builds at baseline, so without
+  # this leg the -march=x86-64-v4 codegen path is first compiled on the day a tag is cut.
+  #
+  # Compile only, and BUILD_TEST=OFF — unlike cuda-compile, which turns tests ON. The CUDA
+  # cases self-skip for want of a device; an AVX-512 binary has no such graceful path. A
+  # GH-hosted runner may or may not have AVX-512, so running anything built here is a coin
+  # toss between "passes" and SIGILL, and neither outcome would say anything about the
+  # code. This job's claim stops at "GCC accepts -march=x86-64-v4 and the whole graph
+  # compiles". BUILD_GUI=OFF because the GUI shares lumice_obj with the CLI: whatever v4
+  # breaks, the CLI target already compiles it, and the GUI would only add its apt deps.
+  #
+  # Own cache discriminator, for the reason spelled out on bench-compile above: this
+  # configure's dependency set is the narrow one, and a shared `cpm-ubuntu-x64-` prefix
+  # would let the build job's fallback restore onto this job's small entry.
+  #
+  # No job-level `if:` — relies on the workflow-level `on: push: branches: [main]`
+  # / `pull_request` triggers, so this gate runs once per PR and once per push to
+  # main.
+  isa-v4-compile:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Cache CPM dependencies
+        uses: actions/cache@v6
+        with:
+          path: cpm_cache
+          key: cpm-isa-v4-ubuntu-x64-${{ hashFiles('**/CMakeLists.txt') }}
+          restore-keys: cpm-isa-v4-ubuntu-x64-
+
+      - name: Configure (x86-64-v4 compile-only)
+        run: >
+          cmake -S . -B build -G Ninja
+          -DCMAKE_BUILD_TYPE=Release
+          -DBUILD_TEST=OFF
+          -DBUILD_GUI=OFF
+          -DLUMICE_ISA_LEVEL=x86-64-v4
+
+      # The whole default graph: the CLI (so lumice_obj is compiled at v4 and linked) and
+      # the launcher (LumiceIsaLauncher, which every Linux x86_64 configure builds).
+      - name: Build (compile + link only, no run)
+        run: cmake --build build --parallel
+
   # Shared + tests + GUI compile-only: the one combination no other job builds.
   # The `build` job builds tests and the GUI but only statically; `e2e-slow` is the
   # only shared-library job and it passes -DBUILD_TEST=OFF -DBUILD_GUI=OFF. That gap

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -865,6 +865,94 @@ jobs:
       - name: Build (compile + link only, no run)
         run: cmake --build build --parallel
 
+  # x86-64-v3 under clang-cl, with CUDA on. The Windows release ships a second build of the
+  # engine compiled by clang-cl at -march=x86-64-v3 (release.yml, windows-x64 row: two
+  # configures, baseline on cl.exe and x86-64-v3 on clang-cl, merged behind a CPUID launcher).
+  # No other job here uses clang-cl at all, so without this leg the clang-cl (C/C++) x nvcc
+  # (.cu, cl.exe host) mixed compile — the one thing the Windows split gambles on that the Linux
+  # split did not — is first exercised on the day a tag is cut.
+  #
+  # Unlike isa-v4-compile this job also RUNS the binary, once, for --benchmark: v3 is AVX2,
+  # which every hosted x64 runner has, so there is no SIGILL coin toss, and the assertion it
+  # buys is the regression this whole path once had — CMake reports MSVC=TRUE for clang-cl,
+  # and a macro gated on if(MSVC) alone left every clang-cl build reporting "baseline" while
+  # -march was in fact applied. A green compile cannot see that; the isa key can.
+  # BUILD_TEST=OFF keeps the claim narrow (does the mixed toolchain build the engine, and does
+  # the tier reach the binary); BUILD_GUI=OFF for the reason isa-v4-compile gives.
+  #
+  # Own cache discriminator, before the platform name, for the reason spelled out on
+  # windows-cuda-compile above. The LLVM pin mirrors release.yml's — a compile gate for a
+  # toolchain the release does not use would be checking the wrong thing.
+  #
+  # No job-level `if:` — relies on the workflow-level `on: push: branches: [main]`
+  # / `pull_request` triggers, so this gate runs once per PR and once per push to
+  # main.
+  windows-isa-v3-compile:
+    runs-on: windows-2022
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      # Before the CUDA step, as on windows-cuda-compile: nvcc needs cl.exe on PATH as its
+      # host compiler, and so does this job's .cu translation unit even though every other
+      # TU goes through clang-cl.
+      - name: Set up MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Install clang-cl (LLVM, pinned)
+        shell: pwsh
+        run: |
+          choco install llvm --version=20.1.0 -y --no-progress --allow-downgrade
+          echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          & "C:\Program Files\LLVM\bin\clang-cl.exe" --version
+
+      - name: Install CUDA toolkit (nvcc + cudart_dev)
+        uses: Jimver/cuda-toolkit@v0.2.36
+        with:
+          cuda: '12.9.2'
+          method: 'network'
+          sub-packages: '["nvcc", "cudart"]'
+
+      - name: Cache CPM dependencies
+        uses: actions/cache@v6
+        with:
+          path: cpm_cache
+          key: cpm-isa-v3-windows-x64-${{ hashFiles('**/CMakeLists.txt') }}
+          restore-keys: cpm-isa-v3-windows-x64-
+
+      - name: Configure (x86-64-v3, clang-cl + nvcc/cl.exe, compile-only)
+        run: >
+          cmake -S . -B build -G Ninja
+          -DCMAKE_BUILD_TYPE=Release
+          -DBUILD_TEST=OFF
+          -DBUILD_GUI=OFF
+          -DLUMICE_ISA_LEVEL=x86-64-v3
+          -DLUMICE_CUDA_ENABLED=ON
+          -DCMAKE_CXX_COMPILER=clang-cl
+          -DCMAKE_C_COMPILER=clang-cl
+          -DCMAKE_CUDA_HOST_COMPILER=cl
+
+      # The whole default graph: the CLI (lumice_obj at v3 under clang-cl, the .cu TU under
+      # nvcc + cl.exe, linked by lld-link) and the Windows launcher (LumiceIsaLauncher, which
+      # every Windows x86_64 configure builds — here under clang-cl, which must accept it too).
+      - name: Build (compile + link only)
+        run: cmake --build build --parallel
+
+      # The one run this job makes. The output directory is the top-level CMakeLists.txt's
+      # CMAKE_RUNTIME_OUTPUT_DIRECTORY (anchored on the source dir, not on -B). Runs the
+      # legacy CPU backend: the CUDA-linked binary starts without a GPU (cudart is on PATH
+      # from the toolkit step, the device probe finds nothing and routes to CPU), which is
+      # the same thing windows-cuda-compile's test binaries already rely on.
+      - name: Assert the isa key reports x86-64-v3 under clang-cl
+        shell: pwsh
+        run: |
+          $out = & "build\Release\static\bin\Lumice.exe" --benchmark -f examples\bench_config.json 2>&1 | Out-String
+          if ($out -notmatch '"isa"\s*:\s*"x86-64-v3"') {
+            Write-Error "isa key did not report x86-64-v3 under clang-cl; output:`n$out"
+            exit 1
+          }
+          Write-Host "isa key reports x86-64-v3 (clang-cl, -march applied)."
+
   # Shared + tests + GUI compile-only: the one combination no other job builds.
   # The `build` job builds tests and the GUI but only statically; `e2e-slow` is the
   # only shared-library job and it passes -DBUILD_TEST=OFF -DBUILD_GUI=OFF. That gap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,10 @@ jobs:
       # The launcher comes from the baseline tree on purpose: it carries no -march flag in
       # either tree, but "the file that must run everywhere came from the build that runs
       # everywhere" is the invariant worth keeping obvious. The Package step below tars
-      # install/ unchanged.
+      # install/ unchanged. Only the six executables are copied: the install trees also hold
+      # what CPM dependencies' own install rules drop (GLFW and tl-expected headers, .a and
+      # cmake config files), which the single-build rows still ship because they tar the
+      # whole prefix; that was never product content, and this row no longer carries it.
       - name: Merge ISA variants behind the launcher (linux-x64)
         if: matrix.isa_split
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,12 +227,16 @@ jobs:
       # LLVM is installed from Chocolatey at a pinned version rather than taken from whatever
       # the runner image ships: the 2.26x figure was measured on 20.1.0, and an image update
       # moving the compiler under a release is exactly the drift a pin exists to stop.
+      # It is NOT put on PATH, and both trees name their compiler explicitly. The first dispatch
+      # of this row prepended LLVM\bin to PATH and let the baseline tree take CMake's default
+      # compiler: with Ninja, CMake's search list reaches `clang++` before `cl`, so the tree
+      # that exists to be the MSVC build was silently compiled by clang's GNU-style driver
+      # (MSVC=FALSE, no NOMINMAX, `std::max` broken by windows.h) and the job went red there.
       - name: Install clang-cl (LLVM, pinned)
         if: matrix.isa_split && runner.os == 'Windows'
         shell: pwsh
         run: |
           choco install llvm --version=20.1.0 -y --no-progress --allow-downgrade
-          echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           & "C:\Program Files\LLVM\bin\clang-cl.exe" --version
 
       # pwsh, three commands per step: the runner only checks the LAST native command's exit
@@ -249,6 +253,8 @@ jobs:
             -DBUILD_GUI=${{ matrix.build_gui }} `
             -DLUMICE_ISA_LEVEL=baseline `
             -DLUMICE_CUDA_ENABLED=${{ matrix.cuda || 'OFF' }} `
+            -DCMAKE_CXX_COMPILER=cl `
+            -DCMAKE_C_COMPILER=cl `
             ${{ env.LUMICE_PYTHON_ARGS }}
           if ($LASTEXITCODE) { exit $LASTEXITCODE }
           cmake --build build-baseline --parallel
@@ -266,8 +272,8 @@ jobs:
             -DBUILD_GUI=${{ matrix.build_gui }} `
             -DLUMICE_ISA_LEVEL=x86-64-v3 `
             -DLUMICE_CUDA_ENABLED=${{ matrix.cuda || 'OFF' }} `
-            -DCMAKE_CXX_COMPILER=clang-cl `
-            -DCMAKE_C_COMPILER=clang-cl `
+            -DCMAKE_CXX_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe" `
+            -DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe" `
             -DCMAKE_CUDA_HOST_COMPILER=cl `
             ${{ env.LUMICE_PYTHON_ARGS }}
           if ($LASTEXITCODE) { exit $LASTEXITCODE }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,8 @@ jobs:
         include:
           # linux-x64 is built TWICE (baseline + x86-64-v4) and merged behind a CPUID
           # launcher — see the "ISA variants" steps below; the shared Configure/Build/
-          # Install steps skip this row.
+          # Install steps skip this row. windows-x64 below is split the same way
+          # (baseline + x86-64-v3), so every isa_split step also names its runner.os.
           - name: linux-x64
             os: ubuntu-24.04
             build_gui: ON
@@ -79,6 +80,7 @@ jobs:
             ext: zip
             msvc: true
             cuda: ON  # ship a CUDA-enabled Windows artifact (multi-arch fatbin)
+            isa_split: true  # baseline (MSVC cl.exe) + x86-64-v3 (clang-cl) behind the launcher
 
     runs-on: ${{ matrix.os }}
     name: Build ${{ matrix.name }}
@@ -167,7 +169,7 @@ jobs:
       # re-download. Cost: roughly 2x this row's build time (release runs on tags and manual
       # dispatch only, never as a PR gate).
       - name: Configure, build and install (linux-x64, baseline)
-        if: matrix.isa_split
+        if: matrix.isa_split && runner.os == 'Linux'
         run: |
           cmake -S . -B build-baseline -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
@@ -179,7 +181,7 @@ jobs:
           cmake --install build-baseline
 
       - name: Configure, build and install (linux-x64, x86-64-v4)
-        if: matrix.isa_split
+        if: matrix.isa_split && runner.os == 'Linux'
         run: |
           cmake -S . -B build-v4 -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
@@ -198,7 +200,7 @@ jobs:
       # cmake config files), which the single-build rows still ship because they tar the
       # whole prefix; that was never product content, and this row no longer carries it.
       - name: Merge ISA variants behind the launcher (linux-x64)
-        if: matrix.isa_split
+        if: matrix.isa_split && runner.os == 'Linux'
         run: |
           mkdir -p install
           for name in Lumice LumiceGUI; do
@@ -208,6 +210,96 @@ jobs:
           done
           chmod +x install/*
           ls -l install
+
+      # ISA variants (windows-x64). Same shape as linux-x64 above with one more moving part:
+      # the second tier is a different COMPILER, not just a different flag. Real MSVC cl.exe
+      # has no -march equivalent and its /arch flags measured at ~1% on this engine, while
+      # clang-cl (LLVM's MSVC-compatible driver) takes ~2.26x at -march=x86-64-v3 (AVX2+FMA)
+      # on the Windows reference box — so the baseline tree stays on cl.exe (the toolchain that
+      # ships today; nothing about it changes) and only the x86-64-v3 tree switches the C/C++
+      # compiler to clang-cl. The .cu translation unit is compiled by nvcc with cl.exe as its
+      # host compiler in BOTH trees (nvcc on Windows supports no other host compiler;
+      # CMAKE_CUDA_HOST_COMPILER=cl states that on the command line even though nvcc finds
+      # cl.exe on the PATH msvc-dev-cmd set up). The launcher (src/launcher/isa_launcher_win.c)
+      # is taken from the baseline tree like on Linux; the v3 tree compiles its own copy too,
+      # which is discarded — a single-file C program, seconds against two full engine builds,
+      # and not worth a CMake switch of its own.
+      # LLVM is installed from Chocolatey at a pinned version rather than taken from whatever
+      # the runner image ships: the 2.26x figure was measured on 20.1.0, and an image update
+      # moving the compiler under a release is exactly the drift a pin exists to stop.
+      - name: Install clang-cl (LLVM, pinned)
+        if: matrix.isa_split && runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install llvm --version=20.1.0 -y --no-progress --allow-downgrade
+          echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          & "C:\Program Files\LLVM\bin\clang-cl.exe" --version
+
+      # pwsh, three commands per step: the runner only checks the LAST native command's exit
+      # code, so each cmake call is followed by its own exit check — a failed build must not
+      # be masked by a succeeding install of whatever was there.
+      - name: Configure, build and install (windows-x64, baseline, MSVC cl.exe)
+        if: matrix.isa_split && runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          cmake -S . -B build-baseline -G Ninja `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install-baseline `
+            -DBUILD_TEST=OFF `
+            -DBUILD_GUI=${{ matrix.build_gui }} `
+            -DLUMICE_ISA_LEVEL=baseline `
+            -DLUMICE_CUDA_ENABLED=${{ matrix.cuda || 'OFF' }} `
+            ${{ env.LUMICE_PYTHON_ARGS }}
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          cmake --build build-baseline --parallel
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          cmake --install build-baseline
+
+      - name: Configure, build and install (windows-x64, x86-64-v3, clang-cl)
+        if: matrix.isa_split && runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          cmake -S . -B build-v3 -G Ninja `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install-v3 `
+            -DBUILD_TEST=OFF `
+            -DBUILD_GUI=${{ matrix.build_gui }} `
+            -DLUMICE_ISA_LEVEL=x86-64-v3 `
+            -DLUMICE_CUDA_ENABLED=${{ matrix.cuda || 'OFF' }} `
+            -DCMAKE_CXX_COMPILER=clang-cl `
+            -DCMAKE_C_COMPILER=clang-cl `
+            -DCMAKE_CUDA_HOST_COMPILER=cl `
+            ${{ env.LUMICE_PYTHON_ARGS }}
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          cmake --build build-v3 --parallel
+          if ($LASTEXITCODE) { exit $LASTEXITCODE }
+          cmake --install build-v3
+
+      # Launcher from the baseline (cl.exe) tree, as on Linux. `$ErrorActionPreference = 'Stop'`
+      # is not boilerplate: PowerShell's default is Continue, under which a Copy-Item whose
+      # source is missing is a NON-terminating error — the script would run on, the zip would
+      # ship without that file, and the job would still be green. The trailing check turns
+      # "all six executables are present" from a thing someone reads off the zip listing into
+      # a red the workflow raises itself.
+      - name: Merge ISA variants behind the launcher (windows-x64)
+        if: matrix.isa_split && runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          New-Item -ItemType Directory -Force -Path install | Out-Null
+          $expected = @()
+          foreach ($name in @('Lumice', 'LumiceGUI')) {
+            Copy-Item "install-baseline\$name.exe" "install\$name.baseline.exe"
+            Copy-Item "install-v3\$name.exe" "install\$name.x86-64-v3.exe"
+            Copy-Item "install-baseline\LumiceIsaLauncher.exe" "install\$name.exe"
+            $expected += "$name.baseline.exe", "$name.x86-64-v3.exe", "$name.exe"
+          }
+          Get-ChildItem install
+          $missing = $expected | Where-Object { -not (Test-Path "install\$_") }
+          if ($missing) {
+            Write-Error "Merge produced an incomplete package, missing: $($missing -join ', ')"
+            exit 1
+          }
 
       # Bundle the dynamic CUDA runtime next to the executables so the CUDA
       # backend loads on a user machine that has an NVIDIA driver but no CUDA

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # linux-x64 is built TWICE (baseline + x86-64-v4) and merged behind a CPUID
+          # launcher — see the "ISA variants" steps below; the shared Configure/Build/
+          # Install steps skip this row.
           - name: linux-x64
             os: ubuntu-24.04
             build_gui: ON
             ext: tar.gz
+            isa_split: true
 
           - name: linux-arm64
             os: ubuntu-24.04-arm
@@ -134,21 +138,73 @@ jobs:
           restore-keys: cpm-${{ matrix.name }}-
 
       - name: Configure
+        if: '!matrix.isa_split'
         run: >
           cmake -S . -B build -G Ninja
           -DCMAKE_BUILD_TYPE=Release
           -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install
           -DBUILD_TEST=OFF
           -DBUILD_GUI=${{ matrix.build_gui }}
-          -DLUMICE_NATIVE_ARCH=OFF
+          -DLUMICE_ISA_LEVEL=baseline
           -DLUMICE_CUDA_ENABLED=${{ matrix.cuda || 'OFF' }}
           ${{ env.LUMICE_PYTHON_ARGS }}
 
       - name: Build
+        if: '!matrix.isa_split'
         run: cmake --build build --parallel
 
       - name: Install
+        if: '!matrix.isa_split'
         run: cmake --install build
+
+      # ISA variants (linux-x64 only). The x86-64-v4 (AVX-512) build of the engine is ~2x the
+      # baseline on CPUs that have it and SIGILLs on the rest, and a user cannot be asked to
+      # know which they own — so the package carries both builds of every entry point plus a
+      # launcher (src/launcher/isa_launcher.c) installed under the entry-point names that picks
+      # one by CPUID at run time. Two full configures, not one: -march is baked into every
+      # lumice_obj object file, so one build tree cannot produce both tiers. They run serially
+      # in this job and share its CPM cache, so the second pass re-compiles but does not
+      # re-download. Cost: roughly 2x this row's build time (release runs on tags and manual
+      # dispatch only, never as a PR gate).
+      - name: Configure, build and install (linux-x64, baseline)
+        if: matrix.isa_split
+        run: |
+          cmake -S . -B build-baseline -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install-baseline \
+            -DBUILD_TEST=OFF \
+            -DBUILD_GUI=${{ matrix.build_gui }} \
+            -DLUMICE_ISA_LEVEL=baseline
+          cmake --build build-baseline --parallel
+          cmake --install build-baseline
+
+      - name: Configure, build and install (linux-x64, x86-64-v4)
+        if: matrix.isa_split
+        run: |
+          cmake -S . -B build-v4 -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install-v4 \
+            -DBUILD_TEST=OFF \
+            -DBUILD_GUI=${{ matrix.build_gui }} \
+            -DLUMICE_ISA_LEVEL=x86-64-v4
+          cmake --build build-v4 --parallel
+          cmake --install build-v4
+
+      # The launcher comes from the baseline tree on purpose: it carries no -march flag in
+      # either tree, but "the file that must run everywhere came from the build that runs
+      # everywhere" is the invariant worth keeping obvious. The Package step below tars
+      # install/ unchanged.
+      - name: Merge ISA variants behind the launcher (linux-x64)
+        if: matrix.isa_split
+        run: |
+          mkdir -p install
+          for name in Lumice LumiceGUI; do
+            cp install-baseline/$name install/$name.baseline
+            cp install-v4/$name       install/$name.x86-64-v4
+            cp install-baseline/LumiceIsaLauncher install/$name
+          done
+          chmod +x install/*
+          ls -l install
 
       # Bundle the dynamic CUDA runtime next to the executables so the CUDA
       # backend loads on a user machine that has an NVIDIA driver but no CUDA

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,14 +113,16 @@ jobs:
             libgtk-3-dev
 
       # CUDA toolkit for the CUDA-enabled Windows artifact (nvcc + cudart).
-      # Pinned to 12.6.3 to match ci.yml's windows-cuda-compile gate; supports
-      # the windows-2022 VS 2022 host compiler and emits the full multi-arch
-      # fatbin (compute_61 PTX + sm_75/86/89 SASS, see CMakeLists.txt).
+      # Pinned to 12.9.2 to match ci.yml's windows-cuda-compile gate (the pin
+      # rationale — why the CUDA major, VS 2022 and windows-2022 move as one —
+      # lives on that job); supports the windows-2022 VS 2022 host compiler
+      # and emits the full multi-arch fatbin (compute_61 PTX +
+      # sm_75/86/89/120 SASS, see CMakeLists.txt).
       - name: Install CUDA toolkit (Windows CUDA artifact)
         if: matrix.cuda == 'ON'
         uses: Jimver/cuda-toolkit@v0.2.36
         with:
-          cuda: '12.6.3'
+          cuda: '12.9.2'
           method: 'network'
           sub-packages: '["nvcc", "cudart"]'
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,8 +105,14 @@ before downloading into it).
   `src/util/fatal.hpp`, the single owner of the pre-abort trap, where unbuffered stderr is the whole
   point — a per-message-unflushed file sink can lose the line precisely when it matters. For an
   unrecoverable invariant call `lumice::FatalAbort(...)` instead of hand-rolling print-then-`abort()`.
-  Enforced by the `no-bare-print` rule in `scripts/check_policies.py`, which also scans `.cu` / `.metal`
-  so a GPU backend cannot reopen the side channel. `test/` is deliberately out of scope: test binaries
+  A third file sits outside the rule by construction rather than by name: `src/launcher/isa_launcher.c`,
+  the Linux release's CPUID launcher, links nothing from the engine (no `lumice_obj`, so no `ILOG_*`
+  exists for it to bypass) and its two error lines go to stderr because there is no other sink in
+  that process. The checker never sees it — its scan covers C++/CUDA/Metal suffixes, not `.c` — which
+  is consistent with what the rule guards (the engine's unified sinks), not a loophole to reuse:
+  a `.c` file that *does* link the engine would still be wrong. Enforced by the `no-bare-print` rule
+  in `scripts/check_policies.py`, which also scans `.cu` / `.metal` so a GPU backend cannot reopen
+  the side channel. `test/` is deliberately out of scope: test binaries
   are their own harness with no app logger to bypass, and some of their output is a parsed contract
   (the regen driver reads gui_test's `PSNR=` line). Device-side `printf` in a CUDA kernel stays a
   legitimate debugging tool — the gate does not stop you adding one while working, only from landing it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,12 +105,13 @@ before downloading into it).
   `src/util/fatal.hpp`, the single owner of the pre-abort trap, where unbuffered stderr is the whole
   point — a per-message-unflushed file sink can lose the line precisely when it matters. For an
   unrecoverable invariant call `lumice::FatalAbort(...)` instead of hand-rolling print-then-`abort()`.
-  A third file sits outside the rule by construction rather than by name: `src/launcher/isa_launcher.c`,
-  the Linux release's CPUID launcher, links nothing from the engine (no `lumice_obj`, so no `ILOG_*`
-  exists for it to bypass) and its two error lines go to stderr because there is no other sink in
-  that process. The checker never sees it — its scan covers C++/CUDA/Metal suffixes, not `.c` — which
-  is consistent with what the rule guards (the engine's unified sinks), not a loophole to reuse:
-  a `.c` file that *does* link the engine would still be wrong. Enforced by the `no-bare-print` rule
+  A third place sits outside the rule by construction rather than by name: `src/launcher/`, the
+  release CPUID launchers (`isa_launcher.c` for Linux, `isa_launcher_win.c` for Windows), link
+  nothing from the engine (no `lumice_obj`, so no `ILOG_*` exists for them to bypass) and their few
+  error lines go to stderr because there is no other sink in that process. The checker never sees
+  them — its scan covers C++/CUDA/Metal suffixes, not `.c` — which is consistent with what the rule
+  guards (the engine's unified sinks), not a loophole to reuse: a `.c` file that *does* link the
+  engine would still be wrong. Enforced by the `no-bare-print` rule
   in `scripts/check_policies.py`, which also scans `.cu` / `.metal` so a GPU backend cannot reopen
   the side channel. `test/` is deliberately out of scope: test binaries
   are their own harness with no app logger to bypass, and some of their output is a parsed contract

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,24 +40,39 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)   #...is required...
 set(CMAKE_CXX_EXTENSIONS OFF)         #...without compiler extensions like gnu++11
 set(CMAKE_C_STANDARD 11)              # C11...
 
-# ISA tier a Release build is compiled for (GCC/Clang only; MSVC has no equivalent flag and
-# is always the baseline). One three-valued variable, not a boolean plus a second knob: the
-# Linux release ships TWO builds of this tree (baseline + x86-64-v4) behind a CPUID launcher,
-# and "which tier is this?" must have exactly one answer per configure.
+# ISA tier a Release build is compiled for (compilers that honor -march: GCC, Clang and
+# clang-cl; real MSVC cl.exe has no equivalent flag wired up and is always the baseline). One
+# four-valued variable, not a boolean plus a second knob: the Linux and Windows releases each
+# ship TWO builds of this tree behind a CPUID launcher, and "which tier is this?" must have
+# exactly one answer per configure.
 #   baseline   no -march flag: the x86-64-v1 floor every x86_64 CPU runs; what CI tests
+#   x86-64-v3  -march=x86-64-v3 (AVX2+FMA): the second Windows release variant (clang-cl —
+#              LLVM takes its whole ~2.26x at v3, where GCC takes none of it; see
+#              doc/performance-testing.md)
 #   x86-64-v4  -march=x86-64-v4 (AVX-512): the second Linux release variant
 #   native     -march=native: local default, a developer machine builds for itself
 set(LUMICE_ISA_LEVEL "native" CACHE STRING
-    "ISA tier for Release builds: baseline | x86-64-v4 | native (GCC/Clang only)")
-set_property(CACHE LUMICE_ISA_LEVEL PROPERTY STRINGS baseline x86-64-v4 native)
-if(NOT LUMICE_ISA_LEVEL MATCHES "^(baseline|x86-64-v4|native)$")
-  message(FATAL_ERROR "LUMICE_ISA_LEVEL=\"${LUMICE_ISA_LEVEL}\" is not one of: baseline, x86-64-v4, native")
+    "ISA tier for Release builds: baseline | x86-64-v3 | x86-64-v4 | native (GCC/Clang/clang-cl only)")
+set_property(CACHE LUMICE_ISA_LEVEL PROPERTY STRINGS baseline x86-64-v3 x86-64-v4 native)
+if(NOT LUMICE_ISA_LEVEL MATCHES "^(baseline|x86-64-v3|x86-64-v4|native)$")
+  message(FATAL_ERROR "LUMICE_ISA_LEVEL=\"${LUMICE_ISA_LEVEL}\" is not one of: baseline, x86-64-v3, x86-64-v4, native")
 endif()
-if(LUMICE_ISA_LEVEL STREQUAL "x86-64-v4" AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|amd64)$")
+if(LUMICE_ISA_LEVEL MATCHES "^x86-64-v[34]$" AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|amd64)$")
   # Fail here, in words, rather than a few hundred lines into the build with a compiler
   # error about an unknown -march value on an arm64 host.
-  message(FATAL_ERROR "LUMICE_ISA_LEVEL=x86-64-v4 is an x86_64 tier; CMAKE_SYSTEM_PROCESSOR is "
+  message(FATAL_ERROR "LUMICE_ISA_LEVEL=${LUMICE_ISA_LEVEL} is an x86_64 tier; CMAKE_SYSTEM_PROCESSOR is "
                       "\"${CMAKE_SYSTEM_PROCESSOR}\"")
+endif()
+
+# clang-cl: CMake reports MSVC=TRUE for it (it drives the MSVC ABI, CRT and /-style flags), yet
+# it is a Clang frontend that honors -march. That one fact is why the Windows release's
+# x86-64-v3 variant exists at all (the ISA-tier STATUS message and lumice_apply_isa_march()
+# below both branch on it), so it is computed once, here, and nowhere else. Not a cache
+# entry: it is derived from the chosen compiler every configure and must never go stale.
+set(LUMICE_CLANG_CL FALSE)
+if(MSVC AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
+   AND CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+  set(LUMICE_CLANG_CL TRUE)
 endif()
 
 # CUDA backend (off by default; turn on for dev49 docker CUDA 11.6+ environments).
@@ -89,20 +104,28 @@ endif()
 # time, whereas the -march gate below adds $<CONFIG:Release> and is only resolved
 # per-configuration at generate/build time, so an assertive phrasing would be wrong for a
 # Debug build with a non-baseline tier selected.
-if(MSVC)
-  message(STATUS "LUMICE_ISA_LEVEL: not applicable to MSVC (no equivalent flag is wired "
-                 "up); this build is the release ISA baseline.")
+if(MSVC AND NOT LUMICE_CLANG_CL)
+  message(STATUS "LUMICE_ISA_LEVEL: not applicable to MSVC cl.exe (no equivalent flag is "
+                 "wired up); this build is the release ISA baseline.")
 elseif(LUMICE_ISA_LEVEL STREQUAL "native")
   message(STATUS "LUMICE_ISA_LEVEL=native (local default): a Release build would apply "
                  "-march=native, so its binary is NOT one release ships. Fine for local "
                  "iteration; take any cross-platform or externally quoted throughput number "
                  "with -DLUMICE_ISA_LEVEL=baseline instead. See doc/performance-testing.md.")
+elseif(LUMICE_ISA_LEVEL STREQUAL "x86-64-v3")
+  message(STATUS "LUMICE_ISA_LEVEL=x86-64-v3: a Release build would apply -march=x86-64-v3 "
+                 "(AVX2+FMA); this is the Windows release's second variant (clang-cl) and "
+                 "runs only on CPUs the ISA launcher selects it for.")
 elseif(LUMICE_ISA_LEVEL STREQUAL "x86-64-v4")
   message(STATUS "LUMICE_ISA_LEVEL=x86-64-v4: a Release build would apply -march=x86-64-v4 "
                  "(AVX-512); this is the Linux release's second variant and runs only on "
                  "CPUs the ISA launcher selects it for.")
 else()
   message(STATUS "LUMICE_ISA_LEVEL=baseline: this build matches the release ISA baseline.")
+endif()
+if(LUMICE_CLANG_CL)
+  message(STATUS "clang-cl detected (MSVC=TRUE, Clang frontend): the -march tier above applies "
+                 "through lumice_apply_isa_march(); the MSVC-only flag set does not.")
 endif()
 
 # Persist the compiler id into CMakeCache.txt for test tooling that has to answer "was
@@ -756,6 +779,40 @@ if(LUMICE_CUDA_ENABLED)
   endif()
 endif()
 
+# Single source of truth for "this compile actually applies a -march flag", shared by the
+# GCC/Clang path (the if(NOT MSVC) block below) and the clang-cl path (the if(LUMICE_CLANG_CL)
+# block after it). One function rather than two inline copies: every future ISA-tier change
+# would otherwise be a two-site edit, and the site that gets missed is the one whose `isa`
+# key then quietly reports the wrong tier on one platform — the same failure shape as the
+# probe that found clang-cl at all, where every arm reported "baseline" because the macro was
+# gated on if(MSVC). Both the compile-option gate and the LUMICE_ISA_LEVEL_STR macro that
+# reports the tier in --benchmark output reference the one _active_cond expression, so the
+# flag and the number's provenance cannot independently drift out of sync. (Its inner
+# $<CONFIG:Release> is redundant with the outer $<$<CONFIG:Release>:...> wrapper; that
+# redundancy is the price of the two gates being literally the same expression.)
+# Scoped to `target`'s own compile: the -march flag is PRIVATE (each object file is compiled
+# for one tier), the macro is PUBLIC (see the comment at that call).
+function(lumice_apply_isa_march target)
+  if(LUMICE_ISA_LEVEL STREQUAL "baseline")
+    set(_march_flag "")
+  else()
+    set(_march_flag "-march=${LUMICE_ISA_LEVEL}")
+  endif()
+  set(_active_cond "$<AND:$<CONFIG:Release>,$<BOOL:${_march_flag}>>")
+  target_compile_options(${target} PRIVATE
+    $<$<CONFIG:Release>:$<${_active_cond}:${_march_flag}>>)
+  # PUBLIC, not PRIVATE: src/main.cpp is not part of lumice_obj — it reaches this macro
+  # through Lumice --PRIVATE--> lumice --PUBLIC--> lumice_obj, the same two-hop usage
+  # requirement chain LUMICE_CUDA_ENABLED already relies on above. The value is the tier
+  # name when the -march flag above is actually applied and "baseline" otherwise (Debug,
+  # MinSizeRel, or the baseline tier itself), so what the binary reports is what it was
+  # compiled with, never what was merely asked for. No counterpart for real MSVC cl.exe:
+  # neither block below runs there, the macro is never defined, and main.cpp's #else falls
+  # back to "baseline".
+  target_compile_definitions(${target} PUBLIC
+    "LUMICE_ISA_LEVEL_STR=\"$<IF:${_active_cond},${LUMICE_ISA_LEVEL},baseline>\"")
+endfunction()
+
 if(NOT MSVC)
   # -Werror=switch is a GCC/Clang host flag; nvcc parses -Werror itself (does
   # NOT forward it) and rejects "switch" as an invalid value. Scope it to CXX so
@@ -769,33 +826,24 @@ if(NOT MSVC)
   # Debug 构建不设置此标志，所有符号均可见，便于调试。
   # NOTE: 当前仅支持 GCC/Clang。若需支持 MSVC 共享库，需将 pragma 改为
   # LUMICE_API 宏（__declspec(dllexport/dllimport)），参见 lumice.h 中的注释。
-  # Single source of truth for "this compile actually applies a -march flag". Both the
-  # compile-option gate below and the LUMICE_ISA_LEVEL_STR macro that reports the ISA tier
-  # in --benchmark output reference this one condition, so the flag and the number's
-  # provenance cannot independently drift out of sync. (Its inner $<CONFIG:Release> is
-  # redundant with the outer $<$<CONFIG:Release>:...> wrapper below; that redundancy is the
-  # price of the two gates being literally the same expression.)
-  if(LUMICE_ISA_LEVEL STREQUAL "baseline")
-    set(LUMICE_ISA_MARCH_FLAG "")
-  else()
-    set(LUMICE_ISA_MARCH_FLAG "-march=${LUMICE_ISA_LEVEL}")
-  endif()
-  set(LUMICE_ISA_LEVEL_ACTIVE_COND "$<AND:$<CONFIG:Release>,$<BOOL:${LUMICE_ISA_MARCH_FLAG}>>")
-
   target_compile_options(lumice_obj PRIVATE
     $<$<CONFIG:Debug>:-O0 -g -ggdb>
-    $<$<CONFIG:Release>:$<${LUMICE_ISA_LEVEL_ACTIVE_COND}:${LUMICE_ISA_MARCH_FLAG}> -ffunction-sections -fdata-sections -fvisibility=hidden>
+    $<$<CONFIG:Release>:-ffunction-sections -fdata-sections -fvisibility=hidden>
     $<$<CONFIG:MinSizeRel>:-ffunction-sections -fdata-sections -fvisibility=hidden>)
+  lumice_apply_isa_march(lumice_obj)
+endif()
 
-  # PUBLIC, not PRIVATE: src/main.cpp is not part of lumice_obj — it reaches this macro
-  # through Lumice --PRIVATE--> lumice --PUBLIC--> lumice_obj, the same two-hop usage
-  # requirement chain LUMICE_CUDA_ENABLED already relies on above. The value is the tier
-  # name when the -march flag above is actually applied and "baseline" otherwise (Debug,
-  # MinSizeRel, or the baseline tier itself), so what the binary reports is what it was
-  # compiled with, never what was merely asked for. No MSVC counterpart is needed: the macro
-  # is never defined there, and main.cpp's #else falls back to "baseline".
-  target_compile_definitions(lumice_obj PUBLIC
-    "LUMICE_ISA_LEVEL_STR=\"$<IF:${LUMICE_ISA_LEVEL_ACTIVE_COND},${LUMICE_ISA_LEVEL},baseline>\"")
+if(LUMICE_CLANG_CL)
+  # clang-cl reports MSVC=TRUE but IS a Clang frontend that honors -march: measured on the
+  # Windows reference box, -march=x86-64-v3 is ~2.26x real MSVC's release build at W=1, where
+  # cl.exe's own /arch flags move nothing (doc/performance-testing.md). Deliberately NOT folded
+  # into the if(NOT MSVC) block above: that block also turns on -Wall/-Werror=switch,
+  # SPDLOG_ACTIVE_LEVEL=TRACE and -fvisibility=hidden, none of which the Windows release needs
+  # or has been validated under clang-cl. The march-flag mapping itself is the shared
+  # lumice_apply_isa_march() above, not a second copy here. Nothing else: clang-cl otherwise
+  # takes the MSVC platform defaults (/EHsc, /GR, the static CRT chosen in the MSVC block),
+  # which is what makes it a drop-in for the .cu host side that still goes through cl.exe.
+  lumice_apply_isa_march(lumice_obj)
 endif()
 
 # Library target — static or shared per BUILD_SHARED_LIBS; reuses lumice_obj objects.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,25 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)   #...is required...
 set(CMAKE_CXX_EXTENSIONS OFF)         #...without compiler extensions like gnu++11
 set(CMAKE_C_STANDARD 11)              # C11...
 
-option(LUMICE_NATIVE_ARCH "Enable -march=native for release builds (GCC/Clang)" ON)
+# ISA tier a Release build is compiled for (GCC/Clang only; MSVC has no equivalent flag and
+# is always the baseline). One three-valued variable, not a boolean plus a second knob: the
+# Linux release ships TWO builds of this tree (baseline + x86-64-v4) behind a CPUID launcher,
+# and "which tier is this?" must have exactly one answer per configure.
+#   baseline   no -march flag: the x86-64-v1 floor every x86_64 CPU runs; what CI tests
+#   x86-64-v4  -march=x86-64-v4 (AVX-512): the second Linux release variant
+#   native     -march=native: local default, a developer machine builds for itself
+set(LUMICE_ISA_LEVEL "native" CACHE STRING
+    "ISA tier for Release builds: baseline | x86-64-v4 | native (GCC/Clang only)")
+set_property(CACHE LUMICE_ISA_LEVEL PROPERTY STRINGS baseline x86-64-v4 native)
+if(NOT LUMICE_ISA_LEVEL MATCHES "^(baseline|x86-64-v4|native)$")
+  message(FATAL_ERROR "LUMICE_ISA_LEVEL=\"${LUMICE_ISA_LEVEL}\" is not one of: baseline, x86-64-v4, native")
+endif()
+if(LUMICE_ISA_LEVEL STREQUAL "x86-64-v4" AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|amd64)$")
+  # Fail here, in words, rather than a few hundred lines into the build with a compiler
+  # error about an unknown -march value on an arm64 host.
+  message(FATAL_ERROR "LUMICE_ISA_LEVEL=x86-64-v4 is an x86_64 tier; CMAKE_SYSTEM_PROCESSOR is "
+                      "\"${CMAKE_SYSTEM_PROCESSOR}\"")
+endif()
 
 # CUDA backend (off by default; turn on for dev49 docker CUDA 11.6+ environments).
 # scrum-cuda-backend-mvp subtask 3: enables CudaTraceBackend + lumice_trace.cu.
@@ -60,26 +78,31 @@ if(MSVC)
 endif()
 
 # Make the local-build-vs-shipped-binary ISA gap visible at configure time. Local
-# scripts/build.sh does not pass LUMICE_NATIVE_ARCH and therefore takes the ON default,
-# while release.yml and every ci.yml job pass -DLUMICE_NATIVE_ARCH=OFF explicitly. That
-# default is deliberate (a developer machine should build for itself and run fast); what
-# it must not do is stay invisible at the point where someone reads a throughput number
-# off this build and compares it with another platform. See doc/performance-testing.md,
-# section "Local builds are not the shipped binary".
+# scripts/build.sh does not pass LUMICE_ISA_LEVEL and therefore takes the "native" default,
+# while every ci.yml job passes -DLUMICE_ISA_LEVEL=baseline explicitly and release.yml builds
+# the Linux x64 package once at baseline and once at x86-64-v4. That default is deliberate
+# (a developer machine should build for itself and run fast); what it must not do is stay
+# invisible at the point where someone reads a throughput number off this build and
+# compares it with another platform. See doc/performance-testing.md, section "Local builds
+# are not the shipped binary".
 # Deliberately conditional wording ("would apply"): this message runs once at configure
-# time, whereas the -march=native gate below adds $<CONFIG:Release> and is only resolved
+# time, whereas the -march gate below adds $<CONFIG:Release> and is only resolved
 # per-configuration at generate/build time, so an assertive phrasing would be wrong for a
-# Debug build with the option ON.
+# Debug build with a non-baseline tier selected.
 if(MSVC)
-  message(STATUS "LUMICE_NATIVE_ARCH: not applicable to MSVC (no equivalent flag is wired "
-                 "up); this build already matches the release ISA baseline.")
-elseif(LUMICE_NATIVE_ARCH)
-  message(STATUS "LUMICE_NATIVE_ARCH=ON (local default): a Release build would apply "
-                 "-march=native, so its binary is NOT the one release ships. Fine for local "
+  message(STATUS "LUMICE_ISA_LEVEL: not applicable to MSVC (no equivalent flag is wired "
+                 "up); this build is the release ISA baseline.")
+elseif(LUMICE_ISA_LEVEL STREQUAL "native")
+  message(STATUS "LUMICE_ISA_LEVEL=native (local default): a Release build would apply "
+                 "-march=native, so its binary is NOT one release ships. Fine for local "
                  "iteration; take any cross-platform or externally quoted throughput number "
-                 "with -DLUMICE_NATIVE_ARCH=OFF instead. See doc/performance-testing.md.")
+                 "with -DLUMICE_ISA_LEVEL=baseline instead. See doc/performance-testing.md.")
+elseif(LUMICE_ISA_LEVEL STREQUAL "x86-64-v4")
+  message(STATUS "LUMICE_ISA_LEVEL=x86-64-v4: a Release build would apply -march=x86-64-v4 "
+                 "(AVX-512); this is the Linux release's second variant and runs only on "
+                 "CPUs the ISA launcher selects it for.")
 else()
-  message(STATUS "LUMICE_NATIVE_ARCH=OFF: this build matches the release ISA baseline.")
+  message(STATUS "LUMICE_ISA_LEVEL=baseline: this build matches the release ISA baseline.")
 endif()
 
 # Persist the compiler id into CMakeCache.txt for test tooling that has to answer "was
@@ -746,25 +769,33 @@ if(NOT MSVC)
   # Debug 构建不设置此标志，所有符号均可见，便于调试。
   # NOTE: 当前仅支持 GCC/Clang。若需支持 MSVC 共享库，需将 pragma 改为
   # LUMICE_API 宏（__declspec(dllexport/dllimport)），参见 lumice.h 中的注释。
-  # Single source of truth for "this compile actually applies -march=native". Both the
-  # compile-option gate below and the LUMICE_NATIVE_ARCH_ACTIVE macro that reports the ISA
-  # tier in --benchmark output reference this one variable, so the flag and the number's
+  # Single source of truth for "this compile actually applies a -march flag". Both the
+  # compile-option gate below and the LUMICE_ISA_LEVEL_STR macro that reports the ISA tier
+  # in --benchmark output reference this one condition, so the flag and the number's
   # provenance cannot independently drift out of sync. (Its inner $<CONFIG:Release> is
   # redundant with the outer $<$<CONFIG:Release>:...> wrapper below; that redundancy is the
   # price of the two gates being literally the same expression.)
-  set(LUMICE_NATIVE_ARCH_ACTIVE_COND "$<AND:$<CONFIG:Release>,$<BOOL:${LUMICE_NATIVE_ARCH}>>")
+  if(LUMICE_ISA_LEVEL STREQUAL "baseline")
+    set(LUMICE_ISA_MARCH_FLAG "")
+  else()
+    set(LUMICE_ISA_MARCH_FLAG "-march=${LUMICE_ISA_LEVEL}")
+  endif()
+  set(LUMICE_ISA_LEVEL_ACTIVE_COND "$<AND:$<CONFIG:Release>,$<BOOL:${LUMICE_ISA_MARCH_FLAG}>>")
 
   target_compile_options(lumice_obj PRIVATE
     $<$<CONFIG:Debug>:-O0 -g -ggdb>
-    $<$<CONFIG:Release>:$<${LUMICE_NATIVE_ARCH_ACTIVE_COND}:-march=native> -ffunction-sections -fdata-sections -fvisibility=hidden>
+    $<$<CONFIG:Release>:$<${LUMICE_ISA_LEVEL_ACTIVE_COND}:${LUMICE_ISA_MARCH_FLAG}> -ffunction-sections -fdata-sections -fvisibility=hidden>
     $<$<CONFIG:MinSizeRel>:-ffunction-sections -fdata-sections -fvisibility=hidden>)
 
   # PUBLIC, not PRIVATE: src/main.cpp is not part of lumice_obj — it reaches this macro
   # through Lumice --PRIVATE--> lumice --PUBLIC--> lumice_obj, the same two-hop usage
-  # requirement chain LUMICE_CUDA_ENABLED already relies on above. No MSVC counterpart is
-  # needed: the macro should never be defined there, and #if defined() gives that for free.
+  # requirement chain LUMICE_CUDA_ENABLED already relies on above. The value is the tier
+  # name when the -march flag above is actually applied and "baseline" otherwise (Debug,
+  # MinSizeRel, or the baseline tier itself), so what the binary reports is what it was
+  # compiled with, never what was merely asked for. No MSVC counterpart is needed: the macro
+  # is never defined there, and main.cpp's #else falls back to "baseline".
   target_compile_definitions(lumice_obj PUBLIC
-    $<${LUMICE_NATIVE_ARCH_ACTIVE_COND}:LUMICE_NATIVE_ARCH_ACTIVE=1>)
+    "LUMICE_ISA_LEVEL_STR=\"$<IF:${LUMICE_ISA_LEVEL_ACTIVE_COND},${LUMICE_ISA_LEVEL},baseline>\"")
 endif()
 
 # Library target — static or shared per BUILD_SHARED_LIBS; reuses lumice_obj objects.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -584,8 +584,9 @@ endif()
 # - PTX floor = compute_61 (Pascal, 2016+); driver JITs to native sm on any
 #   GPU >= sm_61, including future cards.
 # - Multi-arch fatbin (scrum-310.2): on top of the compute_61 PTX floor, emit
-#   native SASS for the common modern cards so they skip first-launch JIT and
-#   the dev49 RTX 4060 (sm_89) bench runs native (not PTX-JIT'd) for fidelity.
+#   native SASS for the common modern cards (Turing through Blackwell, i.e.
+#   RTX 20/30/40/50) so they skip first-launch JIT and the CUDA reference box
+#   bench runs native (not PTX-JIT'd) for fidelity.
 # - Mac/Windows host builds without nvcc keep BUILD_GUI/perf paths intact when
 #   LUMICE_CUDA_ENABLED is OFF (no enable_language(CUDA) at all).
 if(LUMICE_CUDA_ENABLED)
@@ -603,10 +604,18 @@ if(LUMICE_CUDA_ENABLED)
     set(_lumice_cuda_archs "61-virtual")
     # Opportunistic native SASS for common cards: skips first-launch JIT and
     # gives bench fidelity. Each real arch is gated on the toolkit version that
-    # introduced that sm, so older toolchains (dev49 docker 11.6, win-builder
-    # 11.7) still build — they just emit fewer `-real` archs and fall back to
-    # PTX JIT. Distribution/CI builds use a modern toolkit (CI: 12.6) and get
-    # the full fatbin. The PTX floor guarantees universal compat regardless.
+    # introduced that sm, so older toolchains (e.g. an 11.6 / 11.7 docker
+    # image) still build — they just emit fewer `-real` archs and fall back to
+    # PTX JIT. Distribution/CI builds use a modern toolkit (CI: 12.9, the last
+    # 12.x minor) and get the full fatbin. The PTX floor guarantees universal
+    # compat regardless.
+    # Toolkit >= 12.8 prints a deprecation warning for compute_61 (the PTX
+    # floor). That is the expected, accepted cost of keeping the Pascal floor
+    # — not a defect: do not silence it with -Wno-deprecated-gpu-targets and
+    # do not drop 61-virtual over it. It is not promoted to an error by any
+    # flag in this tree (-Werror=switch is CXX-only; there is no /WX).
+    # CUDA 13 removes compute_61 outright, which is why the CUDA major stays
+    # pinned at 12 in ci.yml / release.yml.
     if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "10.0")
       list(APPEND _lumice_cuda_archs "75-real")  # Turing (RTX 20 / GTX 16)
     endif()
@@ -614,7 +623,10 @@ if(LUMICE_CUDA_ENABLED)
       list(APPEND _lumice_cuda_archs "86-real")  # Ampere (RTX 30)
     endif()
     if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "11.8")
-      list(APPEND _lumice_cuda_archs "89-real")  # Ada Lovelace (RTX 40, dev49)
+      list(APPEND _lumice_cuda_archs "89-real")  # Ada Lovelace (RTX 40)
+    endif()
+    if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "12.8")
+      list(APPEND _lumice_cuda_archs "120-real")  # Blackwell (RTX 50)
     endif()
     set(CMAKE_CUDA_ARCHITECTURES "${_lumice_cuda_archs}" CACHE STRING "CUDA archs")
   endif()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,9 @@ The release produces platform-specific packages:
   `doc/performance-testing.md`, "A local build is not the shipped binary"
 - **Linux ARM64**: `.tar.gz` with CLI executable (excludes GUI due to runner GPU limitations)
 - **macOS ARM64**: `.tar.gz` with CLI executable and `LumiceGUI.app` bundle
-- **Windows x64**: `.zip` with CLI and GUI executables (`.exe` with embedded icon)
+- **Windows x64**: `.zip` with CLI and GUI executables, each shipped twice (`<name>.baseline.exe`
+  built by MSVC cl.exe, `<name>.x86-64-v3.exe` built by clang-cl) behind a CPUID launcher installed
+  as `Lumice.exe` / `LumiceGUI.exe` — the same shape as Linux x64, see the same doc section
 
 The release page's body is that version's `CHANGELOG.md` section; GitHub's auto-generated pull-request list follows it as an appendix.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,10 @@ section, so a "cut only" commit on `main` with the notes written some other time
 occur.
 
 The release produces platform-specific packages:
-- **Linux x64/ARM64**: `.tar.gz` with CLI executable (ARM64 excludes GUI due to runner GPU limitations)
+- **Linux x64**: `.tar.gz` with CLI and GUI executables, each shipped twice (`<name>.baseline`,
+  `<name>.x86-64-v4`) behind a CPUID launcher installed as `Lumice` / `LumiceGUI` — see
+  `doc/performance-testing.md`, "A local build is not the shipped binary"
+- **Linux ARM64**: `.tar.gz` with CLI executable (excludes GUI due to runner GPU limitations)
 - **macOS ARM64**: `.tar.gz` with CLI executable and `LumiceGUI.app` bundle
 - **Windows x64**: `.zip` with CLI and GUI executables (`.exe` with embedded icon)
 

--- a/doc/gpu-remote-cuda-build-testing.md
+++ b/doc/gpu-remote-cuda-build-testing.md
@@ -36,8 +36,10 @@
   要么 `set -o pipefail`。
 - **arch 表**：本仓库默认 `CMAKE_CUDA_ARCHITECTURES` 以 `61-virtual` 为 PTX floor。
   ⚠️ **CUDA 13 已移除 `compute_61`**，用它构建会直接 `nvcc fatal`，与你改的东西无关。
-  参照机须装 CUDA 12.x。做吞吐 bench 时还要追加与卡匹配的 `-real` arch，否则跑的是
-  驱动 JIT 出来的 PTX 而非原生 SASS（详见 [`machines.md`](machines.md) 的「已知坑」）。
+  参照机须装 CUDA 12.x。默认表在 floor 之上按 toolkit 版本门控追加原生 SASS（12.9 上是
+  `sm_75/86/89/120`，两台参照机的 RTX 5090 已在其中）；只有卡的 sm 不在默认表里时，做吞吐
+  bench 才需要显式追加与卡匹配的 `-real` arch，否则跑的是驱动 JIT 出来的 PTX 而非原生 SASS
+  （详见 [`machines.md`](machines.md) 的「已知坑」）。
 
 ## 2. CUDA 参照机（Linux）
 

--- a/doc/machines.md
+++ b/doc/machines.md
@@ -65,6 +65,7 @@
 |---|---|
 | 仓库 | `C:\Users\15093\Codes\lumice` |
 | 工具链 | VS Build Tools 2022 17.14.37 / MSVC 14.44.35207 |
+| clang-cl | **LLVM 20.1.0，独立安装于 `C:\Program Files\LLVM`**（不是 VS 的 LLVM 组件——本机 Build Tools 没装那个）；Windows release 的 `x86-64-v3` 变体用它编译，与 `release.yml` 钉的版本一致 |
 | cmake / ninja | **VS Build Tools 自带**，位于 `Common7\IDE\CommonExtensions\Microsoft\CMake\` 下 |
 | CUDA | **12.9**，标准路径 `C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.9` |
 | 构建脚本 | `C:\Users\15093\win_build.cmd`（产物-only 版 `win_build_product.cmd`） |
@@ -73,6 +74,16 @@
 - ssh 默认 shell 是 **PowerShell 5.1**：`&&` 不是有效的语句分隔符。多条命令请分开发，
   或用 `-EncodedCommand` 传整段脚本（本地 shell 容易吃掉 `$`）。
 - ssh 会话**自带管理员令牌**，需要提权的安装可以直接远程执行。
+- **Smart App Control 开着**，对未签名的**新哈希**做 ISG 云裁决，判「拦」时 exe 启动即失败
+  （`ERRORLEVEL 4551`，「was blocked by your organization's Device Guard policy」）。实测两条规律：
+  同一哈希的裁决稳定（拦的一直拦、放的一直放）；重新链接换个哈希通常就放行。⛔ 不关 SAC（不可逆）。
+  取证脚本里每个新构建的 exe 先 `-h` 探一次，`4551` 就删掉产物重链再探；且**把每次 exe 启动包在
+  `cmd /c "…"` 里**——被拦的启动会让承载它的 `.cmd` 批处理直接终止，不包一层整个脚本就在那一行静默
+  收尾。
+- **`bcdedit /set xsavedisable 1`**（关闭 OS 的 XSAVE/AVX 状态保存，重启生效）是本机做「无 AVX2
+  环境」负对照的办法——launcher 的 OSXSAVE 检查会真实读到 0。⚠️ 它是系统级、影响整台机器（两个环境）；
+  用完必须 `bcdedit /deletevalue xsavedisable` 再重启复原。任何 session 接手本机前先看
+  `bcdedit /enum | findstr /i xsave` 是否留有条目。
 - ⚠️ `scripts/bench_throughput.py` 的默认二进制探测**不带 `.exe`** 后缀
   ⇒ 在 Windows 上必须显式设 `LUMICE_BENCH_BIN`。
 

--- a/doc/machines.md
+++ b/doc/machines.md
@@ -81,10 +81,15 @@
 1. **CUDA 13 编译不了本仓库。** `nvcc -arch=compute_61` 报
    `nvcc fatal : Unsupported gpu architecture 'compute_61'`，而本仓库的 arch floor 就是
    `61-virtual`（见 `CMakeLists.txt` 的 `CMAKE_CUDA_ARCHITECTURES` 默认表）。
-   ⇒ CUDA 参照机必须装 12.x（12.9 接受 `compute_61`，只报 deprecation warning）。
-   **吞吐 bench 另需显式追加 `120-real`**，否则 sm_120 的卡跑的是驱动 JIT 出来的
-   Pascal PTX 而不是原生 SASS，不够 bench 保真度：
-   `-DCMAKE_CUDA_ARCHITECTURES="61-virtual;75-real;86-real;89-real;120-real"`
+   ⇒ CUDA 参照机必须装 12.x（12.9 接受 `compute_61`，只报 deprecation warning——
+   这条 warning 是保留 Pascal PTX floor 的预期代价，不是要修的问题，`CMakeLists.txt`
+   的 arch 块注释里写明了不要压掉它）。
+   toolkit ≥ 12.8 时 `120-real`（Blackwell 原生 SASS）**已经在 `CMakeLists.txt` 默认
+   arch 表里**（`_lumice_cuda_archs` 构造逻辑按 `CUDAToolkit_VERSION` 门控追加），
+   这两台机器的 12.9 直接 configure 就能拿到，吞吐 bench **不再需要**手动覆盖
+   `CMAKE_CUDA_ARCHITECTURES`。要确认本次构建实际覆盖了哪些 arch，看 configure 打印的
+   `CUDA backend enabled (arch=...)` STATUS 行，或对产物跑 `cuobjdump --list-elf`
+   （⚠️ 它把 `compute_61` 的 PTX 条目列为 `sm_61`，grep 时别按 `compute_` 匹配）。
 2. **WSL 上 GLFW 会选中 Wayland 后端然后段错误**（`_glfwInitWayland` →
    `wl_proxy_get_version` SIGSEGV）。成因是 WSLg 把 wayland socket 放进
    `XDG_RUNTIME_DIR`，于是 `wl_display_connect` 会成功但后续不兼容。

--- a/doc/performance-testing.md
+++ b/doc/performance-testing.md
@@ -208,41 +208,55 @@ This one is not about *which* number `--benchmark` reports; it is about *which b
 it. It has already cost one cross-platform conclusion, which was written down and acted on
 before the cause was found.
 
-**Mechanism.** `option(LUMICE_NATIVE_ARCH ... ON)` (`CMakeLists.txt:43`) expands to
-`-march=native` for Release builds on GCC/Clang (`CMakeLists.txt:733`). Three facts about who
-passes it:
+**Mechanism.** `LUMICE_ISA_LEVEL` (`CMakeLists.txt:50`) is the one variable that says which ISA
+tier a Release build is compiled for, and it has three values:
 
-- **Local**: `scripts/build.sh` does not pass the option at all, so every local build takes the
-  `ON` default. That default is deliberate — a developer machine should build for itself.
-- **Shipped**: `.github/workflows/release.yml:135` and all seven configure steps in
-  `.github/workflows/ci.yml` pass `-DLUMICE_NATIVE_ARCH=OFF` explicitly. What ships, and what CI
-  measures, is the baseline ISA.
-- **MSVC**: the option is only read inside the `if(NOT MSVC)` branch, so a Windows/MSVC build has
-  no equivalent to turn on. It is *structurally* incapable of being on the local side of this gap.
+| `LUMICE_ISA_LEVEL` | flag on GCC/Clang Release | who builds it |
+|---|---|---|
+| `native` | `-march=native` | **local default** — `scripts/build.sh` passes nothing, so every local build takes it; a developer machine should build for itself |
+| `baseline` | none (x86-64-v1, the floor every x86_64 CPU runs) | every configure step in `.github/workflows/ci.yml`, and every release package except the Linux x64 v4 variant below |
+| `x86-64-v4` | `-march=x86-64-v4` (AVX-512) | the Linux x64 release's second variant: `release.yml` builds that row twice and packages both |
+
+The flag is applied on `lumice_obj` (`CMakeLists.txt:783`), so the CLI and the GUI are the same
+tier. MSVC reads none of this — the variable is only consumed inside the `if(NOT MSVC)` branch,
+so a Windows/MSVC build has no equivalent to turn on and is *structurally* always the baseline.
+
+**What the Linux release does with it.** The `linux-x64` tarball carries every entry point
+twice — `Lumice.baseline` / `Lumice.x86-64-v4`, `LumiceGUI.baseline` / `LumiceGUI.x86-64-v4` —
+and installs a small launcher (`src/launcher/isa_launcher.c`) under the plain names `Lumice` /
+`LumiceGUI`. The launcher reads CPUID (`__builtin_cpu_supports("x86-64-v4")`) and `execv`s the
+matching sidecar; a `--isa=baseline` / `--isa=x86-64-v4` token anywhere on the command line
+forces one and is consumed before the real binary sees its arguments. Nothing else changes for
+the user: one download, the same two names. Measured on this codebase (Zen 5 / GCC 13.3), the v4
+variant is 1.9–2.3× the baseline at 1–4 workers and the whole gain is AVX-512 — `x86-64-v2` and
+`-v3` measure 1.00× — which is why there are exactly two variants and not a ladder.
 
 **Consequence.** A throughput number taken from a local non-MSVC build is systematically
-optimistic relative to the binary that ships (measured on this codebase, Zen 5 / GCC 13.3:
-1.9–2.3×). Worse, a Windows-vs-anything A/B run on two default local builds compares a
-native-ISA binary against a baseline-ISA one, and nothing anywhere warns you: both builds
-succeed, both print plausible numbers, and the ratio between them is partly an artifact of a
-compiler flag rather than of whatever you were trying to measure.
+optimistic relative to the baseline binary that ships (the same 1.9–2.3×). Worse, a
+Windows-vs-anything A/B run on two default local builds compares a native-ISA binary against a
+baseline-ISA one, and nothing anywhere warns you: both builds succeed, both print plausible
+numbers, and the ratio between them is partly an artifact of a compiler flag rather than of
+whatever you were trying to measure.
 
 **Rules.**
 
 1. **Any number that leaves your machine — a cross-platform comparison, a figure quoted in an
-   issue, a doc, or a review — must be taken with `-DLUMICE_NATIVE_ARCH=OFF`.** That is the
-   configuration release and CI use, and the only one comparable across platforms.
-2. **Day-to-day local iteration can keep the `ON` default.** This is not a rule against
+   issue, a doc, or a review — must be taken with `-DLUMICE_ISA_LEVEL=baseline`.** That is the
+   configuration CI uses, and the only one comparable across platforms. A number taken at
+   `x86-64-v4` is a legitimate number about the Linux v4 variant, and must say so.
+2. **Day-to-day local iteration can keep the `native` default.** This is not a rule against
    `-march=native`; it is a rule about where the resulting number is allowed to travel. A
    before/after A/B of your own change, taken on the same machine with the same setting on both
    arms, is unaffected.
 3. **Read the `isa` key rather than trying to remember.** Every `[BENCHMARK]` line carries
-   `"isa": "native"` or `"isa": "baseline"` (`src/main.cpp`, `RunBenchmarkPass`, gated by the
-   `LUMICE_NATIVE_ARCH_ACTIVE` macro that `CMakeLists.txt`'s `LUMICE_NATIVE_ARCH_ACTIVE_COND`
-   defines from the same condition as the `-march=native` flag itself). An old log therefore
-   answers "which build was this?" on its own, with no configure log needed. `baseline` is the
-   comparable tier; two rows may only be compared with each other when their `isa` values match.
-4. **Watch the configure line.** Every `cmake` configure prints one `-- LUMICE_NATIVE_ARCH=...`
+   `"isa": "native"`, `"isa": "baseline"` or `"isa": "x86-64-v4"` (`src/main.cpp`,
+   `RunBenchmarkPass`, from the `LUMICE_ISA_LEVEL_STR` macro that `CMakeLists.txt` resolves with
+   the same `LUMICE_ISA_LEVEL_ACTIVE_COND` that gates the `-march` flag itself, so the key
+   reads `baseline` whenever no flag was actually applied — a Debug build included). An old
+   log therefore answers "which build was this?" on its own, with no configure log needed.
+   `baseline` is the comparable tier; two rows may only be compared with each other when their
+   `isa` values match.
+4. **Watch the configure line.** Every `cmake` configure prints one `-- LUMICE_ISA_LEVEL=...`
    status line saying which tier this build tree is on.
 
 

--- a/doc/performance-testing.md
+++ b/doc/performance-testing.md
@@ -240,9 +240,10 @@ tarball below: `Lumice.baseline.exe` / `Lumice.x86-64-v3.exe`, `LumiceGUI.baseli
 `#UD` otherwise), starts the matching sidecar with `CreateProcess`, waits, and returns its exit
 code (Windows has no `exec`; the CRT's `_execv` neither preserves the child's exit code nor quotes
 arguments, so the launcher does both itself). `--isa=baseline` / `--isa=x86-64-v3` forces one, as on
-Linux. On the release-equivalent CUDA-on build the v3 variant measures
-<TODO: AC4 measured ratio, filled by Step 10.5> the baseline at ms1 W=1 (Windows reference box,
-Zen 5) — the CUDA-off probe number above is a different arm and must not be quoted for it.
+Linux. On the release-equivalent CUDA-on build the v3 variant measures **2.23×** the baseline at ms1 W=1
+(1.701 vs 0.761 M rays/s, CoV 0.72% / 0.33%, five interleaved repetitions through the launcher's
+`--isa=` override; Windows reference box, Zen 5, 2026-09-11) — within 1.3% of the CUDA-off probe
+figure above, which is a different arm and must not be quoted for it.
 
 **What the Linux release does with it.** The `linux-x64` tarball carries every entry point
 twice — `Lumice.baseline` / `Lumice.x86-64-v4`, `LumiceGUI.baseline` / `LumiceGUI.x86-64-v4` —

--- a/doc/performance-testing.md
+++ b/doc/performance-testing.md
@@ -209,17 +209,40 @@ it. It has already cost one cross-platform conclusion, which was written down an
 before the cause was found.
 
 **Mechanism.** `LUMICE_ISA_LEVEL` (`CMakeLists.txt:50`) is the one variable that says which ISA
-tier a Release build is compiled for, and it has three values:
+tier a Release build is compiled for, and it has four values:
 
-| `LUMICE_ISA_LEVEL` | flag on GCC/Clang Release | who builds it |
+| `LUMICE_ISA_LEVEL` | flag on GCC/Clang/clang-cl Release | who builds it |
 |---|---|---|
 | `native` | `-march=native` | **local default** — `scripts/build.sh` passes nothing, so every local build takes it; a developer machine should build for itself |
-| `baseline` | none (x86-64-v1, the floor every x86_64 CPU runs) | every configure step in `.github/workflows/ci.yml`, and every release package except the Linux x64 v4 variant below |
+| `baseline` | none (x86-64-v1, the floor every x86_64 CPU runs) | every configure step in `.github/workflows/ci.yml`, and every release package except the two second variants below |
+| `x86-64-v3` | `-march=x86-64-v3` (AVX2+FMA) | the Windows x64 release's second variant, compiled by **clang-cl**: `release.yml` builds that row twice (baseline on MSVC cl.exe, v3 on clang-cl) and packages both |
 | `x86-64-v4` | `-march=x86-64-v4` (AVX-512) | the Linux x64 release's second variant: `release.yml` builds that row twice and packages both |
 
-The flag is applied on `lumice_obj` (`CMakeLists.txt:783`), so the CLI and the GUI are the same
-tier. MSVC reads none of this — the variable is only consumed inside the `if(NOT MSVC)` branch,
-so a Windows/MSVC build has no equivalent to turn on and is *structurally* always the baseline.
+The flag is applied on `lumice_obj` through one shared CMake function, `lumice_apply_isa_march()`,
+so the CLI and the GUI are the same tier. Real MSVC cl.exe reads none of this — the function is
+called only from the GCC/Clang branch and from the clang-cl branch — so a Windows build made with
+cl.exe (the local `win_build.cmd` default, and CI's every Windows job) has no equivalent to turn on
+and is *structurally* always the baseline. **clang-cl is the exception**, and the reason the
+Windows release has a second variant at all: CMake reports `MSVC=TRUE` for it (it drives the MSVC
+ABI and `/`-style flags), but it is a Clang frontend that honors `-march`, which `CMakeLists.txt`
+detects once as `LUMICE_CLANG_CL` and routes into the same function. Measured on the Windows
+reference box (Zen 5, clang-cl 20.1.0, CUDA-off arm), clang-cl at `x86-64-v3` is **2.26× (W=1) /
+2.28× (W=4)** real MSVC's release build, `x86-64-v4` and `-mprefer-vector-width=512` add nothing on
+top (2.25×/2.29×), and clang-cl with no `-march` is 1.01× — the gain is the flag, not the compiler,
+and LLVM takes all of it at AVX2 where GCC (below) takes none of it before AVX-512. That is why the
+two platforms' second variants are different tiers.
+
+**What the Windows release does with it.** The `windows-x64` zip has the same shape as the Linux
+tarball below: `Lumice.baseline.exe` / `Lumice.x86-64-v3.exe`, `LumiceGUI.baseline.exe` /
+`LumiceGUI.x86-64-v3.exe`, and the launcher (`src/launcher/isa_launcher_win.c`) installed as
+`Lumice.exe` / `LumiceGUI.exe`. It reads CPUID for the whole x86-64-v3 feature level plus XGETBV
+(the OS must save YMM state — the launcher checks OSXSAVE before it executes XGETBV, which is
+`#UD` otherwise), starts the matching sidecar with `CreateProcess`, waits, and returns its exit
+code (Windows has no `exec`; the CRT's `_execv` neither preserves the child's exit code nor quotes
+arguments, so the launcher does both itself). `--isa=baseline` / `--isa=x86-64-v3` forces one, as on
+Linux. On the release-equivalent CUDA-on build the v3 variant measures
+<TODO: AC4 measured ratio, filled by Step 10.5> the baseline at ms1 W=1 (Windows reference box,
+Zen 5) — the CUDA-off probe number above is a different arm and must not be quoted for it.
 
 **What the Linux release does with it.** The `linux-x64` tarball carries every entry point
 twice — `Lumice.baseline` / `Lumice.x86-64-v4`, `LumiceGUI.baseline` / `LumiceGUI.x86-64-v4` —
@@ -243,16 +266,19 @@ whatever you were trying to measure.
 1. **Any number that leaves your machine — a cross-platform comparison, a figure quoted in an
    issue, a doc, or a review — must be taken with `-DLUMICE_ISA_LEVEL=baseline`.** That is the
    configuration CI uses, and the only one comparable across platforms. A number taken at
-   `x86-64-v4` is a legitimate number about the Linux v4 variant, and must say so.
+   `x86-64-v4` is a legitimate number about the Linux v4 variant, and must say so; the same for
+   `x86-64-v3` and the Windows clang-cl variant, which additionally must say it was clang-cl (a
+   cl.exe build cannot produce that tier, so the key alone already implies the compiler).
 2. **Day-to-day local iteration can keep the `native` default.** This is not a rule against
    `-march=native`; it is a rule about where the resulting number is allowed to travel. A
    before/after A/B of your own change, taken on the same machine with the same setting on both
    arms, is unaffected.
 3. **Read the `isa` key rather than trying to remember.** Every `[BENCHMARK]` line carries
-   `"isa": "native"`, `"isa": "baseline"` or `"isa": "x86-64-v4"` (`src/main.cpp`,
-   `RunBenchmarkPass`, from the `LUMICE_ISA_LEVEL_STR` macro that `CMakeLists.txt` resolves with
-   the same `LUMICE_ISA_LEVEL_ACTIVE_COND` that gates the `-march` flag itself, so the key
-   reads `baseline` whenever no flag was actually applied — a Debug build included). An old
+   `"isa": "native"`, `"isa": "baseline"`, `"isa": "x86-64-v3"` or `"isa": "x86-64-v4"`
+   (`src/main.cpp`, `RunBenchmarkPass`, from the `LUMICE_ISA_LEVEL_STR` macro that
+   `lumice_apply_isa_march()` resolves with the same condition that gates the `-march` flag
+   itself, so the key reads `baseline` whenever no flag was actually applied — a Debug build
+   included, and every cl.exe build). An old
    log therefore answers "which build was this?" on its own, with no configure log needed.
    `baseline` is the comparable tier; two rows may only be compared with each other when their
    `isa` values match.

--- a/doc/performance-testing_zh.md
+++ b/doc/performance-testing_zh.md
@@ -80,17 +80,36 @@ CLI 基准测试和 GUI 性能测试均支持日志级别选项。
 跨平台结论——那条结论被写下来、被当作待办流传了一段时间，才查出成因。
 
 **机制。** `LUMICE_ISA_LEVEL`（`CMakeLists.txt:50`）是唯一一个说明「Release 构建编译到哪一档
-ISA」的变量，取三个值：
+ISA」的变量，取四个值：
 
-| `LUMICE_ISA_LEVEL` | GCC/Clang Release 下的 flag | 谁在用 |
+| `LUMICE_ISA_LEVEL` | GCC/Clang/clang-cl Release 下的 flag | 谁在用 |
 |---|---|---|
 | `native` | `-march=native` | **本地默认**——`scripts/build.sh` 什么都不传，所以每次本地构建吃的都是它；开发机就该为自己编译 |
-| `baseline` | 无（x86-64-v1，任何 x86_64 CPU 都能跑的地板） | `.github/workflows/ci.yml` 里每一处 configure，以及除下面那个 Linux x64 v4 变体之外的每一个 release 包 |
+| `baseline` | 无（x86-64-v1，任何 x86_64 CPU 都能跑的地板） | `.github/workflows/ci.yml` 里每一处 configure，以及除下面两个第二变体之外的每一个 release 包 |
+| `x86-64-v3` | `-march=x86-64-v3`（AVX2+FMA） | Windows x64 release 的第二个变体，由 **clang-cl** 编译：`release.yml` 把那一行构建两遍（baseline 用 MSVC cl.exe、v3 用 clang-cl）、两份都打进包 |
 | `x86-64-v4` | `-march=x86-64-v4`（AVX-512） | Linux x64 release 的第二个变体：`release.yml` 把那一行构建两遍、两份都打进包 |
 
-flag 挂在 `lumice_obj` 上（`CMakeLists.txt:783`），所以 CLI 和 GUI 永远同一档。MSVC 完全不读
-这个变量——它只在 `if(NOT MSVC)` 分支里被消费，所以 Windows/MSVC 构建**结构上**没有等价物可开，
-永远是基线。
+flag 经同一个共享 CMake 函数 `lumice_apply_isa_march()` 挂在 `lumice_obj` 上，所以 CLI 和 GUI
+永远同一档。真正的 MSVC cl.exe 完全不读这个变量——该函数只在 GCC/Clang 分支与 clang-cl 分支被
+调用——所以用 cl.exe 做的 Windows 构建（本地 `win_build.cmd` 默认、CI 的每一个 Windows job）
+**结构上**没有等价物可开，永远是基线。**clang-cl 是例外**，也是 Windows release 有第二个变体的
+全部原因：CMake 对它报告 `MSVC=TRUE`（它驱动 MSVC ABI 与 `/` 风格 flag），但它是一个认 `-march`
+的 Clang 前端；`CMakeLists.txt` 把这一点一次性判成 `LUMICE_CLANG_CL`，走同一个函数。Windows
+参照机实测（Zen 5、clang-cl 20.1.0、CUDA-off 臂）：clang-cl 在 `x86-64-v3` 上是真 MSVC release
+构建的 **2.26×（W=1）/ 2.28×（W=4）**，`x86-64-v4` 与 `-mprefer-vector-width=512` 再加不上去
+（2.25×/2.29×），不带 `-march` 的 clang-cl 是 1.01×——收益来自 flag 而非换编译器，且 LLVM 在 AVX2
+就全部拿到，而 GCC（见下）在 AVX-512 之前一分不拿。这就是两个平台的第二变体档位不同的原因。
+
+**Windows release 拿它做什么。** `windows-x64` 的 zip 与下面的 Linux tarball 同形：
+`Lumice.baseline.exe` / `Lumice.x86-64-v3.exe`、`LumiceGUI.baseline.exe` /
+`LumiceGUI.x86-64-v3.exe`，再把 launcher（`src/launcher/isa_launcher_win.c`）装成 `Lumice.exe` /
+`LumiceGUI.exe`。它读 CPUID 判整个 x86-64-v3 特性级别外加 XGETBV（OS 必须保存 YMM 状态——launcher
+先确认 OSXSAVE 再执行 XGETBV，否则那条指令是 `#UD`），用 `CreateProcess` 起对应 sidecar、等待、
+把它的退出码当自己的返回（Windows 没有 `exec`；CRT 的 `_execv` 既不保留子进程退出码也不给参数
+加引号，所以这两件事 launcher 自己做）。`--isa=baseline` / `--isa=x86-64-v3` 可强制其一，与 Linux
+同语法。在与 release 等价的 CUDA-on 构建上，v3 变体在 ms1 W=1 下量到基线的
+<TODO: AC4 measured ratio, filled by Step 10.5>（Windows 参照机，Zen 5）——上面那个 CUDA-off
+探针数字是另一条臂，不得拿来代替它。
 
 **Linux release 拿它做什么。** `linux-x64` 的 tarball 里每个入口都有两份——
 `Lumice.baseline` / `Lumice.x86-64-v4`、`LumiceGUI.baseline` / `LumiceGUI.x86-64-v4`——
@@ -110,14 +129,16 @@ A/B，比的是 native-ISA 二进制对基线-ISA 二进制，而**任何地方�
 
 1. **任何要离开你这台机器的数字**——跨平台对照、写进 issue / 文档 / 评审里的数字——
    **必须用 `-DLUMICE_ISA_LEVEL=baseline` 取**。那才是 CI 用的配置，也是唯一跨平台可比的那一档。
-   在 `x86-64-v4` 上取的数字是关于 Linux v4 变体的合法数字，但必须写明。
+   在 `x86-64-v4` 上取的数字是关于 Linux v4 变体的合法数字，但必须写明；`x86-64-v3` 与 Windows
+   clang-cl 变体同理，且还要写明是 clang-cl（cl.exe 构建产不出这一档，所以键值本身已经隐含了
+   编译器）。
 2. **日常本机迭代可以继续吃 `native` 默认值。** 这不是在禁止 `-march=native`，而是在划清「这个数字
    能走多远」这条线。自己改动的前后 A/B，只要两臂在同一台机器、同一档设置上取，不受影响。
 3. **读 `isa` 键，别指望记得住。** 每一行 `[BENCHMARK]` 都带 `"isa": "native"`、
-   `"isa": "baseline"` 或 `"isa": "x86-64-v4"`（`src/main.cpp` 的 `RunBenchmarkPass`，取自
-   `LUMICE_ISA_LEVEL_STR` 宏；`CMakeLists.txt` 用与 `-march` flag 本身相同的
-   `LUMICE_ISA_LEVEL_ACTIVE_COND` 条件解析该宏，所以只要没有真正应用 flag——包括 Debug 构建——
-   这个键就读 `baseline`）。于是一份旧 log 自己就能回答「这是哪个构建取的」，
+   `"isa": "baseline"`、`"isa": "x86-64-v3"` 或 `"isa": "x86-64-v4"`（`src/main.cpp` 的
+   `RunBenchmarkPass`，取自 `LUMICE_ISA_LEVEL_STR` 宏；`lumice_apply_isa_march()` 用与 `-march`
+   flag 本身相同的条件解析该宏，所以只要没有真正应用 flag——包括 Debug 构建，以及每一个 cl.exe
+   构建——这个键就读 `baseline`）。于是一份旧 log 自己就能回答「这是哪个构建取的」，
    不需要还留着当时的 configure 输出。`baseline` 是可比的那一档；两行数字只有在 `isa` 相同时
    才允许互相比较。
 4. **留意 configure 那一行。** 每次 `cmake` configure 都会打印一行 `-- LUMICE_ISA_LEVEL=...`

--- a/doc/performance-testing_zh.md
+++ b/doc/performance-testing_zh.md
@@ -107,9 +107,9 @@ flag 经同一个共享 CMake 函数 `lumice_apply_isa_march()` 挂在 `lumice_o
 先确认 OSXSAVE 再执行 XGETBV，否则那条指令是 `#UD`），用 `CreateProcess` 起对应 sidecar、等待、
 把它的退出码当自己的返回（Windows 没有 `exec`；CRT 的 `_execv` 既不保留子进程退出码也不给参数
 加引号，所以这两件事 launcher 自己做）。`--isa=baseline` / `--isa=x86-64-v3` 可强制其一，与 Linux
-同语法。在与 release 等价的 CUDA-on 构建上，v3 变体在 ms1 W=1 下量到基线的
-<TODO: AC4 measured ratio, filled by Step 10.5>（Windows 参照机，Zen 5）——上面那个 CUDA-off
-探针数字是另一条臂，不得拿来代替它。
+同语法。在与 release 等价的 CUDA-on 构建上，v3 变体在 ms1 W=1 下量到基线的 **2.23×**（1.701 vs 0.761 M
+rays/s，CoV 0.72% / 0.33%，5 次交错重复、经 launcher 的 `--isa=` 覆盖；Windows 参照机，Zen 5，
+2026-09-11）——与上面那个 CUDA-off 探针数字相差 1.3%，但那是另一条臂，不得拿来代替它。
 
 **Linux release 拿它做什么。** `linux-x64` 的 tarball 里每个入口都有两份——
 `Lumice.baseline` / `Lumice.x86-64-v4`、`LumiceGUI.baseline` / `LumiceGUI.x86-64-v4`——

--- a/doc/performance-testing_zh.md
+++ b/doc/performance-testing_zh.md
@@ -79,35 +79,48 @@ CLI 基准测试和 GUI 性能测试均支持日志级别选项。
 这一条讲的不是 `--benchmark` 报的是*哪个*数字，而是这个数字出自*哪个二进制*。它已经害过一次
 跨平台结论——那条结论被写下来、被当作待办流传了一段时间，才查出成因。
 
-**机制。** `option(LUMICE_NATIVE_ARCH ... ON)`（`CMakeLists.txt:43`）在 GCC/Clang 的 Release
-构建上展开为 `-march=native`（`CMakeLists.txt:733`）。关于谁传这个开关，有三件事：
+**机制。** `LUMICE_ISA_LEVEL`（`CMakeLists.txt:50`）是唯一一个说明「Release 构建编译到哪一档
+ISA」的变量，取三个值：
 
-- **本地**：`scripts/build.sh` 根本不传这个选项，所以每一次本地构建吃的都是 `ON` 默认值。
-  这个默认是**有意的**——开发机就该为自己编译。
-- **出货**：`.github/workflows/release.yml:135` 与 `.github/workflows/ci.yml` 里全部 7 处
-  configure 步骤都显式传 `-DLUMICE_NATIVE_ARCH=OFF`。出货的、以及 CI 测的，都是基线 ISA。
-- **MSVC**：这个选项只在 `if(NOT MSVC)` 分支里被读取，所以 Windows/MSVC 构建**结构上**就没有
-  等价物可开，永远待在这条缝的另一侧。
+| `LUMICE_ISA_LEVEL` | GCC/Clang Release 下的 flag | 谁在用 |
+|---|---|---|
+| `native` | `-march=native` | **本地默认**——`scripts/build.sh` 什么都不传，所以每次本地构建吃的都是它；开发机就该为自己编译 |
+| `baseline` | 无（x86-64-v1，任何 x86_64 CPU 都能跑的地板） | `.github/workflows/ci.yml` 里每一处 configure，以及除下面那个 Linux x64 v4 变体之外的每一个 release 包 |
+| `x86-64-v4` | `-march=x86-64-v4`（AVX-512） | Linux x64 release 的第二个变体：`release.yml` 把那一行构建两遍、两份都打进包 |
 
-**后果。** 从本地非 MSVC 构建取的吞吐数字，相对出货二进制系统性偏乐观（本仓库实测，
-Zen 5 / GCC 13.3：1.9–2.3×）。更糟的是：拿两个默认设置的本地构建做 Windows vs 非 Windows 的
+flag 挂在 `lumice_obj` 上（`CMakeLists.txt:783`），所以 CLI 和 GUI 永远同一档。MSVC 完全不读
+这个变量——它只在 `if(NOT MSVC)` 分支里被消费，所以 Windows/MSVC 构建**结构上**没有等价物可开，
+永远是基线。
+
+**Linux release 拿它做什么。** `linux-x64` 的 tarball 里每个入口都有两份——
+`Lumice.baseline` / `Lumice.x86-64-v4`、`LumiceGUI.baseline` / `LumiceGUI.x86-64-v4`——
+并在原名 `Lumice` / `LumiceGUI` 下装一个小 launcher（`src/launcher/isa_launcher.c`）。launcher
+读 CPUID（`__builtin_cpu_supports("x86-64-v4")`）然后 `execv` 对应的 sidecar；命令行里任何位置
+的 `--isa=baseline` / `--isa=x86-64-v4` 可强制其一，且在真正的二进制看到参数之前就被吃掉。
+对用户什么都没变：一个下载、同样的两个名字。本仓库实测（Zen 5 / GCC 13.3），v4 变体在 1–4
+worker 下是基线的 1.9–2.3×，且**收益全部来自 AVX-512**——`x86-64-v2` 与 `-v3` 都量到 1.00×——
+所以恰好是两个变体而不是一个阶梯。
+
+**后果。** 从本地非 MSVC 构建取的吞吐数字，相对出货的基线二进制系统性偏乐观（就是上面那个
+1.9–2.3×）。更糟的是：拿两个默认设置的本地构建做 Windows vs 非 Windows 的
 A/B，比的是 native-ISA 二进制对基线-ISA 二进制，而**任何地方都不会给你任何警告**——两边都构建
 成功、都打印出看起来合理的数字，而两者之比里有一部分只是编译开关的产物，与你想量的东西无关。
 
 **规则。**
 
 1. **任何要离开你这台机器的数字**——跨平台对照、写进 issue / 文档 / 评审里的数字——
-   **必须用 `-DLUMICE_NATIVE_ARCH=OFF` 取**。那才是 release 与 CI 用的配置，也是唯一跨平台
-   可比的那一档。
-2. **日常本机迭代可以继续吃 `ON` 默认值。** 这不是在禁止 `-march=native`，而是在划清「这个数字
+   **必须用 `-DLUMICE_ISA_LEVEL=baseline` 取**。那才是 CI 用的配置，也是唯一跨平台可比的那一档。
+   在 `x86-64-v4` 上取的数字是关于 Linux v4 变体的合法数字，但必须写明。
+2. **日常本机迭代可以继续吃 `native` 默认值。** 这不是在禁止 `-march=native`，而是在划清「这个数字
    能走多远」这条线。自己改动的前后 A/B，只要两臂在同一台机器、同一档设置上取，不受影响。
-3. **读 `isa` 键，别指望记得住。** 每一行 `[BENCHMARK]` 都带 `"isa": "native"` 或
-   `"isa": "baseline"`（`src/main.cpp` 的 `RunBenchmarkPass`，由 `LUMICE_NATIVE_ARCH_ACTIVE` 宏
-   门控；该宏与 `-march=native` 标志本身共用 `CMakeLists.txt` 里同一个
-   `LUMICE_NATIVE_ARCH_ACTIVE_COND` 条件）。于是一份旧 log 自己就能回答「这是哪个构建取的」，
+3. **读 `isa` 键，别指望记得住。** 每一行 `[BENCHMARK]` 都带 `"isa": "native"`、
+   `"isa": "baseline"` 或 `"isa": "x86-64-v4"`（`src/main.cpp` 的 `RunBenchmarkPass`，取自
+   `LUMICE_ISA_LEVEL_STR` 宏；`CMakeLists.txt` 用与 `-march` flag 本身相同的
+   `LUMICE_ISA_LEVEL_ACTIVE_COND` 条件解析该宏，所以只要没有真正应用 flag——包括 Debug 构建——
+   这个键就读 `baseline`）。于是一份旧 log 自己就能回答「这是哪个构建取的」，
    不需要还留着当时的 configure 输出。`baseline` 是可比的那一档；两行数字只有在 `isa` 相同时
    才允许互相比较。
-4. **留意 configure 那一行。** 每次 `cmake` configure 都会打印一行 `-- LUMICE_NATIVE_ARCH=...`
+4. **留意 configure 那一行。** 每次 `cmake` configure 都会打印一行 `-- LUMICE_ISA_LEVEL=...`
    状态，说明这棵构建树在哪一档。
 
 

--- a/doc/testing-architecture.md
+++ b/doc/testing-architecture.md
@@ -1556,6 +1556,11 @@ to `push` on `main` because it writes the gh-pages benchmark history.
 | new-refs | 11 | 11 | no — second-scale gate |
 | | **4401s** | 5645s | warm head = 3365s (76%) |
 
+`isa-v4-compile` (the `-march=x86-64-v4` compile-only leg added for the two-variant Linux release)
+post-dates this measurement and has no row yet: it is the same shape as `bench-compile` — narrow
+configure, `BUILD_TEST=OFF`, `BUILD_GUI=OFF`, compile and link only — but its number is to be
+read off a real run, not inferred from that resemblance.
+
 ⚠️ **The `Ubuntu x86_64` row is still settling, and its history is worth more than its number.**
 That leg went 650s uncached → 657s (cold, nothing to restore) → 567s → 479s → 353s across five
 consecutive runs, and its ccache hit rate over the last three was 26.34% → 41.39% → **55.96%**, still

--- a/doc/testing-architecture.md
+++ b/doc/testing-architecture.md
@@ -1561,6 +1561,14 @@ post-dates this table. Its first run, with nothing under its own cache key to re
 (run 34574596545); the same shape as `bench-compile` — narrow configure, `BUILD_TEST=OFF`,
 `BUILD_GUI=OFF`, compile and link only — and in the same "no — compile-only" column of §7.0's head.
 
+`windows-isa-v3-compile` (the clang-cl `-march=x86-64-v3` × nvcc/cl.exe leg added for the two-variant
+Windows release) post-dates it as well. Its first run, with nothing under its own cache key, took
+**338s** (run 34587240975): LLVM 20.1.0 from Chocolatey 79s, CUDA toolkit 59s, configure 42s, build
+122s, and 11s for the one thing that makes it more than compile-only — a `--benchmark` run asserting
+the `isa` key reads `x86-64-v3`. That is the `windows-cuda-compile` shape plus a compiler install,
+which is why it sits at the same scale as that row and not at `isa-v4-compile`'s; it still belongs in
+the "no" column of §7.0's head, since one benchmark invocation is not a test suite.
+
 ⚠️ **The `Ubuntu x86_64` row is still settling, and its history is worth more than its number.**
 That leg went 650s uncached → 657s (cold, nothing to restore) → 567s → 479s → 353s across five
 consecutive runs, and its ccache hit rate over the last three was 26.34% → 41.39% → **55.96%**, still

--- a/doc/testing-architecture.md
+++ b/doc/testing-architecture.md
@@ -1557,9 +1557,9 @@ to `push` on `main` because it writes the gh-pages benchmark history.
 | | **4401s** | 5645s | warm head = 3365s (76%) |
 
 `isa-v4-compile` (the `-march=x86-64-v4` compile-only leg added for the two-variant Linux release)
-post-dates this measurement and has no row yet: it is the same shape as `bench-compile` — narrow
-configure, `BUILD_TEST=OFF`, `BUILD_GUI=OFF`, compile and link only — but its number is to be
-read off a real run, not inferred from that resemblance.
+post-dates this table. Its first run, with nothing under its own cache key to restore, took **71s**
+(run 34574596545); the same shape as `bench-compile` — narrow configure, `BUILD_TEST=OFF`,
+`BUILD_GUI=OFF`, compile and link only — and in the same "no — compile-only" column of §7.0's head.
 
 ⚠️ **The `Ubuntu x86_64` row is still settling, and its history is worth more than its number.**
 That leg went 650s uncached → 657s (cold, nothing to restore) → 567s → 479s → 353s across five

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -39,7 +39,7 @@ function format_dir() {
   echo "Directory ${working_dir} ..."
   pushd "`pwd`" >/dev/null
   cd "${working_dir}"
-  for f in $(find . | grep -E "[^/]*\.(cpp|cc|h|hpp|inl|mm|m|java)\$"); do
+  for f in $(find . | grep -E "[^/]*\.(c|cpp|cc|h|hpp|inl|mm|m|java)\$"); do
     format_file "$f"
   done
   popd >/dev/null

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,19 +30,28 @@ endif()
 install(TARGETS Lumice
     DESTINATION "${CMAKE_INSTALL_PREFIX}")
 
-# Linux x64 release: the tarball carries two builds of every entry point (`<name>.baseline`,
-# `<name>.x86-64-v4`, produced by two configures at different LUMICE_ISA_LEVEL) and this
-# launcher installed under the user-facing name picks one by CPUID at run time
-# (src/launcher/isa_launcher.c has the full story). It deliberately gets none of the engine:
-# no lumice_obj, no -march flag — it has to run on exactly the CPUs the v4 sidecar cannot.
-# Built on every Linux x86_64 configure so a plain CI build compiles it, but only
-# release.yml's merge step installs it under the entry-point names; a local
-# build/cmake_install/<flavor>/Lumice is still the real binary.
-# Compiler floor: `__builtin_cpu_supports("x86-64-v4")` needs GCC 12+ or Clang 18+ (it is a
-# compile error below that, not a silent misdetection).
+# Linux and Windows x64 releases: the package carries two builds of every entry point
+# (`<name>.baseline` + `<name>.x86-64-v4` on Linux, `<name>.baseline.exe` +
+# `<name>.x86-64-v3.exe` on Windows, produced by two configures at different LUMICE_ISA_LEVEL)
+# and this launcher installed under the user-facing name picks one by CPUID at run time
+# (src/launcher/isa_launcher.c and isa_launcher_win.c have the full story). It deliberately
+# gets none of the engine: no lumice_obj, no -march flag — it has to run on exactly the CPUs
+# the faster sidecar cannot. Built on every x86_64 configure of either OS so a plain CI build
+# compiles it, but only release.yml's merge step installs it under the entry-point names; a
+# local build/cmake_install/<flavor>/Lumice is still the real binary.
+# Linux compiler floor: `__builtin_cpu_supports("x86-64-v4")` needs GCC 12+ or Clang 18+ (it
+# is a compile error below that, not a silent misdetection). The Windows launcher uses the
+# `<intrin.h>` CPUID/XGETBV intrinsics, which cl.exe and clang-cl both provide.
+# -Wall -Wextra stay on the Linux branch only: they are GCC/Clang spellings, and the Windows
+# file is compiled by whichever compiler the configure chose (cl.exe for the baseline tree
+# release.yml takes the launcher from; clang-cl in the v3 tree, whose copy is discarded).
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|amd64)$")
   add_executable(LumiceIsaLauncher "${PROJ_SRC_DIR}/launcher/isa_launcher.c")
   target_compile_options(LumiceIsaLauncher PRIVATE -Wall -Wextra)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows" AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|amd64)$")
+  add_executable(LumiceIsaLauncher "${PROJ_SRC_DIR}/launcher/isa_launcher_win.c")
+endif()
+if(TARGET LumiceIsaLauncher)
   install(TARGETS LumiceIsaLauncher
       DESTINATION "${CMAKE_INSTALL_PREFIX}")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,3 +29,20 @@ if(BUILD_SHARED_LIBS)
 endif()
 install(TARGETS Lumice
     DESTINATION "${CMAKE_INSTALL_PREFIX}")
+
+# Linux x64 release: the tarball carries two builds of every entry point (`<name>.baseline`,
+# `<name>.x86-64-v4`, produced by two configures at different LUMICE_ISA_LEVEL) and this
+# launcher installed under the user-facing name picks one by CPUID at run time
+# (src/launcher/isa_launcher.c has the full story). It deliberately gets none of the engine:
+# no lumice_obj, no -march flag — it has to run on exactly the CPUs the v4 sidecar cannot.
+# Built on every Linux x86_64 configure so a plain CI build compiles it, but only
+# release.yml's merge step installs it under the entry-point names; a local
+# build/cmake_install/<flavor>/Lumice is still the real binary.
+# Compiler floor: `__builtin_cpu_supports("x86-64-v4")` needs GCC 12+ or Clang 18+ (it is a
+# compile error below that, not a silent misdetection).
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|amd64)$")
+  add_executable(LumiceIsaLauncher "${PROJ_SRC_DIR}/launcher/isa_launcher.c")
+  target_compile_options(LumiceIsaLauncher PRIVATE -Wall -Wextra)
+  install(TARGETS LumiceIsaLauncher
+      DESTINATION "${CMAKE_INSTALL_PREFIX}")
+endif()

--- a/src/launcher/isa_launcher.c
+++ b/src/launcher/isa_launcher.c
@@ -1,0 +1,124 @@
+// Linux ISA launcher for the release tarball.
+//
+// The Linux x64 release ships every entry point twice — `<name>.baseline` (x86-64-v1, runs
+// on any x86_64 CPU) and `<name>.x86-64-v4` (AVX-512, ~2x faster on CPUs that have it) — and
+// installs this program under the user-facing name (`Lumice`, `LumiceGUI`). It does exactly
+// one thing: pick the sidecar this CPU can run and `execv` it. Process replacement, not
+// fork+wait: the real binary takes over this PID, so exit codes, signals (Ctrl-C on a long
+// trace) and the environment pass through with no forwarding code to get wrong.
+//
+// Two decisions worth knowing before changing anything here:
+//
+// - Detection is the CPUID instruction (`__builtin_cpu_supports`), never `/proc/cpuinfo`.
+//   `__builtin_cpu_supports("x86-64-v4")` checks the whole psABI level — every v2/v3/v4
+//   feature bit plus the XGETBV check that the OS actually saves ZMM state — which is what
+//   a `-march=x86-64-v4` binary assumes; a hand-rolled AVX-512F test would miss the OS half.
+//   It is also the only detection that can be *tested* on a machine that has AVX-512:
+//   `qemu-x86_64 -cpu <pre-AVX-512 model>` emulates CPUID per its `-cpu` argument but hands
+//   the guest the host's real `/proc/cpuinfo`, so a text-file detector would pick the v4
+//   sidecar under QEMU and SIGILL, and the negative control this launcher must pass would be
+//   defeated by the detector itself.
+//
+// - This file is plain C, is compiled with no -march flag and links nothing from the engine
+//   (no lumice_obj, no ILOG_*). It must run on the very CPUs it exists to protect, so it
+//   cannot itself be an ISA-gated binary; and because it has no logger, its two error
+//   messages go to stderr directly — the one place in src/ besides main.cpp and fatal.hpp
+//   where that is the design rather than a bypass (see the Logging rule in AGENTS.md).
+//
+// Bootstrap argument: a single `--isa=baseline` / `--isa=x86-64-v4` token anywhere in argv
+// overrides detection and is removed before the sidecar sees its arguments. It is the
+// negative-control hook and the user's escape hatch; it is deliberately not an environment
+// variable (doc/env-var-policy.md).
+
+#if !defined(__linux__) || !defined(__x86_64__)
+#error "isa_launcher.c is Linux x86_64 only: it reads /proc/self/exe and dispatches on x86 CPUID"
+#endif
+
+// readlink() and PATH_MAX are POSIX, not ISO C: ask for them explicitly rather than depend on
+// the build defaulting to gnu11 (a strict -std=c11 compile fails without this line).
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static const char kIsaPrefix[] = "--isa=";
+static const char kBaseline[] = "baseline";
+static const char kV4[] = "x86-64-v4";
+
+static void Usage(const char* self) {
+  fprintf(stderr,
+          "%s: ISA launcher. Runs %s.%s or %s.%s from the same directory, chosen by CPUID.\n"
+          "  %s%s | %s%s   force one variant (the token is consumed, not forwarded)\n",
+          self, self, kBaseline, self, kV4, kIsaPrefix, kBaseline, kIsaPrefix, kV4);
+}
+
+static const char* DetectVariant(void) {
+  __builtin_cpu_init();
+  return __builtin_cpu_supports("x86-64-v4") ? kV4 : kBaseline;
+}
+
+int main(int argc, char** argv) {
+  // Own path first: dirname decides where the sidecars are, basename decides their stem
+  // (the same launcher binary is installed as both `Lumice` and `LumiceGUI`).
+  char self_path[PATH_MAX];
+  ssize_t n = readlink("/proc/self/exe", self_path, sizeof(self_path) - 1);
+  if (n < 0) {
+    fprintf(stderr, "%s: cannot resolve /proc/self/exe: %s\n", argv[0], strerror(errno));
+    return 1;
+  }
+  self_path[n] = '\0';
+  char* slash = strrchr(self_path, '/');
+  const char* self_name = slash ? slash + 1 : self_path;
+  size_t dir_len = slash ? (size_t)(slash - self_path) + 1 : 0;  // keeps the trailing '/'
+
+  // Consume the override token; every other argument is forwarded verbatim and in order.
+  const char* forced = NULL;
+  char** fwd = (char**)calloc((size_t)argc + 1, sizeof(char*));
+  if (!fwd) {
+    fprintf(stderr, "%s: out of memory\n", self_name);
+    return 1;
+  }
+  int fwd_n = 0;
+  fwd[fwd_n++] = (char*)self_name;  // argv[0] stays the user-facing name, not the sidecar's
+  for (int i = 1; i < argc; ++i) {
+    if (strncmp(argv[i], kIsaPrefix, sizeof(kIsaPrefix) - 1) != 0) {
+      fwd[fwd_n++] = argv[i];
+      continue;
+    }
+    const char* value = argv[i] + sizeof(kIsaPrefix) - 1;
+    if (forced) {
+      fprintf(stderr, "%s: %s given more than once\n", self_name, kIsaPrefix);
+      Usage(self_name);
+      return 1;
+    }
+    if (strcmp(value, kBaseline) == 0) {
+      forced = kBaseline;
+    } else if (strcmp(value, kV4) == 0) {
+      forced = kV4;
+    } else {
+      fprintf(stderr, "%s: unknown ISA variant \"%s\"\n", self_name, value);
+      Usage(self_name);
+      return 1;
+    }
+  }
+  fwd[fwd_n] = NULL;
+
+  const char* variant = forced ? forced : DetectVariant();
+
+  char target[PATH_MAX];
+  int len = snprintf(target, sizeof(target), "%.*s%s.%s", (int)dir_len, self_path, self_name, variant);
+  if (len < 0 || (size_t)len >= sizeof(target)) {
+    fprintf(stderr, "%s: sidecar path too long\n", self_name);
+    return 1;
+  }
+
+  execv(target, fwd);
+  // execv only returns on failure. 127 is the shell's "command not found" code, and a
+  // missing or non-executable sidecar (a partially unpacked tarball) is the same failure.
+  fprintf(stderr, "%s: cannot exec %s: %s\n", self_name, target, strerror(errno));
+  return 127;
+}

--- a/src/launcher/isa_launcher_win.c
+++ b/src/launcher/isa_launcher_win.c
@@ -1,0 +1,291 @@
+// Windows ISA launcher for the release zip.
+//
+// The Windows x64 release ships every entry point twice — `<name>.baseline.exe` (x86-64-v1,
+// MSVC cl.exe, runs on any x86_64 CPU) and `<name>.x86-64-v3.exe` (AVX2+FMA, clang-cl, ~2.3x
+// faster on CPUs that have it) — and installs this program under the user-facing name
+// (`Lumice.exe`, `LumiceGUI.exe`). It does exactly one thing: pick the sidecar this CPU can
+// run and hand the process over to it. It is the Windows twin of src/launcher/isa_launcher.c;
+// the same structure, with every step that was a POSIX primitive there replaced by the
+// Win32/CRT one, and the same override token. Read that file's header for the decisions the
+// two share (CPUID-instruction detection, no engine code, plain C, stderr on purpose).
+//
+// Three things are different here, and each is a measured fact, not a preference:
+//
+// - There is no exec() on Windows. The CRT's `_execv` is not process replacement: measured on
+//   the Windows reference box, the parent exits 0 the moment the child starts (a child that
+//   returned 3 read as ERRORLEVEL 0 in the calling shell), and `_execv` joins argv with spaces
+//   and no quoting (an argument "a b" arrived as two). So this launcher spawns the sidecar with
+//   CreateProcess from a command line it quotes itself (MSVC argv rules, below), waits, and
+//   returns the child's exit code as its own — the exit-code and argv pass-through that execv
+//   gives Linux for free are the two things a launcher must not get wrong.
+//
+// - Ctrl-C goes to every process attached to the console, so the sidecar sees it directly
+//   with no forwarding. The launcher installs a handler that swallows its own copy — a handler
+//   *function*, never `SetConsoleCtrlHandler(NULL, TRUE)`, whose ignore flag is inherited by
+//   the child and would make the engine itself deaf to Ctrl-C — and keeps waiting, so the
+//   shell sees the child's real termination status rather than the launcher dying first.
+//
+// - The launcher detaches from the console once the child is running. LumiceGUI is a
+//   console-subsystem binary that calls FreeConsole() at startup so the window Explorer opens
+//   for a double-click closes again; with the launcher still attached that window would stay
+//   open for the whole GUI session. Detaching costs the CLI nothing: the child inherited the
+//   stdout/stderr handles at creation, and the launcher writes nothing after this point.
+//
+// Detection covers the whole x86-64-v3 psABI level (every v2/v3 feature bit plus the XGETBV
+// check that the OS saves YMM state), not just the four bits an AVX2 binary visibly needs:
+// `-march=x86-64-v3` lets the compiler use all of them, and the Linux launcher's
+// `__builtin_cpu_supports("x86-64-v4")` checks its whole level the same way. Order matters in
+// one place: OSXSAVE (CPUID.1:ECX[27]) must be confirmed before `_xgetbv` is executed — with
+// CR4.OSXSAVE clear (a machine booted with `bcdedit /set xsavedisable 1`) XGETBV is #UD, and
+// the launcher exists precisely to not crash on the CPU/OS states it is protecting against.
+
+#if !defined(_WIN32) || !defined(_M_X64)
+#error "isa_launcher_win.c is Windows x64 only: it reads GetModuleFileName and dispatches on x86 CPUID"
+#endif
+
+#include <intrin.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <windows.h>
+
+static const char kIsaPrefix[] = "--isa=";
+static const char kBaseline[] = "baseline";
+static const char kV3[] = "x86-64-v3";
+static const char kExeSuffix[] = ".exe";
+
+static void Usage(const char* self) {
+  fprintf(stderr,
+          "%s: ISA launcher. Runs %s.%s.exe or %s.%s.exe from the same directory, chosen by CPUID.\n"
+          "  %s%s | %s%s   force one variant (the token is consumed, not forwarded)\n",
+          self, self, kBaseline, self, kV3, kIsaPrefix, kBaseline, kIsaPrefix, kV3);
+}
+
+// One CPUID feature bit: which leaf/subleaf to query, which register (0=EAX..3=EDX) and bit.
+typedef struct {
+  int leaf;
+  int subleaf;
+  int reg;
+  int bit;
+} CpuidBit;
+
+static int HasBit(const CpuidBit* b) {
+  int info[4];
+  __cpuidex(info, b->leaf, b->subleaf);
+  return (info[b->reg] >> b->bit) & 1;
+}
+
+static const char* DetectVariant(void) {
+  // Leaf availability first: CPUID.0:EAX is the highest basic leaf, and leaf 7 (AVX2/BMI) is
+  // only meaningful if it is reported; the extended leaf 0x80000001 likewise.
+  int info[4];
+  __cpuid(info, 0);
+  if ((unsigned)info[0] < 7u) {
+    return kBaseline;
+  }
+  __cpuid(info, (int)0x80000000);
+  if ((unsigned)info[0] < 0x80000001u) {
+    return kBaseline;
+  }
+
+  // x86-64-v2: CMPXCHG16B, LAHF-SAHF, POPCNT, SSE3, SSE4.1, SSE4.2, SSSE3.
+  // x86-64-v3: AVX, AVX2, BMI1, BMI2, F16C, FMA, LZCNT, MOVBE, plus OS-enabled YMM state.
+  static const CpuidBit kV3Bits[] = {
+    { 1, 0, 2, 0 },                // SSE3
+    { 1, 0, 2, 9 },                // SSSE3
+    { 1, 0, 2, 12 },               // FMA
+    { 1, 0, 2, 13 },               // CMPXCHG16B
+    { 1, 0, 2, 19 },               // SSE4.1
+    { 1, 0, 2, 20 },               // SSE4.2
+    { 1, 0, 2, 22 },               // MOVBE
+    { 1, 0, 2, 23 },               // POPCNT
+    { 1, 0, 2, 27 },               // OSXSAVE — must be checked before _xgetbv below (XGETBV is #UD otherwise)
+    { 1, 0, 2, 28 },               // AVX
+    { 1, 0, 2, 29 },               // F16C
+    { 7, 0, 1, 3 },                // BMI1
+    { 7, 0, 1, 5 },                // AVX2
+    { 7, 0, 1, 8 },                // BMI2
+    { (int)0x80000001, 0, 2, 0 },  // LAHF-SAHF
+    { (int)0x80000001, 0, 2, 5 },  // LZCNT (ABM)
+  };
+  for (size_t i = 0; i < sizeof(kV3Bits) / sizeof(kV3Bits[0]); ++i) {
+    if (!HasBit(&kV3Bits[i])) {
+      return kBaseline;
+    }
+  }
+  // Every bit above is set, OSXSAVE included, so XGETBV is legal here. XCR0[1] = SSE state,
+  // XCR0[2] = AVX (YMM upper) state: the OS has to save both across context switches, or a
+  // -march=x86-64-v3 binary corrupts its own registers.
+  unsigned long long xcr0 = _xgetbv(0);
+  if ((xcr0 & 0x6ull) != 0x6ull) {
+    return kBaseline;
+  }
+  return kV3;
+}
+
+// Append one argument to a command line the way the MSVC CRT (and CommandLineToArgvW) will
+// read it back: quote when it contains whitespace, a quote, or is empty; inside quotes,
+// double every backslash run that precedes a quote (or the closing quote) and escape the
+// quote itself. Returns the number of characters written, or -1 if `cap` is too small.
+static int AppendQuoted(char* out, size_t cap, size_t at, const char* arg) {
+  size_t n = at;
+  int need_quotes = (*arg == '\0') || (strpbrk(arg, " \t\"") != NULL);
+  if (!need_quotes) {
+    size_t len = strlen(arg);
+    if (n + len + 1 > cap)
+      return -1;
+    memcpy(out + n, arg, len);
+    return (int)(n + len);
+  }
+  if (n + 1 > cap)
+    return -1;
+  out[n++] = '"';
+  for (const char* p = arg; *p; ++p) {
+    size_t backslashes = 0;
+    while (*p == '\\') {
+      ++backslashes;
+      ++p;
+    }
+    if (*p == '\0') {
+      // Trailing backslashes precede the closing quote: double them.
+      if (n + 2 * backslashes + 1 > cap)
+        return -1;
+      memset(out + n, '\\', 2 * backslashes);
+      n += 2 * backslashes;
+      break;
+    }
+    if (*p == '"') {
+      if (n + 2 * backslashes + 2 + 1 > cap)
+        return -1;
+      memset(out + n, '\\', 2 * backslashes + 1);
+      n += 2 * backslashes + 1;
+      out[n++] = '"';
+    } else {
+      if (n + backslashes + 1 + 1 > cap)
+        return -1;
+      memset(out + n, '\\', backslashes);
+      n += backslashes;
+      out[n++] = *p;
+    }
+  }
+  out[n++] = '"';
+  return (int)n;
+}
+
+static BOOL WINAPI SwallowCtrl(DWORD type) {
+  (void)type;
+  // Handled: the sidecar, attached to the same console, receives the same event and acts on
+  // it; this process just keeps waiting for it to exit.
+  return TRUE;
+}
+
+static void PrintLastError(const char* self, const char* what, const char* target) {
+  DWORD err = GetLastError();
+  char msg[512];
+  DWORD n =
+      FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, err, 0, msg, sizeof(msg), NULL);
+  if (n == 0) {
+    snprintf(msg, sizeof(msg), "error %lu", (unsigned long)err);
+  }
+  fprintf(stderr, "%s: %s %s: %s", self, what, target, msg);
+  if (n == 0 || msg[n - 1] != '\n')
+    fputc('\n', stderr);
+}
+
+int main(int argc, char** argv) {
+  // Own path first: the directory decides where the sidecars are, the stem (file name minus
+  // `.exe`) decides their names — the same launcher binary is installed as both `Lumice.exe`
+  // and `LumiceGUI.exe`.
+  char self_path[MAX_PATH];
+  DWORD n = GetModuleFileNameA(NULL, self_path, (DWORD)sizeof(self_path));
+  if (n == 0 || n >= sizeof(self_path)) {
+    fprintf(stderr, "%s: cannot resolve own executable path\n", argv[0]);
+    return 1;
+  }
+  char* slash = strrchr(self_path, '\\');
+  const char* self_name = slash ? slash + 1 : self_path;
+  size_t dir_len = slash ? (size_t)(slash - self_path) + 1 : 0;  // keeps the trailing '\'
+  char stem[MAX_PATH];
+  snprintf(stem, sizeof(stem), "%s", self_name);
+  size_t stem_len = strlen(stem);
+  if (stem_len > sizeof(kExeSuffix) - 1 && _stricmp(stem + stem_len - (sizeof(kExeSuffix) - 1), kExeSuffix) == 0) {
+    stem[stem_len - (sizeof(kExeSuffix) - 1)] = '\0';
+  }
+
+  // Consume the override token; every other argument is forwarded verbatim and in order.
+  const char* forced = NULL;
+  size_t cmd_cap = 32768;  // CreateProcess's own command-line limit
+  char* cmd = (char*)malloc(cmd_cap);
+  if (!cmd) {
+    fprintf(stderr, "%s: out of memory\n", self_name);
+    return 1;
+  }
+  int cmd_len = AppendQuoted(cmd, cmd_cap, 0, self_name);  // argv[0] stays the user-facing name
+  for (int i = 1; i < argc && cmd_len >= 0; ++i) {
+    if (strncmp(argv[i], kIsaPrefix, sizeof(kIsaPrefix) - 1) != 0) {
+      if ((size_t)cmd_len + 1 >= cmd_cap) {
+        cmd_len = -1;
+        break;
+      }
+      cmd[cmd_len++] = ' ';
+      cmd_len = AppendQuoted(cmd, cmd_cap, (size_t)cmd_len, argv[i]);
+      continue;
+    }
+    const char* value = argv[i] + sizeof(kIsaPrefix) - 1;
+    if (forced) {
+      fprintf(stderr, "%s: %s given more than once\n", self_name, kIsaPrefix);
+      Usage(stem);
+      return 1;
+    }
+    if (strcmp(value, kBaseline) == 0) {
+      forced = kBaseline;
+    } else if (strcmp(value, kV3) == 0) {
+      forced = kV3;
+    } else {
+      fprintf(stderr, "%s: unknown ISA variant \"%s\"\n", self_name, value);
+      Usage(stem);
+      return 1;
+    }
+  }
+  if (cmd_len < 0) {
+    fprintf(stderr, "%s: command line too long\n", self_name);
+    return 1;
+  }
+  cmd[cmd_len] = '\0';
+
+  const char* variant = forced ? forced : DetectVariant();
+
+  char target[MAX_PATH];
+  int len = snprintf(target, sizeof(target), "%.*s%s.%s%s", (int)dir_len, self_path, stem, variant, kExeSuffix);
+  if (len < 0 || (size_t)len >= sizeof(target)) {
+    fprintf(stderr, "%s: sidecar path too long\n", self_name);
+    return 1;
+  }
+
+  SetConsoleCtrlHandler(SwallowCtrl, TRUE);
+
+  STARTUPINFOA si;
+  PROCESS_INFORMATION pi;
+  memset(&si, 0, sizeof(si));
+  si.cb = sizeof(si);
+  memset(&pi, 0, sizeof(pi));
+  // lpApplicationName is the resolved sidecar path, so no PATH or current-directory search
+  // takes place; lpCommandLine is what the child parses into its argv. Handles are inherited
+  // so `> file` and pipes set up by the caller reach the child unchanged.
+  if (!CreateProcessA(target, cmd, NULL, NULL, TRUE, 0, NULL, NULL, &si, &pi)) {
+    // 127 is the shell's "command not found" code, and a missing sidecar (a partially
+    // unpacked zip) is the same failure — the same code the Linux launcher uses.
+    PrintLastError(self_name, "cannot start", target);
+    return 127;
+  }
+  CloseHandle(pi.hThread);
+  FreeConsole();
+
+  WaitForSingleObject(pi.hProcess, INFINITE);
+  DWORD code = 1;
+  if (!GetExitCodeProcess(pi.hProcess, &code)) {
+    code = 1;
+  }
+  CloseHandle(pi.hProcess);
+  return (int)code;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -591,13 +591,16 @@ void RunBenchmarkPass(const std::string& config_str, int num_workers, const char
       // ISA tier this binary was actually compiled for, so a recorded [BENCHMARK] line
       // answers "which build was this measured on?" without anyone having to still have
       // the configure log. "native" means -march=native was compiled in (local default);
-      // "baseline" is what release and CI ship, and is the only tier comparable across
-      // platforms — MSVC has no equivalent flag, so a Windows-vs-other A/B taken on
-      // "native" numbers is not measuring what it looks like it is measuring. The macro
-      // is defined by CMakeLists.txt's LUMICE_NATIVE_ARCH_ACTIVE_COND, which gates the
-      // -march=native flag itself; see doc/performance-testing.md.
-#if defined(LUMICE_NATIVE_ARCH_ACTIVE)
-      result["isa"] = "native";
+      // "x86-64-v4" is the AVX-512 variant the Linux release ships beside the baseline;
+      // "baseline" is what CI tests and every other release build ships, and is the only
+      // tier comparable across platforms — MSVC has no equivalent flag, so a
+      // Windows-vs-other A/B taken on "native" numbers is not measuring what it looks like
+      // it is measuring. The string is CMakeLists.txt's LUMICE_ISA_LEVEL_STR, resolved by
+      // the same LUMICE_ISA_LEVEL_ACTIVE_COND that gates the -march flag itself, so it
+      // reads "baseline" whenever no flag was applied (any non-Release config included);
+      // see doc/performance-testing.md. MSVC never defines it.
+#if defined(LUMICE_ISA_LEVEL_STR)
+      result["isa"] = LUMICE_ISA_LEVEL_STR;
 #else
       result["isa"] = "baseline";
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -592,13 +592,14 @@ void RunBenchmarkPass(const std::string& config_str, int num_workers, const char
       // answers "which build was this measured on?" without anyone having to still have
       // the configure log. "native" means -march=native was compiled in (local default);
       // "x86-64-v4" is the AVX-512 variant the Linux release ships beside the baseline;
+      // "x86-64-v3" is the AVX2 variant the Windows release ships beside it (clang-cl);
       // "baseline" is what CI tests and every other release build ships, and is the only
-      // tier comparable across platforms — MSVC has no equivalent flag, so a
+      // tier comparable across platforms — real MSVC cl.exe has no equivalent flag, so a
       // Windows-vs-other A/B taken on "native" numbers is not measuring what it looks like
-      // it is measuring. The string is CMakeLists.txt's LUMICE_ISA_LEVEL_STR, resolved by
-      // the same LUMICE_ISA_LEVEL_ACTIVE_COND that gates the -march flag itself, so it
-      // reads "baseline" whenever no flag was applied (any non-Release config included);
-      // see doc/performance-testing.md. MSVC never defines it.
+      // it is measuring. The string is CMakeLists.txt's LUMICE_ISA_LEVEL_STR, resolved in
+      // lumice_apply_isa_march() by the same condition that gates the -march flag itself,
+      // so it reads "baseline" whenever no flag was applied (any non-Release config
+      // included); see doc/performance-testing.md. cl.exe never defines it.
 #if defined(LUMICE_ISA_LEVEL_STR)
       result["isa"] = LUMICE_ISA_LEVEL_STR;
 #else

--- a/test/e2e-correctness/test_cli.py
+++ b/test/e2e-correctness/test_cli.py
@@ -568,23 +568,24 @@ class TestAxisSlotTypeRequired(LumiceTestCase):
 class TestBenchmarkIsaField(LumiceTestCase):
     """`--benchmark`'s JSON must say which ISA tier the binary was compiled for.
 
-    Why the key exists at all: a Release build takes `-march=native` unless
-    `-DLUMICE_NATIVE_ARCH=OFF` is passed, local `scripts/build.sh` does not pass it,
-    every release and CI job does, and MSVC has no equivalent flag wired up. So a
+    Why the key exists at all: a Release build's ISA tier is `LUMICE_ISA_LEVEL`
+    (`baseline` | `x86-64-v4` | `native`); local `scripts/build.sh` takes the `native`
+    default, every CI job passes `baseline`, the Linux release builds `baseline` and
+    `x86-64-v4` side by side, and MSVC has no equivalent flag wired up. So a
     throughput number recorded off a local build is not the shipped binary's number,
     and a Windows-vs-other comparison of two local builds is ISA-asymmetric by
     default. The `isa` key makes an already-recorded number answer that on its own.
 
     Why this test is not "run it and read the output": the cross-check below reads
     `CMakeCache.txt`, which CMake writes at configure time. That is a different
-    producer from the `LUMICE_NATIVE_ARCH_ACTIVE` macro → `#if` → JSON path being
+    producer from the `LUMICE_ISA_LEVEL_STR` macro → `#if` → JSON path being
     checked, so the two do not share a failure mode: if the generator expression
-    gating the macro were written wrong (inverted, or missing one of its two
+    resolving the macro were written wrong (inverted, or missing one of its two
     conjuncts), the cache would still hold what CMake actually consumed and this
     would go red.
     """
 
-    _ISA_VALUES = {"native", "baseline"}
+    _ISA_VALUES = {"native", "baseline", "x86-64-v4"}
 
     def _run_benchmark(self):
         """Run `--benchmark` on the shared bench config with a ray budget small
@@ -672,13 +673,13 @@ class TestBenchmarkIsaField(LumiceTestCase):
             )
         cache_text = cache_path.read_text()
 
-        native_arch = self._read_cache_entry(cache_text, "LUMICE_NATIVE_ARCH")
+        isa_level = self._read_cache_entry(cache_text, "LUMICE_ISA_LEVEL")
         build_type = self._read_cache_entry(cache_text, "CMAKE_BUILD_TYPE")
         compiler_id = self._read_cache_entry(cache_text, "LUMICE_COMPILER_ID_SNAPSHOT")
         missing = [
             name
             for name, value in (
-                ("LUMICE_NATIVE_ARCH", native_arch),
+                ("LUMICE_ISA_LEVEL", isa_level),
                 ("CMAKE_BUILD_TYPE", build_type),
                 ("LUMICE_COMPILER_ID_SNAPSHOT", compiler_id),
             )
@@ -690,10 +691,12 @@ class TestBenchmarkIsaField(LumiceTestCase):
             # than raising KeyError or inventing an expectation.
             self.skipTest(f"{cache_path} lacks {', '.join(missing)} — cross-check skipped")
 
-        native_on = native_arch.upper() in ("ON", "1", "TRUE", "YES", "Y")
+        # The tier name is reported only when its -march flag was actually applied:
+        # Release config on a non-MSVC compiler. Everything else (Debug, MinSizeRel,
+        # MSVC, or the baseline tier itself) compiles without a flag and must say so.
         expected = (
-            "native"
-            if (native_on and build_type == "Release" and compiler_id != "MSVC")
+            isa_level
+            if (build_type == "Release" and compiler_id != "MSVC")
             else "baseline"
         )
         for row in self._run_benchmark():
@@ -701,6 +704,6 @@ class TestBenchmarkIsaField(LumiceTestCase):
                 row["isa"],
                 expected,
                 f"isa={row['isa']!r} but {cache_path} records "
-                f"LUMICE_NATIVE_ARCH={native_arch}, CMAKE_BUILD_TYPE={build_type}, "
+                f"LUMICE_ISA_LEVEL={isa_level}, CMAKE_BUILD_TYPE={build_type}, "
                 f"LUMICE_COMPILER_ID_SNAPSHOT={compiler_id} (expected {expected!r})",
             )

--- a/test/e2e-correctness/test_cli.py
+++ b/test/e2e-correctness/test_cli.py
@@ -569,12 +569,14 @@ class TestBenchmarkIsaField(LumiceTestCase):
     """`--benchmark`'s JSON must say which ISA tier the binary was compiled for.
 
     Why the key exists at all: a Release build's ISA tier is `LUMICE_ISA_LEVEL`
-    (`baseline` | `x86-64-v4` | `native`); local `scripts/build.sh` takes the `native`
-    default, every CI job passes `baseline`, the Linux release builds `baseline` and
-    `x86-64-v4` side by side, and MSVC has no equivalent flag wired up. So a
-    throughput number recorded off a local build is not the shipped binary's number,
-    and a Windows-vs-other comparison of two local builds is ISA-asymmetric by
-    default. The `isa` key makes an already-recorded number answer that on its own.
+    (`baseline` | `x86-64-v3` | `x86-64-v4` | `native`); local `scripts/build.sh` takes
+    the `native` default, every CI job passes `baseline`, the Linux release builds
+    `baseline` and `x86-64-v4` side by side, the Windows release builds `baseline`
+    (MSVC cl.exe) and `x86-64-v3` (clang-cl) side by side, and real MSVC cl.exe has no
+    equivalent flag wired up. So a throughput number recorded off a local build is not
+    the shipped binary's number, and a Windows-vs-other comparison of two local builds
+    is ISA-asymmetric by default. The `isa` key makes an already-recorded number answer
+    that on its own.
 
     Why this test is not "run it and read the output": the cross-check below reads
     `CMakeCache.txt`, which CMake writes at configure time. That is a different
@@ -585,7 +587,7 @@ class TestBenchmarkIsaField(LumiceTestCase):
     would go red.
     """
 
-    _ISA_VALUES = {"native", "baseline", "x86-64-v4"}
+    _ISA_VALUES = {"native", "baseline", "x86-64-v3", "x86-64-v4"}
 
     def _run_benchmark(self):
         """Run `--benchmark` on the shared bench config with a ray budget small
@@ -656,14 +658,16 @@ class TestBenchmarkIsaField(LumiceTestCase):
     def test_isa_key_matches_the_configure_time_record(self):
         """Cross-check layer — the `isa` value against CMake's own configure record.
 
-        Stated assumption: the oracle below treats `compiler_id == "MSVC"` as
-        equivalent to CMake's `MSVC` boolean, which is what CMakeLists.txt actually
-        gates the macro on. Those two decouple under clang-cl (`MSVC` is true, but
-        the compiler id is "Clang"), which would make this oracle expect "native"
-        against a binary correctly reporting "baseline". No clang-cl build exists in
-        this repo's toolchain matrix today; if one is introduced, persist the `MSVC`
-        boolean itself as a second cache snapshot rather than inferring it from the
-        compiler id.
+        The oracle below keys on `compiler_id == "MSVC"`, and that is exactly the
+        right key even though CMake's `MSVC` boolean is also true for clang-cl: under
+        clang-cl `LUMICE_COMPILER_ID_SNAPSHOT` reads "Clang", and CMakeLists.txt
+        defines the macro for clang-cl too (`lumice_apply_isa_march()` runs in both the
+        GCC/Clang and the clang-cl branch; only real cl.exe never defines it). So a
+        clang-cl Release build at `x86-64-v3` is expected to report "x86-64-v3", which
+        is what the Windows release's second variant is measured to do. The one way
+        for this oracle to go wrong is the failure it exists to catch: gating the macro
+        on `if(MSVC)` alone, which would leave a clang-cl binary reporting "baseline"
+        while this test expects the tier.
         """
         cache_path = self._find_cmake_cache()
         if cache_path is None:


### PR DESCRIPTION
## Summary

Scrum `hardware-perf-distribution` (534): let the shipped binaries use the hardware they land on, **without moving the support floor** — the CPU baseline stays x86-64-v1 and the CUDA PTX floor stays `compute_61`. The shape is "one download, the choice happens on the user's machine". 14 commits, three deliverables:

### 1. CUDA fatbin ships native `sm_120` (RTX 50) — `8934ef0e` `a65626aa` `e931bf59`
- `CMakeLists.txt`: default arch table gains `120-real` on toolkit >= 12.8, same gate shape as the existing `75/86/89-real` rows.
- CI `cuda-compile`, CI `windows-cuda-compile` and the release windows-x64 artifact move CUDA 12.6.3 -> 12.9.2 (last 12.x minor; same major, so the `compute_61 -> CUDA 12 -> VS 2022 -> windows-2022` chain is untouched — that chain is now spelled out in the `windows-cuda-compile` pin rationale).
- home-win (RTX 5090 D): `cuobjdump --list-elf Lumice.exe` lists `sm_75/86/89/120` + `sm_61` PTX; first-launch JIT drops 1.87 s -> 0.22 s (differential vs a control build without `120-real`); CUDA parity battery 11/11.

### 2. Linux x64 release: baseline + x86-64-v4 behind a CPUID launcher — `2a93a027` … `e81144cf`
- `LUMICE_ISA_LEVEL ∈ {baseline, x86-64-v3, x86-64-v4, native}` replaces the ON/OFF `LUMICE_NATIVE_ARCH`; the `[BENCHMARK]` `isa` key reports the tier from the same generator-expression condition as the `-march` flag.
- `src/launcher/isa_launcher.c`: pure C, CPUID-instruction detection (`__builtin_cpu_supports("x86-64-v4")` — QEMU proved `/proc/cpuinfo` is the host's), `execv` semantics, `--isa=<level>` override.
- release.yml linux-x64: two configure/build/install passes + merge; tarball ships `Lumice`, `Lumice.baseline`, `Lumice.x86-64-v4` and the same trio for `LumiceGUI`, entry names unchanged. New CI leg `isa-v4-compile`.
- home-wsl (9950X): v4 variant **1.990×** at W=1 (CoV 0.3%) vs baseline, same session; QEMU `-cpu Skylake-Client` negative control: v4 sidecar exits 132 (SIGILL), launcher picks baseline and runs.

### 3. Windows x64 release: baseline (cl.exe) + x86-64-v3 (clang-cl) behind a CPUID launcher — `238202be` … `119f02d8`
- Probe result that shaped this: MSVC gets nothing from `/arch:*` (it barely vectorizes these loops); **clang-cl 20.1 gets 2.26× at `-march=x86-64-v3` (AVX2+FMA)**, and v4 / AVX-512 add nothing on top — the opposite of GCC, where v3 is 0.993× and the gain is all in v3->v4. So the Windows tier is v3, which covers every Haswell+/Zen1+ desktop including Intel 12–14 gen.
- `LUMICE_ISA_LEVEL` now applies under clang-cl (CMake files clang-cl as `MSVC=1`; an explicit `LUMICE_CLANG_CL` branch calls the shared `lumice_apply_isa_march()` via `target_compile_options`, so `/EHsc` is not clobbered).
- `src/launcher/isa_launcher_win.c`: `__cpuid`/`_xgetbv` full x86-64-v3 psABI check incl. XCR0 (OS YMM state), `CreateProcessA` + Ctrl-C forwarding + exit-code passthrough (`_execv` was probed and rejected: it does not wait and does not quote arguments).
- release.yml windows-x64: baseline pass explicitly `-DCMAKE_{C,CXX}_COMPILER=cl`, v3 pass clang-cl by full path (LLVM deliberately not on PATH — the first run showed Ninja picking clang++ for the baseline pass); zip ships the six executables + `cudart64_12.dll`. New CI leg `windows-isa-v3-compile` (clang-cl × nvcc/cl.exe, CUDA ON, asserts the `isa` key).
- home-win, CUDA ON, same session: v3 variant **2.234×** at W=1 vs baseline; `bcdedit /set xsavedisable 1` real AVX-disabled negative control: v3 variant raises `STATUS_ILLEGAL_INSTRUCTION` directly, launcher auto-falls back to baseline and runs; `--backend cuda` works on the v3 variant.

Out of scope, deliberately: the GPU-backend factory default (still CPU on all three entry points), CUDA major 13, VS 2026 / windows-2025, any change to the support floor.

## Verification
- CI on this PR @ `119f02d8`: 17/18 success, `benchmark-summary` skipped as designed on PRs. Release `workflow_dispatch` run 34588143182 @ `119f02d8`: windows-x64 11m03s green, six-executable zip verified.
- Each subtask carries independent code review (APPROVE, 0 Critical / 0 Major) and per-AC first-hand evidence; `./scripts/test.sh quick` PASS on the final state (one `RenderConsumerLabel.*` red on the first run is the already-recorded load-dependent flake, isolated rerun 3/3 green).
- All throughput numbers are from one machine (9950X / Zen 5); "v3 also gives ~2.2× on Intel" is inferred from v3 using only AVX2/FMA, not measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Wd3Zv7hDGZoG4hJ2TvW2G
