### PR TITLE
chore: refresh the install manual, land the metric-by-layer review minors, report wrong-size anchor planes once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,12 +421,18 @@ jobs:
       # rule that has to tolerate this runner but not a real layout change has to be derived from
       # these captures, not from the log. Same condition, action and retention as the log: one
       # diagnostic family, one policy.
+      # if-no-files-found: the directory is created up front by the run step, so an empty upload
+      # would otherwise succeed silently — and an empty capture set is exactly the evidence loss
+      # this artifact exists to prevent (a filter that matched nothing, a binary that never got as
+      # far as a capture). Make that state red here rather than discover it when someone opens the
+      # artifact.
       - name: Upload GUI visual-regression captures
         if: always() && matrix.run_gui_visual == 'ON'
         uses: actions/upload-artifact@v7
         with:
           name: gui-visual-regression-captures
           path: gui_captures
+          if-no-files-found: error
           retention-days: 30
 
       - name: Benchmark

--- a/doc/user-manual/01-install.md
+++ b/doc/user-manual/01-install.md
@@ -2,7 +2,7 @@
 
 # Install and Build Lumice
 
-This chapter walks you from a fresh clone to a working `Lumice` and `LumiceGUI` binary, plus a smoke test that confirms the toolchain is wired up correctly.
+This chapter walks you from a fresh clone to a working `Lumice` binary (and, if you want it, `LumiceGUI`), plus a smoke test that confirms the toolchain is wired up correctly.
 
 ## Prerequisites
 
@@ -11,37 +11,40 @@ Lumice is a C++17 project built with CMake. You need the following on `PATH`:
 | Tool | Minimum | Notes |
 |------|---------|-------|
 | C++ compiler | C++17 | Apple Clang ≥ 14, GCC ≥ 11, MSVC 2022 |
-| CMake | 3.20 | `cmake --version` |
-| Ninja | 1.10 | recommended generator (`ninja --version`) |
-| Python | 3.9 | only required for E2E tests under `test/e2e/` |
-| Qt 6 | 6.5 | optional, required only for the GUI binary |
+| CMake | 3.14 | `cmake --version` |
+| Ninja | 1.10 | recommended generator (`ninja --version`); `scripts/build.sh` passes `-G Ninja` |
+| Python | 3.9 | required by **every** build: CMake runs `scripts/embed_binary.py` at build time to embed the label font. Also runs the E2E tests under `test/` |
+| OpenGL dev packages | — | GUI build (`-g`) only. macOS and Windows need nothing extra. On Linux GLFW builds against X11 and the file dialog against GTK 3: `sudo apt-get install libgl-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgtk-3-dev` |
 
-External libraries (spdlog, nlohmann/json, stb, googletest, …) are fetched automatically via [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) at configure time — you do not need to install them by hand.
+External libraries (spdlog, nlohmann/json, stb, googletest, and for the GUI GLFW, Dear ImGui, nativefiledialog-extended, …) are fetched automatically via [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) at configure time — you do not need to install them by hand. The downloaded sources are cached per machine under `$HOME/.cache/lumice-cpm` (`$USERPROFILE/.cache/lumice-cpm` on a Windows shell that sets no `HOME`), so a second clone or worktree on the same machine does not re-download them; set `CPM_SOURCE_CACHE` to move the cache elsewhere.
 
 ## Build
 
 The convenience script `scripts/build.sh` is the supported way to build:
 
 ```bash
-# Release build, parallel, install artefacts under build/cmake_install/static/
+# Release build of the CLI, parallel, install artefacts under build/cmake_install/static/
 ./scripts/build.sh -j release
 ```
 
 Other useful flavours (see `scripts/build.sh -h` for the full list):
 
 ```bash
+./scripts/build.sh -gj release    # build the GUI as well (Dear ImGui + GLFW + OpenGL)
 ./scripts/build.sh -tj release    # build + run unit tests
-./scripts/build.sh -gtj release   # build + run GUI tests (needs a display server)
+./scripts/build.sh -gtj release   # build GUI + run unit tests and GUI tests (needs a display server)
 LUMICE_SKIP_GUI_TESTS=1 ./scripts/build.sh -gtj release   # skip GUI tests on a headless box
-./scripts/build.sh -k release     # clean and rebuild
+./scripts/build.sh -k release     # clean this flavour's build tree and rebuild (keeps the CPM cache)
 ```
+
+`-t` / `-g` / `-b` choose *what* to build (tests / GUI app / benchmarks); the GUI binary only exists after a build that passed `-g`. `-s` switches the library flavour to shared (static when omitted) and composes with any of them.
 
 After a successful release build, the artefacts you care about live here:
 
 | Artefact | Path | Purpose |
 |----------|------|---------|
 | CLI binary | `build/cmake_install/static/Lumice` | Run a JSON config from the command line |
-| GUI binary | `build/cmake_install/static/LumiceGUI` | Interactive GUI app (requires Qt) |
+| GUI binary | `build/cmake_install/static/LumiceGUI` | Interactive GUI app (only built with `-g`; no runtime dependency beyond the system's OpenGL driver) |
 
 > Both trees are per-flavor: a `-s` (shared) build never shares a directory with a static one. The
 > CMake build tree is `build/cmake_build/<flavor>/`. Release artefacts in `build/cmake_install/static/`
@@ -51,32 +54,35 @@ After a successful release build, the artefacts you care about live here:
 
 ## Smoke test
 
-Run the bundled example config to confirm the binary works end-to-end. From the project root:
+Run the bundled example config to confirm the binary works end-to-end. From the project root (the CLI does not create the output directory for you):
 
 ```bash
+mkdir -p /tmp/lumice-smoke
 ./build/cmake_install/static/Lumice -f examples/config_example.json -o /tmp/lumice-smoke
 ```
 
 You should see:
 
-1. A short banner identifying the build.
-2. Per-batch progress lines while rays are traced.
-3. A final `Stats: ...` block with the total simulated rays.
-4. Four `.jpg` files written to `/tmp/lumice-smoke/`, named `example_img_01.jpg` … `example_img_04.jpg`.
+1. A few `[I]` log lines at startup (`CommitConfig`, `GenerateScene`, `ConsumeData`) identifying the run.
+2. Roughly once per second, a `Saved: ...` line per output image followed by a `Stats: sim_rays=..., crystals=..., orientations=...` line — the CLI re-saves its intermediate renders as the simulation accumulates.
+3. A final `Saved:` / `Stats:` block once all rays are traced.
+4. Four `.jpg` files in `/tmp/lumice-smoke/`, named `img_01.jpg` … `img_04.jpg` (one per `render` entry in the config).
 
 ![Lumice CLI completion output](../figs/cli_screenshot_02.jpg)
 
 If you see all four images, the toolchain is healthy.
 
-> The example config uses 9 spectral wavelengths × `ray_num=5e7`, so the simulator traces ~4.5 × 10⁸ rays. On a recent multi-core laptop this takes about 2 minutes. To get a faster smoke test, copy the example and lower `scene.ray_num` to `1e6`.
+> The example config sets `scene.ray_num` to `4.5e8` — the total across its 9 spectral wavelengths. On a recent multi-core laptop this takes about 2 minutes. To get a faster smoke test, copy the example and lower `scene.ray_num` to `1e6`.
 
 ## Common build issues
 
 | Symptom | Likely cause | Fix |
 |---------|--------------|-----|
 | `cmake: command not found` | CMake not installed or not on `PATH` | Install via Homebrew / apt / official installer |
-| Build fails downloading dependencies | First build with no CPM cache and no network | Re-run with network access; CPM caches under `~/.cache/CPM` |
-| GUI fails at runtime with Qt error | Qt 6 not on the loader path | Either install Qt 6 system-wide, or build with `-DLUMICE_BUILD_GUI=OFF` |
+| Build fails downloading dependencies | First build with no CPM cache and no network | Re-run with network access; CPM caches under `$HOME/.cache/lumice-cpm` (or wherever `CPM_SOURCE_CACHE` points) |
+| Configure fails on `Python3` | No Python 3 interpreter on `PATH` | Install Python 3 — every build needs it to embed fonts |
+| GUI configure fails in GLFW / nfd (Linux) | X11 / OpenGL / GTK 3 dev headers missing | Install the packages from the prerequisites table, or build without the GUI (drop `-g`) |
+| GUI exits at startup with a GLFW / OpenGL error | No display, or no OpenGL 3.3 driver on the loader path | Run on a machine with a desktop session; on a headless box use the CLI instead |
 | `LUMICE_SKIP_GUI_TESTS` ignored on CI | Stale cached config | `./scripts/build.sh -k release` to clean rebuild |
 
 ## Further reading

--- a/doc/user-manual/01-install_zh.md
+++ b/doc/user-manual/01-install_zh.md
@@ -2,7 +2,7 @@
 
 # 安装与构建 Lumice
 
-本章带你从一份干净的 clone，走到一对可用的 `Lumice` / `LumiceGUI` 二进制文件，并执行一次 smoke test 确认工具链就位。
+本章带你从一份干净的 clone，走到一个可用的 `Lumice` 二进制文件（需要的话再加上 `LumiceGUI`），并执行一次 smoke test 确认工具链就位。
 
 ## 前置依赖
 
@@ -11,37 +11,40 @@ Lumice 是一个使用 CMake 构建的 C++17 项目，环境需要：
 | 工具 | 最低版本 | 说明 |
 |------|----------|------|
 | C++ 编译器 | C++17 | Apple Clang ≥ 14、GCC ≥ 11、MSVC 2022 |
-| CMake | 3.20 | `cmake --version` 验证 |
-| Ninja | 1.10 | 推荐使用的 generator（`ninja --version`）|
-| Python | 3.9 | 仅在跑 `test/e2e/` 时需要 |
-| Qt 6 | 6.5 | 可选，仅 GUI 需要 |
+| CMake | 3.14 | `cmake --version` 验证 |
+| Ninja | 1.10 | 推荐使用的 generator（`ninja --version`）；`scripts/build.sh` 会传 `-G Ninja` |
+| Python | 3.9 | **每一次**构建都需要：CMake 在构建期调用 `scripts/embed_binary.py` 把标注字体嵌进二进制。跑 `test/` 下的 E2E 测试也用它 |
+| OpenGL 开发包 | — | 仅 GUI 构建（`-g`）需要。macOS 与 Windows 无需额外安装。Linux 上 GLFW 依赖 X11、文件对话框依赖 GTK 3：`sudo apt-get install libgl-dev libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgtk-3-dev` |
 
-外部依赖（spdlog、nlohmann/json、stb、googletest 等）在 configure 阶段由 [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) 自动拉取，无需手动安装。
+外部依赖（spdlog、nlohmann/json、stb、googletest，以及 GUI 用到的 GLFW、Dear ImGui、nativefiledialog-extended 等）在 configure 阶段由 [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) 自动拉取，无需手动安装。下载的源码按机器缓存在 `$HOME/.cache/lumice-cpm`（未设 `HOME` 的 Windows shell 下为 `$USERPROFILE/.cache/lumice-cpm`），同一台机器上再 clone 一份或新开 worktree 不会重新下载；想换位置可设置 `CPM_SOURCE_CACHE`。
 
 ## 构建
 
 推荐用脚本 `scripts/build.sh` 构建：
 
 ```bash
-# Release 构建，并行，产物安装到 build/cmake_install/static/
+# CLI 的 Release 构建，并行，产物安装到 build/cmake_install/static/
 ./scripts/build.sh -j release
 ```
 
 其他常用变体（完整列表见 `scripts/build.sh -h`）：
 
 ```bash
+./scripts/build.sh -gj release    # 连 GUI 一起构建（Dear ImGui + GLFW + OpenGL）
 ./scripts/build.sh -tj release    # 构建 + 跑单元测试
-./scripts/build.sh -gtj release   # 构建 + 跑 GUI 测试（需要显示服务器）
+./scripts/build.sh -gtj release   # 构建 GUI + 跑单元测试与 GUI 测试（需要显示服务器）
 LUMICE_SKIP_GUI_TESTS=1 ./scripts/build.sh -gtj release   # 在无显示器的机器上跳过 GUI 测试
-./scripts/build.sh -k release     # 清理后重新构建
+./scripts/build.sh -k release     # 清理本 flavor 的构建树后重新构建（保留 CPM 缓存）
 ```
+
+`-t` / `-g` / `-b` 决定*构建什么*（测试 / GUI 应用 / 基准）；只有带过 `-g` 的构建才会产出 GUI 二进制。`-s` 把库的 flavor 切到 shared（省略即 static），可与上述任意选项组合。
 
 Release 构建成功后，关键产物位置如下：
 
 | 产物 | 路径 | 用途 |
 |------|------|------|
 | CLI 二进制 | `build/cmake_install/static/Lumice` | 命令行执行 JSON 配置 |
-| GUI 二进制 | `build/cmake_install/static/LumiceGUI` | 交互式 GUI（依赖 Qt）|
+| GUI 二进制 | `build/cmake_install/static/LumiceGUI` | 交互式 GUI（仅 `-g` 构建产出；除系统 OpenGL 驱动外无其他运行时依赖）|
 
 > 两棵树都按 flavor 分开：`-s`（shared）构建与静态构建永不共用目录。CMake 构建树是
 > `build/cmake_build/<flavor>/`。本手册其余章节默认使用 `build/cmake_install/static/` 下的 Release 产物。
@@ -50,32 +53,35 @@ Release 构建成功后，关键产物位置如下：
 
 ## Smoke test
 
-跑一遍内置示例配置，确认端到端可用。在项目根目录执行：
+跑一遍内置示例配置，确认端到端可用。在项目根目录执行（CLI 不会替你创建输出目录）：
 
 ```bash
+mkdir -p /tmp/lumice-smoke
 ./build/cmake_install/static/Lumice -f examples/config_example.json -o /tmp/lumice-smoke
 ```
 
 你应该看到：
 
-1. 一段简短的版本横幅；
-2. 模拟过程中按 batch 输出的进度信息；
-3. 结尾的 `Stats: ...` 块（汇总光线总数等）；
-4. `/tmp/lumice-smoke/` 下生成 4 个 `.jpg` 文件，文件名形如 `example_img_01.jpg` … `example_img_04.jpg`。
+1. 启动时几行 `[I]` 日志（`CommitConfig`、`GenerateScene`、`ConsumeData`），标识本次运行；
+2. 大约每秒一次，每张输出图一行 `Saved: ...`，后面跟一行 `Stats: sim_rays=..., crystals=..., orientations=...`——CLI 会随模拟累积不断重存中间渲染结果；
+3. 所有光线追踪完毕后最后一组 `Saved:` / `Stats:`；
+4. `/tmp/lumice-smoke/` 下生成 4 个 `.jpg` 文件，文件名为 `img_01.jpg` … `img_04.jpg`（配置里每个 `render` 条目一张）。
 
 ![Lumice CLI 完成输出](../figs/cli_screenshot_02.jpg)
 
 只要 4 张图都生成出来，就说明工具链没问题。
 
-> 示例配置使用了 9 段离散波长 × `ray_num=5e7`，模拟器实际追踪 ~4.5 × 10⁸ 条光线。在较新的多核笔记本上约 2 分钟。想跑得更快？把示例 copy 一份，把 `scene.ray_num` 改到 `1e6` 即可。
+> 示例配置把 `scene.ray_num` 设为 `4.5e8`——这是 9 段离散波长加起来的总数。在较新的多核笔记本上约 2 分钟。想跑得更快？把示例 copy 一份，把 `scene.ray_num` 改到 `1e6` 即可。
 
 ## 常见构建问题
 
 | 现象 | 可能原因 | 处理 |
 |------|----------|------|
 | `cmake: command not found` | 未安装 CMake 或不在 `PATH` | Homebrew / apt / 官方安装包安装 |
-| 拉依赖失败 | 首次构建无 CPM 缓存且无网络 | 切到有网环境重试，CPM 缓存默认在 `~/.cache/CPM` |
-| GUI 启动报 Qt 错误 | Qt 6 不在 loader 路径 | 系统级安装 Qt 6，或加 `-DLUMICE_BUILD_GUI=OFF` 跳过 GUI |
+| 拉依赖失败 | 首次构建无 CPM 缓存且无网络 | 切到有网环境重试，CPM 缓存默认在 `$HOME/.cache/lumice-cpm`（或 `CPM_SOURCE_CACHE` 指向的位置）|
+| configure 在 `Python3` 处失败 | `PATH` 上没有 Python 3 解释器 | 安装 Python 3——每次构建都靠它嵌入字体 |
+| GUI configure 在 GLFW / nfd 处失败（Linux） | 缺 X11 / OpenGL / GTK 3 开发头文件 | 按前置依赖表安装，或去掉 `-g` 不构建 GUI |
+| GUI 启动时报 GLFW / OpenGL 错误退出 | 没有显示器，或 loader 路径上没有 OpenGL 3.3 驱动 | 在有桌面会话的机器上运行；无显示器的机器改用 CLI |
 | `LUMICE_SKIP_GUI_TESTS` 在 CI 上不生效 | 配置缓存陈旧 | `./scripts/build.sh -k release` 清理重建 |
 
 ## 延伸阅读

--- a/src/server/anchor_consumer.cpp
+++ b/src/server/anchor_consumer.cpp
@@ -4,6 +4,7 @@
 
 #include "core/anchor_buffer.hpp"
 #include "core/color_util.hpp"
+#include "util/logger.hpp"
 
 namespace lumice {
 
@@ -69,6 +70,18 @@ void AnchorConsumer::AccumulateDevicePlane(const SimData& data) {
     // would then fire thousands of times; the cross-backend agreement test is what fails
     // loudly. Leaving the plane untouched keeps the scalar at 0, which reads as "no
     // anchor" rather than as a plausible wrong value.
+    //
+    // Reported ONCE per consumer, then counted. The per-batch objection above is to the
+    // volume, not to the signal: that agreement test is `-m slow` and no CI job runs it,
+    // so before this line the only place the defect could show was a developer's machine
+    // on the day they happened to run the slow leg. One line on the first batch puts it
+    // in every log of every affected run; the counter says how many batches it swallowed.
+    if (device_plane_size_mismatch_count_++ == 0) {
+      ILOG_ERROR(logger_,
+                 "device anchor plane has {} floats, expected {} ({}x{}); ignoring it for the whole run — "
+                 "L99_sky will read 0 and every relative-EV frame will be exposed against nothing",
+                 data.anchor_y_pixel_data_.size(), kAnchorPixels, kAnchorWidth, kAnchorHeight);
+    }
     return;
   }
   const float* src = data.anchor_y_pixel_data_.data();
@@ -91,6 +104,9 @@ void AnchorConsumer::PrepareSnapshot() {
 void AnchorConsumer::Reset() {
   std::memset(anchor_y_.get(), 0, kAnchorPixels * sizeof(float));
   snapshot_l99_sky_ = 0.0f;
+  // A reused consumer starts a new run, and the route (hence the backend that fills the
+  // plane) can differ from the last one: "once" means once per run, not once per object.
+  device_plane_size_mismatch_count_ = 0;
 }
 
 }  // namespace lumice

--- a/src/server/anchor_consumer.cpp
+++ b/src/server/anchor_consumer.cpp
@@ -79,7 +79,7 @@ void AnchorConsumer::AccumulateDevicePlane(const SimData& data) {
     if (device_plane_size_mismatch_count_++ == 0) {
       ILOG_ERROR(logger_,
                  "device anchor plane has {} floats, expected {} ({}x{}); ignoring it for the whole run — "
-                 "L99_sky will read 0 and every relative-EV frame will be exposed against nothing",
+                 "L99_sky will read 0, so ExposureScale() returns 0 and every ev_mode=relative render is black",
                  data.anchor_y_pixel_data_.size(), kAnchorPixels, kAnchorWidth, kAnchorHeight);
     }
     return;

--- a/src/server/anchor_consumer.hpp
+++ b/src/server/anchor_consumer.hpp
@@ -6,6 +6,7 @@
 
 #include "core/shared/projection_shared.h"
 #include "server/consumer.hpp"
+#include "util/logger.hpp"
 
 namespace lumice {
 
@@ -14,7 +15,14 @@ namespace lumice {
  * @details The THIRD kind of IConsume, alongside RenderConsumer and StatsConsumer, and it
  *          is the third kind for the same reason StatsConsumer is the second: it is a
  *          property of the SESSION, not of any renderer. Exactly one instance lives in
- *          `consumers_` no matter how many renderers the config declares.
+ *          `consumers_` no matter how many renderers the config declares — including
+ *          none: `"render": []` parses (config_manager.cpp iterates the array without
+ *          requiring a member), and such a session's `consumers_` is StatsConsumer plus
+ *          this. Nothing here reads a renderer, so the scalar is measured and published
+ *          exactly as it would be with one; a frame simply carries an anchor no renderer
+ *          consumes. The renderer-less session that exists BY DESIGN — the raypath
+ *          analysis run — deliberately builds no AnchorConsumer at all (server.cpp,
+ *          StartRaypathAnalysis), since nothing there is exposed.
  *
  *          That is not an economy, it is the contract. Every element of `consumers_` gets
  *          its own Consume() call on the same batch, so an anchor folded into
@@ -61,6 +69,11 @@ class AnchorConsumer : public IConsume {
   /// RenderConsumer::VisibleMaskForTest.
   const float* AnchorPlaneForTest() const { return anchor_y_.get(); }
 
+  /// How many device-fused batches AccumulateDevicePlane refused because their anchor plane
+  /// was not kAnchorWidth * kAnchorHeight floats. Only the first is logged (see the .cpp);
+  /// this is the rest of the evidence.
+  size_t DevicePlaneSizeMismatchCount() const { return device_plane_size_mismatch_count_; }
+
  private:
   // Host path: project this batch's outgoing rays into the anchor plane. One
   // ProjectExitToPixel call per ray against the fixed anchor params — the same single
@@ -74,6 +87,8 @@ class AnchorConsumer : public IConsume {
   std::unique_ptr<float[]> anchor_y_;
   lm_proj::ProjParams proj_params_;
   float snapshot_l99_sky_ = 0.0f;
+  size_t device_plane_size_mismatch_count_ = 0;
+  Logger logger_{ "Anchor" };
 };
 
 }  // namespace lumice

--- a/test/gui/parity/test_gui_cli_export_parity.cpp
+++ b/test/gui/parity/test_gui_cli_export_parity.cpp
@@ -1094,15 +1094,20 @@ ParityScene MakeLinesOnlyScene(const LinesOnlyScene& lines, const ParityScene& b
   return s;
 }
 
+// Pixel `p` of an interleaved RGB image packed 0xRRGGBB — the one definition of the packing that
+// ModeColor, AnnotationMembership and kLinesOnlyCanvasPacked all assume.
+inline uint32_t PackRgb(const unsigned char* rgb, size_t p) {
+  return (static_cast<uint32_t>(rgb[p * 3]) << 16) | (static_cast<uint32_t>(rgb[p * 3 + 1]) << 8) |
+         static_cast<uint32_t>(rgb[p * 3 + 2]);
+}
+
 // The most frequent byte triple of an RGB image, packed 0xRRGGBB. One pass over a hash map; the
 // frames here have under forty distinct colours.
 uint32_t ModeColor(const unsigned char* rgb, int w, int h) {
   std::unordered_map<uint32_t, int> counts;
   const size_t n_px = static_cast<size_t>(w) * h;
   for (size_t p = 0; p < n_px; ++p) {
-    const uint32_t key = (static_cast<uint32_t>(rgb[p * 3]) << 16) | (static_cast<uint32_t>(rgb[p * 3 + 1]) << 8) |
-                         static_cast<uint32_t>(rgb[p * 3 + 2]);
-    ++counts[key];
+    ++counts[PackRgb(rgb, p)];
   }
   uint32_t mode = 0;
   int best = -1;
@@ -1121,9 +1126,7 @@ std::vector<unsigned char> AnnotationMembership(const unsigned char* rgb, int w,
   const size_t n_px = static_cast<size_t>(w) * h;
   std::vector<unsigned char> mask(n_px, 0);
   for (size_t p = 0; p < n_px; ++p) {
-    const uint32_t key = (static_cast<uint32_t>(rgb[p * 3]) << 16) | (static_cast<uint32_t>(rgb[p * 3 + 1]) << 8) |
-                         static_cast<uint32_t>(rgb[p * 3 + 2]);
-    mask[p] = key != canvas ? 1 : 0;
+    mask[p] = PackRgb(rgb, p) != canvas ? 1 : 0;
   }
   return mask;
 }

--- a/test/gui/test_screenshot.cpp
+++ b/test/gui/test_screenshot.cpp
@@ -157,6 +157,14 @@ bool CheckAgainstReference(const char* group, const char* tag, const std::string
       fprintf(stderr, "[%s] %s: largest differing blob exceeds K — possible regression\n", group, tag);
       return false;
     }
+    // Early warning, not a verdict: K is set against the CI leg's llvmpipe residue, and the margin
+    // between that residue and K is thin for some groups (modal_layout: 1.36x). A Mesa upgrade that
+    // grows the residue would otherwise surface as a red with no run-up; this line surfaces it
+    // while the comparison is still green. Half of K, deliberately not a second constant.
+    if (diff.max_cc > ruler->max_cc_threshold / 2) {
+      fprintf(stderr, "[%s] %s: [WARN] largest differing blob (%d px) is past K/2=%d — margin to a red is thinning\n",
+              group, tag, diff.max_cc, ruler->max_cc_threshold / 2);
+    }
   } else {
     fprintf(stderr, "[%s] %s: PSNR=%.2f dB (threshold=%.1f dB)\n", group, tag, psnr, threshold);
     if (psnr < threshold) {

--- a/test/gui/visual/test_gui_capture_smoke.cpp
+++ b/test/gui/visual/test_gui_capture_smoke.cpp
@@ -25,7 +25,7 @@
 // demands byte-identity outright: tau = 0, K = 0. PSNR is still printed beside it — the
 // scripts/regen_gui_test_refs.py Phase B audit trail (test/gui/references/_thresholds.json)
 // records both — but it no longer decides pass/fail; see support/pixel_diff_metrics.hpp.
-static constexpr lumice::test::MaxCcRuler kRuler{ /*tau=*/0, /*max_cc_threshold=*/0 };
+constexpr lumice::test::MaxCcRuler kRuler{ /*tau=*/0, /*max_cc_threshold=*/0 };
 // The PSNR floor the old ruler applied, kept for the diagnostic line only.
 static constexpr double kPsnrThreshold = 40.0;
 

--- a/test/gui/visual/test_gui_modal_layout.cpp
+++ b/test/gui/visual/test_gui_modal_layout.cpp
@@ -69,7 +69,7 @@ struct ModalLayoutScene {
 // smallest real drift on record for this group (95 px at this tau) stays at least 1.3x above it:
 // K = 70 gives 70/35 = 2.0x and 95/70 = 1.36x. Measurements, provenance and the jitter check:
 // doc/testing-architecture.md §4.6.
-static constexpr lumice::test::MaxCcRuler kRuler{ /*tau=*/16, /*max_cc_threshold=*/70 };
+constexpr lumice::test::MaxCcRuler kRuler{ /*tau=*/16, /*max_cc_threshold=*/70 };
 // The PSNR floor the old ruler applied; printed on the diagnostic line, not enforced.
 static constexpr double kDeterministicThresholdDb = 40.0;
 

--- a/test/unit-correctness/server/test_anchor_consumer.cpp
+++ b/test/unit-correctness/server/test_anchor_consumer.cpp
@@ -20,10 +20,13 @@
 // such, rather than as evidence of the new property.
 
 #include <gtest/gtest.h>
+#include <spdlog/sinks/ostream_sink.h>
 
 #include <cmath>
 #include <cstddef>
 #include <memory>
+#include <sstream>
+#include <string>
 #include <vector>
 
 #include "config/color_class_table.hpp"
@@ -35,6 +38,7 @@
 #include "server/anchor_consumer.hpp"
 #include "server/render.hpp"
 #include "server/server.hpp"
+#include "util/logger.hpp"
 
 namespace lumice {
 namespace {
@@ -311,6 +315,60 @@ TEST(AnchorConsumer, VisibleIsNotAnAnchorInput) {
   (void)LegacyAnchorFor(data, upper);
   (void)LegacyAnchorFor(data, lower);
   EXPECT_FLOAT_EQ(AnchorFor(data), once);
+}
+
+// Captures everything the global sink receives for the object's lifetime — the same RAII shape
+// test_print_mode_colour_exclusions.cpp uses, for the same reason: GetSharedSink() is a
+// process-wide singleton, so an early return with the sink still attached would leave later
+// cases writing into a destroyed ostringstream.
+class LogCapture {
+ public:
+  LogCapture() : sink_(std::make_shared<spdlog::sinks::ostream_sink_mt>(oss_)) { GetSharedSink()->add_sink(sink_); }
+  ~LogCapture() { GetSharedSink()->remove_sink(sink_); }
+  LogCapture(const LogCapture&) = delete;
+  LogCapture& operator=(const LogCapture&) = delete;
+
+  std::string Text() const { return oss_.str(); }
+
+ private:
+  std::ostringstream oss_;
+  std::shared_ptr<spdlog::sinks::ostream_sink_mt> sink_;
+};
+
+int CountOccurrences(const std::string& text, const std::string& needle) {
+  int n = 0;
+  for (size_t pos = text.find(needle); pos != std::string::npos; pos = text.find(needle, pos + needle.size())) {
+    ++n;
+  }
+  return n;
+}
+
+// A device-fused batch whose anchor plane has the wrong size is refused, and the refusal is
+// reported once per run and counted per batch. The plane must stay untouched — the scalar reads
+// 0, "no anchor", not a plausible wrong number — and the second batch must add to the counter
+// without adding a second log line, since the point of logging at all is that the slow
+// cross-backend agreement test is the only other place this defect can surface.
+TEST(AnchorConsumer, WrongSizeDevicePlaneIsRefusedLoggedOnceAndCounted) {
+  constexpr const char* kNotice = "device anchor plane has";
+  SimData fused;
+  fused.curr_wl_ = kWl;
+  fused.xyz_pixel_data_.assign(12, 0.0f);  // marks the batch as device-fused
+  fused.anchor_y_pixel_data_.assign(static_cast<size_t>(kAnchorWidth) * kAnchorHeight / 2, 1.0f);
+
+  AnchorConsumer ac;
+  LogCapture capture;
+  ac.Consume(fused);
+  ac.Consume(fused);
+  ac.PrepareSnapshot();
+  EXPECT_FLOAT_EQ(ac.SnapshotL99Sky(), 0.0f);
+  EXPECT_EQ(ac.DevicePlaneSizeMismatchCount(), 2u);
+  EXPECT_EQ(CountOccurrences(capture.Text(), kNotice), 1) << capture.Text();
+
+  // Reset starts a new run; the next mismatch is news again.
+  ac.Reset();
+  ac.Consume(fused);
+  EXPECT_EQ(ac.DevicePlaneSizeMismatchCount(), 1u);
+  EXPECT_EQ(CountOccurrences(capture.Text(), kNotice), 2) << capture.Text();
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

Three unrelated, already-verified small debts, one commit each:

- **Install manual (`doc/user-manual/01-install{,_zh}.md`) rewritten against the current build** — CPM cache is `$HOME/.cache/lumice-cpm` (not `~/.cache/CPM`), the GUI is ImGui + GLFW so every Qt mention is gone (Linux gets the real X11/GL/GTK apt list from `ci.yml`), `-DLUMICE_BUILD_GUI=OFF` never existed (GUI is opted in by `build.sh -g`), Python 3 is required on every build (font embedding), CMake floor 3.14, smoke-test output names / log lines match what the CLI actually prints.
- **scrum-532 (PR #344) review non-blocking items**: `CheckAgainstReference` prints a `[WARN]` when `K/2 < maxcc ≤ K` so a shrinking margin is seen before it goes red; `gui-visual-regression-captures` artifact step gets `if-no-files-found: error`; `ModeColor` / `AnnotationMembership` share `PackRgb`; the two `static constexpr kRuler` outliers become plain `constexpr` like the other 116 in the tree. `bm4_threshold` is **kept** — it is the live gate (`IM_CHECK_GE(bm4, scene.bm4_threshold)`), the "delete it" wording in the issue was a misreading of a Suggestion to keep it.
- **`AnchorConsumer`**: a wrong-size device anchor plane is now reported once per run via `ILOG_ERROR` and counted (`DevicePlaneSizeMismatchCount()`, reset each run) instead of silently dropped; new unit test pins "logged once, counted every time". `renders_.size()==0` confirmed reachable (`"render": []` runs to COMPLETED) and documented in the class docstring.

## Verification

- `./scripts/test.sh quick` → `RESULT: PASS` (ctest 7/7, fast e2e 121, gui_test 413/413)
- `[WARN]` red-state probe: `modal_layout` with `tau=-1, K=500000` prints one `[WARN]` per scene and stays green; restored.
- `unit_correctness_test --gtest_filter='AnchorConsumer.*'` 11/11 incl. the new case.
- `check_policies.py` / `check_new_refs.py` / `check_new_gui_tests.py` / `check_loop_fatal_asserts.py --range 70eb8f5f..HEAD` all 0.
- Independent code review: APPROVE, 0 Critical / 0 Major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BcEZUvJP2JfKBYVcwhbYat