### PR TITLE
fix(test): root-cause the RenderConsumerLabel flake — an uninitialized SunParam azimuth

### DIFF
--- a/src/config/light_config.hpp
+++ b/src/config/light_config.hpp
@@ -10,10 +10,17 @@
 
 namespace lumice {
 
+// Every field carries a default so that a partially filled `SunParam` is a well-defined value
+// rather than an uninitialized read. The zeros are the same bytes `SunParam p{}` (the JSON
+// decoder's starting point) already produced, so no default changed; what changed is that
+// `SunParam s; s.altitude_ = x;` no longer leaves `azimuth_` holding whatever the stack held.
+// That shape put a NaN into the annotation layer's sun direction, whose normalizer then fell
+// back to the zenith and moved a whole family of circles — intermittently, since it depended
+// on the previous frame's residue.
 struct SunParam {
-  float altitude_;  // Degree
-  float azimuth_;   // Degree
-  float diameter_;  // Degree
+  float altitude_{};  // Degree
+  float azimuth_{};   // Degree
+  float diameter_{};  // Degree
 };
 
 struct WlParam {

--- a/src/server/c_api.cpp
+++ b/src/server/c_api.cpp
@@ -2169,7 +2169,7 @@ static bool ConfigHasFilter(const ConfigScratch& c, int id) {
 static LUMICE_ErrorCode JsonToSceneParams(const nlohmann::json& scene, ConfigScratch* out) {
   // Light source: required, and so are its `type` / `altitude` / `spectrum` keys (core
   // LightSourceConfig::from_json reads all three with .at()). A `type` other than "sun" is
-  // rejected rather than mirrored: core only logs and leaves its SunParam uninitialized.
+  // rejected rather than mirrored: core only logs and leaves its SunParam at the all-zero default.
   {
     if (!scene.contains("light_source")) {
       return LUMICE_ERR_MISSING_FIELD;

--- a/test/unit-correctness/server/test_render_consumer_label.cpp
+++ b/test/unit-correctness/server/test_render_consumer_label.cpp
@@ -114,10 +114,17 @@ RenderConfig MakeLabelConfig(LabelSwitches on, LineSwitches lines = {}, float li
 // The sun 20 deg up, which is where the angular-distance circles are centred. Its default (0) is
 // on the horizon and would put the 22 deg circle half below it; nothing here depends on the exact
 // value beyond the circle being fully inside the frame.
+//
+// All three fields, spelled out, like every sibling fixture in this directory. This used to write
+// `altitude_` alone into a default-constructed SunParam, back when the struct had no member
+// initializers, and the azimuth the circles were centred on was therefore whatever the stack held
+// — usually a denormal that rounds to the same pixels as 0, occasionally a NaN, which the overlay's
+// direction normalizer maps to the zenith. Two arms of one case then drew their circle around two
+// different points, and the difference between them read as one line switch reaching another
+// family's line. SunParam now zero-initializes itself, so the old spelling would be well-defined
+// today; the explicit triple is kept so the fixture does not depend on that.
 SunParam MakeSun() {
-  SunParam sun;
-  sun.altitude_ = 20.0f;
-  return sun;
+  return SunParam{ 20.0f, 0.0f, 0.5f };
 }
 
 // One ray straight up, for the reason test_render_consumer_horizon.cpp states: PostSnapshot takes


### PR DESCRIPTION
## Summary

`RenderConsumerLabel.EachFamilyLineSwitchGatesOnlyItsOwnFamily` / `TheGridAndCircleLabelsAreDrawnWithTheirLinesSwitchedOff` went red ~13% of iterations under `--gtest_repeat` on an idle machine, always with the same pixel counts (24/188, 24/564, 0 vs 145, 32 vs 105).

**Root cause**: the fixture's `MakeSun()` only wrote `SunParam::altitude_`; `SunParam` had no default member initializers, so `azimuth_` was an uninitialized stack read (UB). When the residue happened to be NaN, `annotation::SunWorldDir`'s normalization fell back to the zenith and the two arms of one case drew the 22° circle around two different points. The four "constant" numbers are the geometric intersection counts of those two circles with the meridian / latitude lines — pure geometry, not randomness. The plan's main hypothesis (cross-case `ResetWith` contamination) was falsified by a negative control (only the two victim cases, still 35/200 red).

**Fix**: the fixture sets all three fields, and `SunParam` gets zero-value NSDMIs so a partially constructed `SunParam` can no longer read garbage anywhere (one `c_api.cpp` comment updated accordingly). No user-visible behavior change; label pixels are byte-identical (0 reference changes).

AC3 (a deterministic regression test) does not apply: UB has no deterministic red state to pin, and the only assertion that would hold is the NSDMI definition itself — the type-level fix is stronger than a test.

## Verification

- Before: `unit_correctness_test --gtest_filter='RenderConsumerLabel.*' --gtest_repeat=200 --gtest_shuffle --gtest_random_seed=7` → 26/200 red. After: seeds 7, 12345, 999 → 200/200 green each.
- `./scripts/test.sh quick` → `RESULT: PASS`; `check_policies` / `check_new_refs` / `check_new_gui_tests` / `check_loop_fatal_asserts` / `format.sh --check` all exit 0.
- `test/gui/references` and `test/e2e-correctness/references`: 0 lines changed.
- Independent code review: APPROVE, 0 Critical / 0 Major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BcEZUvJP2JfKBYVcwhbYat