### PR TITLE
feat(gui): Rays(M) slider spans 0.1..100 000 M on a kLog track, one domain for both rows

### DIFF
--- a/doc/gui-guide.md
+++ b/doc/gui-guide.md
@@ -123,7 +123,7 @@ The right panel groups every parameter that influences how the simulated rays ar
 ### Scene
 
 - **Sun**: `Altitude` (-90° to 90°), apparent `Diameter` (0.1° to 5°), and `Spectrum` (one of `D50` / `D55` / `D65` / `D75` / `A` / `E`).
-- **Simulation**: `Infinite rays` checkbox (let the simulator keep accumulating until you stop it), `Rays(M)` count in millions when bounded, `Max hits` per ray (1 – 20), and the `Adaptive ray allocation` checkbox — on by default in a new document — which deals each crystal's rays by its measured per-ray energy variance instead of its population share (`scene.ray_allocation` in `configuration.md`): the expected image is unchanged, but noise is made more even across crystals, so a faint halo's edge no longer looks rougher than the rest. The choice is saved in the `.lmc` and written to an exported config; a document saved before the control existed opens with it on.
+- **Simulation**: `Infinite rays` checkbox (let the simulator keep accumulating until you stop it), `Rays(M)` count in millions when bounded (0.1 to 100 000 M, i.e. 1e5 to 1e11 rays, on a logarithmic slider so both ends of the range are reachable by hand; the box beside it takes a typed value), `Max hits` per ray (1 – 20), and the `Adaptive ray allocation` checkbox — on by default in a new document — which deals each crystal's rays by its measured per-ray energy variance instead of its population share (`scene.ray_allocation` in `configuration.md`): the expected image is unchanged, but noise is made more even across crystals, so a faint halo's edge no longer looks rougher than the rest. The choice is saved in the `.lmc` and written to an exported config; a document saved before the control existed opens with it on.
 
 ### View
 

--- a/doc/gui-guide_zh.md
+++ b/doc/gui-guide_zh.md
@@ -118,7 +118,7 @@ GUI 需要 display server 和支持 OpenGL 3.2 Core Profile 的 GPU。
 ### Scene（场景）
 
 - **Sun**：`Altitude`（-90° ~ 90°）、`Diameter`（视角直径，0.1° ~ 5°）、`Spectrum`（标准光源 `D50` / `D55` / `D65` / `D75` / `A` / `E` 之一）。
-- **Simulation**：`Infinite rays` 复选框（让模拟器持续累计直到手动停止）、有限模式下的 `Rays(M)`（单位：百万）、`Max hits`（每条光线最多碰撞次数，1 – 20）、以及 `Adaptive ray allocation` 复选框——新文档默认勾选——按各晶体实测的逐光线能量方差而非人口占比分配光线（对应 `configuration.md` 的 `scene.ray_allocation`）：期望画面不变，噪声在晶体之间更均匀，弱晕的边缘不再比其余部分显得更粗糙。这个选择会保存进 `.lmc`，也会写进导出的 config；控件出现之前保存的文档打开后视为勾选。
+- **Simulation**：`Infinite rays` 复选框（让模拟器持续累计直到手动停止）、有限模式下的 `Rays(M)`（单位：百万，范围 0.1 – 100 000 M 即 1e5 – 1e11 条光线，滑杆按对数刻度，两端都能用手拖到；旁边的输入框接受直接键入）、`Max hits`（每条光线最多碰撞次数，1 – 20）、以及 `Adaptive ray allocation` 复选框——新文档默认勾选——按各晶体实测的逐光线能量方差而非人口占比分配光线（对应 `configuration.md` 的 `scene.ray_allocation`）：期望画面不变，噪声在晶体之间更均匀，弱晕的边缘不再比其余部分显得更粗糙。这个选择会保存进 `.lmc`，也会写进导出的 config；控件出现之前保存的文档打开后视为勾选。
 
 ### View（视图）
 

--- a/src/gui/analysis_panel.cpp
+++ b/src/gui/analysis_panel.cpp
@@ -19,6 +19,7 @@
 #include "gui/gui_constants.hpp"
 #include "gui/gui_logger.hpp"
 #include "gui/panels.hpp"  // SliderWithInput
+#include "gui/ray_num_domain.hpp"
 #include "gui/raypath_segments.hpp"
 #include "gui/semantic_colors.hpp"
 #include "gui/server_poller.hpp"
@@ -849,9 +850,11 @@ void RenderRequestParamsControls(GuiState& state) {
   auto& a = state.analysis;
   EnsureDefaultAnalysisRayBudget(state);
   // The document's Rays row, re-drawn for the session's own field: a checkbox that turns the
-  // total off and a slider for the total. Kept in step with panels.cpp by hand — evaluated and
-  // not shared, because the two rows read different fields under different constraint sources
-  // (the registry's versus these constants), and a helper would need both spelled as parameters.
+  // total off and a slider for the total. The RENDERING is kept in step with panels.cpp by hand —
+  // evaluated and not shared, because the two rows read different fields under different enable
+  // gates (the registry's Applicability versus a.infinite), and a helper would need both spelled
+  // as parameters. The DOMAIN is not hand-copied: range, format and scale are the same four symbols
+  // the registry row reads (gui/ray_num_domain.hpp), so the two cannot disagree on what a budget is.
   PushLabelColumnItemWidth();
   Checkbox("Infinite rays", &a.infinite);
   if (ImGui::IsItemHovered()) {
@@ -860,7 +863,8 @@ void RenderRequestParamsControls(GuiState& state) {
   ImGui::PopItemWidth();
   ImGui::BeginGroup();
   ImGui::BeginDisabled(a.infinite);
-  SliderWithInput("Rays(M)", &a.ray_num_millions, kAnalysisRayNumMinMillions, kAnalysisRayNumMaxMillions, "%.1f");
+  SliderWithInput("Rays(M)", &a.ray_num_millions, kRayNumMinMillions, kRayNumMaxMillions, kRayNumSliderFmt,
+                  kRayNumSliderScale);
   ImGui::EndDisabled();
   ImGui::EndGroup();
   if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) {

--- a/src/gui/field_editor_registry.cpp
+++ b/src/gui/field_editor_registry.cpp
@@ -7,6 +7,7 @@
 #include "gui/app.hpp"
 #include "gui/gui_constants.hpp"
 #include "gui/panels.hpp"
+#include "gui/ray_num_domain.hpp"
 #include "gui/slider_format_rules.hpp"
 #include "gui/theme.hpp"
 #include "imgui.h"
@@ -487,7 +488,9 @@ const std::unordered_map<std::string, FieldEditorEntry>& Registry() {
     // relative format on it would be the same mismatch as the defect, in the other direction. The
     // rest of this registry is out of the gate's reach for a structural reason, not an oversight:
     // most of its domains are FloatDomainFn closures over live GuiState (renderer.fov and friends),
-    // so their bounds are not constant expressions and no static_assert can read them.
+    // so their bounds are not constant expressions and no static_assert can read them. The other
+    // constant-domain row, sim.ray_num_millions below, is gated too — in gui/ray_num_domain.hpp,
+    // where its quadruple is defined once for this row and the analysis panel's.
     {
       constexpr float kSunDiameterMin = 0.1f;
       constexpr float kSunDiameterMax = 5.0f;
@@ -501,15 +504,18 @@ const std::unordered_map<std::string, FieldEditorEntry>& Registry() {
     map.emplace("sun.spectrum", SpectrumField());
 
     // ---- sim ----
-    map.emplace("sim.ray_num_millions", FloatField([](GuiState& s) { return &s.sim.ray_num_millions; },
-                                                   FixedDomain(0.1f, 100.0f), "%.1f", SliderScale::kLinear,
-                                                   [](const GuiState& s) -> Applicability {
-                                                     if (s.sim.infinite) {
-                                                       return { false,
-                                                                "Infinite rays is on, so no ray total applies." };
-                                                     }
-                                                     return {};
-                                                   }));
+    // Domain, format and scale come from gui/ray_num_domain.hpp, which the analysis panel's own
+    // Rays(M) row reads too; the pairing gate is static_asserted there, beside the one definition,
+    // rather than in a local block here like sun.diameter's above (that form fits a single consumer).
+    map.emplace("sim.ray_num_millions",
+                FloatField([](GuiState& s) { return &s.sim.ray_num_millions; },
+                           FixedDomain(kRayNumMinMillions, kRayNumMaxMillions), kRayNumSliderFmt, kRayNumSliderScale,
+                           [](const GuiState& s) -> Applicability {
+                             if (s.sim.infinite) {
+                               return { false, "Infinite rays is on, so no ray total applies." };
+                             }
+                             return {};
+                           }));
     map.emplace("sim.max_hits", IntField([](GuiState& s) { return &s.sim.max_hits; }, 1, 64));
     map.emplace("sim.infinite", BoolField([](GuiState& s) { return &s.sim.infinite; }));
     map.emplace("sim.ray_allocation", BoolField([](GuiState& s) { return &s.sim.ray_allocation_adaptive; }));

--- a/src/gui/gui_constants.hpp
+++ b/src/gui/gui_constants.hpp
@@ -171,12 +171,6 @@ constexpr float kCameraTiltDeg = 15.0f;
 constexpr float kAnalysisConeMaxRadiusDeg = 15.0f;
 constexpr int kAnalysisConeRingCount = 30;  // 0.5 degrees per ring
 constexpr float kAnalysisConeDefaultRadiusDeg = 2.0f;
-// The panel's own Rays(M) input bounds — the same domain as sim.ray_num_millions's
-// (field_editor_registry.cpp), repeated here because this field is session-tier, not a document
-// field the registry governs. Two constants, one meaning: a budget the document may ask for, the
-// analysis may ask for too.
-constexpr float kAnalysisRayNumMinMillions = 0.1f;
-constexpr float kAnalysisRayNumMaxMillions = 100.0f;
 static_assert(kAnalysisConeRingCount >= 1 && kAnalysisConeRingCount <= LUMICE_MAX_RAYPATH_CONE_RINGS,
               "the cone ring count must be a request the C API accepts (it rejects, not truncates)");
 static_assert(kAnalysisConeDefaultRadiusDeg > 0.0f && kAnalysisConeDefaultRadiusDeg <= kAnalysisConeMaxRadiusDeg,

--- a/src/gui/ray_num_domain.hpp
+++ b/src/gui/ray_num_domain.hpp
@@ -1,0 +1,58 @@
+#ifndef LUMICE_GUI_RAY_NUM_DOMAIN_HPP
+#define LUMICE_GUI_RAY_NUM_DOMAIN_HPP
+
+// The Rays(M) slider's domain: its range, its display format and the scale its slider traverses.
+// One definition for the TWO controls that draw it — the document's sim.ray_num_millions row
+// (field_editor_registry.cpp, rendered by panels.cpp) and the raypath-analysis panel's own
+// session-tier budget (analysis_panel.cpp). The two rows deliberately read different fields under
+// different enable gates and are not rendered by a shared helper; what they must not do is disagree
+// on what a ray budget can be, and the way to make that structurally impossible is for neither of
+// them to hold a literal.
+//
+// The whole quadruple is shared, not just the bounds. The format and the scale are a pair: a
+// relatively-quantizing law rendered through an absolute format freezes its readout over part of
+// the travel (slider_format_rules.hpp states the criterion), so a consumer that copied the bounds
+// and kept its own "%.1f" would be a silent precision fork that no compile catches. Sharing all
+// four means a format change is one edit that both rows follow.
+//
+// The pairing gate lives HERE and not in a local block beside either consumer (the form
+// sun.diameter takes in field_editor_registry.cpp): that form suits a domain with one consumer,
+// where the constants and the row are the same few lines. This domain has two, and the value is
+// written once, so the gate guards that one place — whichever translation unit includes this
+// header compiles the assertion, and a consumer cannot render a quadruple the gate has not seen.
+//
+// Why the numbers are what they are:
+//   - 0.1 M (1e5 rays) is the smallest finite budget worth a run; unchanged from the linear era.
+//   - 100 000 M (1e11 rays) is the owner's "reproducible large budget" ceiling — hours of tracing on
+//     a GPU, a working day on the CPU path — the bounded counterpart to Infinite rays, not a
+//     replacement for it. LUMICE_RayCount is 64-bit, so the C API and core carry it whole.
+//   - kLog, because six decades on one track need a per-pixel step that scales with the value:
+//     under kLinear the whole 0.1..100 M range the slider used to span would sit in the first
+//     pixel. kLogLinear is not an option here — its law requires min < kLogLinearX0 (0.01), and
+//     this floor is above it (shape_scalar_domain.hpp static_asserts that requirement for the rows
+//     that do use it).
+//   - "%.6g": a relative format for a relative law, wide enough that no decade in [0.1, 1e5]
+//     switches to exponent notation (%g does so only once the exponent reaches the precision), so
+//     the input box reads "0.1", "5", "12345.6", "100000" — never "1e+05". The pairing gate
+//     below is what actually decides the precision; the choice is confirmed by it, not by this
+//     comment.
+
+#include "gui/panels.hpp"               // SliderScale
+#include "gui/slider_format_rules.hpp"  // FormatIsFineEnough -- the fmt/scale pairing gate
+
+namespace lumice::gui {
+
+inline constexpr float kRayNumMinMillions = 0.1f;
+inline constexpr float kRayNumMaxMillions = 100000.0f;
+inline constexpr const char* kRayNumSliderFmt = "%.6g";
+inline constexpr SliderScale kRayNumSliderScale = SliderScale::kLog;
+
+static_assert(kRayNumMinMillions > 0.0f, "a kLog slider needs a strictly positive floor (panels.cpp routes on it)");
+static_assert(slider_format::FormatIsFineEnough(kRayNumSliderFmt, kRayNumSliderScale, kRayNumMinMillions,
+                                                kRayNumMaxMillions),
+              "the Rays(M) slider's display format is coarser than its mapping resolves: the readout would freeze "
+              "over part of the travel (see gui/slider_format_rules.hpp)");
+
+}  // namespace lumice::gui
+
+#endif  // LUMICE_GUI_RAY_NUM_DOMAIN_HPP

--- a/test/composition-correctness/gui/test_document_roundtrip_chain.cpp
+++ b/test/composition-correctness/gui/test_document_roundtrip_chain.cpp
@@ -391,6 +391,29 @@ TEST(DocumentRoundtripChain, EveryProbedFieldSurvivesJsonRoundTrip) {
   }
 }
 
+// The ray budget's two domain bounds (gui/ray_num_domain.hpp) survive the document, exactly. The
+// probe table above moves the field off its default and asks whether it comes back; this asks the
+// stricter question at the two values the slider can actually park on. Neither is a round-trip
+// gimme: 0.1 has no exact binary form, so it is only preserved if the writer emits enough digits
+// for the reader to land on the same float, and 100000 is the new ceiling — a writer that rendered
+// millions through a fixed short format would round one and a reader with a stale clamp would cut
+// the other. EXPECT_FLOAT_EQ (4 ULP) is the same figure the analysis-params case below uses.
+TEST(DocumentRoundtripChain, TheRayBudgetsDomainBoundsSurviveTheDocumentExactly) {
+  for (const float millions : { 100000.0f, 0.1f }) {
+    GuiState before = MinimalDocument();
+    before.sim.infinite = false;
+    before.sim.ray_num_millions = millions;
+    GuiState after = MinimalDocument();
+    after.sim.ray_num_millions = 5.0f;  // seed off the expectation
+    if (!DeserializeGuiStateJson(SerializeGuiStateJson(before), after)) {
+      ADD_FAILURE() << millions << " M: DeserializeGuiStateJson rejected its own output";
+      continue;
+    }
+    EXPECT_FLOAT_EQ(after.sim.ray_num_millions, millions);
+    EXPECT_FALSE(after.sim.infinite) << millions << " M";
+  }
+}
+
 // The analysis panel's request parameters (ray_num_millions / infinite, and the
 // ray_budget_initialized latch) are session-tier tool state — gui_state_tiers.hpp registers
 // the whole `analysis` struct as kSession — and must not be in the document. Not a row in the

--- a/test/composition-correctness/gui/test_legacy_document_chain.cpp
+++ b/test/composition-correctness/gui/test_legacy_document_chain.cpp
@@ -433,5 +433,43 @@ TEST(LegacyDocumentChain, ADocumentSurvivesAWriteToDiskAndAReadBack) {
   EXPECT_NEAR(loaded.sim.ray_num_millions, 3.0f, 0.01f);
 }
 
+// The core-config side of the same document: the ray budget's two domain bounds
+// (gui/ray_num_domain.hpp) written by the export path as whole rays and read back by the legacy
+// importer as millions. The importer scales `ray_num` to millions by casting the integer to float
+// FIRST (file_io.cpp, DeserializeFromJson) — exact up to 2^24 rays and rounded past it, which at
+// the 1e11 ceiling is a 2048-ray error (float's spacing there is 8192) that the division by 1e6
+// then rounds back onto 100000 M, whose own float spacing is 1/128 M — 0.002 M of error against a
+// 0.004 M rounding radius. That is a computed property of these two values, not a general one, so
+// the ceiling is asserted here rather than inferred from the 3 M case above. The exported figure
+// itself is asserted as the integer the CLI will read, since that is the contract the GUI's
+// export makes with core.
+TEST(LegacyDocumentChain, TheRayBudgetsDomainBoundsSurviveExportAndImport) {
+  struct Row {
+    float millions;
+    unsigned long long rays;
+  };
+  for (const Row& row : { Row{ 100000.0f, 100000000000ULL }, Row{ 0.1f, 100000ULL } }) {
+    DoNew();
+    g_state.sim.infinite = false;
+    g_state.sim.ray_num_millions = row.millions;
+    std::string json;
+    if (!BuildExportJsonOrWarn(g_state, &json, nullptr)) {
+      ADD_FAILURE() << row.millions << " M: the export path refused the document";
+      continue;
+    }
+    const nlohmann::json exported = nlohmann::json::parse(json);
+    EXPECT_EQ(exported["scene"]["ray_num"].get<unsigned long long>(), row.rays) << row.millions << " M";
+
+    GuiState loaded = InitDefaultState();
+    loaded.sim.ray_num_millions = 5.0f;  // seed off the expectation
+    if (!DeserializeFromJson(json, loaded)) {
+      ADD_FAILURE() << row.millions << " M: the importer rejected the export";
+      continue;
+    }
+    EXPECT_FLOAT_EQ(loaded.sim.ray_num_millions, row.millions);
+    EXPECT_FALSE(loaded.sim.infinite) << row.millions << " M";
+  }
+}
+
 }  // namespace
 }  // namespace lumice::gui

--- a/test/composition-correctness/gui/test_scene_commit_chain.cpp
+++ b/test/composition-correctness/gui/test_scene_commit_chain.cpp
@@ -818,6 +818,32 @@ TEST(SceneCommitChain, TheAnalysisSubmitsTheSceneTheRunWouldCommit) {
   EXPECT_EQ(from_emitter["scene"]["ray_num"].get<int>(), 250000);
 }
 
+// The ray budget's two domain bounds (gui/ray_num_domain.hpp: 0.1 M and 100 000 M) reach the
+// commit as whole integers. The ceiling is the one that can fail quietly: 1e11 is above what a
+// float carries exactly (its spacing there is 8192), so the value must be scaled to rays while it
+// is still a double — the millions figure IS float-exact, and the multiply happens in double —
+// and LUMICE_RayCount must be wide enough to hold the result. `get<unsigned long long>()` rather
+// than the int the case above uses, because 1e11 does not fit an int and a narrowing read would
+// be the same defect this asserts against, on the reading side.
+TEST(SceneCommitChain, TheRayBudgetsDomainBoundsReachTheCommitWhole) {
+  struct Row {
+    float millions;
+    unsigned long long rays;
+  };
+  for (const Row& row : { Row{ 100000.0f, 100000000000ULL }, Row{ 0.1f, 100000ULL } }) {
+    SeedOneEntryDocument();
+    g_state.sim.infinite = false;
+    g_state.sim.ray_num_millions = row.millions;
+    const nlohmann::json commit_doc = CommitSceneJson(g_state);
+    if (commit_doc.is_null()) {
+      ADD_FAILURE() << row.millions << " M: the commit arm produced no scene";
+      continue;
+    }
+    EXPECT_TRUE(commit_doc["scene"]["ray_num"].is_number_unsigned()) << row.millions << " M";
+    EXPECT_EQ(commit_doc["scene"]["ray_num"].get<unsigned long long>(), row.rays) << row.millions << " M";
+  }
+}
+
 // scene.ray_allocation reaches BOTH arms, from the document's own switch, spelled as core spells
 // it. Both values are driven, not one: with only `adaptive` asserted, a BuildScene that stopped
 // calling the setter would still pass whenever core's default happened to agree. And the key is

--- a/test/gui/functional/test_scene_controls.cpp
+++ b/test/gui/functional/test_scene_controls.cpp
@@ -31,6 +31,7 @@ namespace {
 const char* const kAltitude = "**/##Altitude_input";
 const char* const kDiameter = "**/##Diameter_input";
 const char* const kRays = "**/##Rays(M)_input";
+const char* const kRaysSlider = "**/##Rays(M)_slider";
 const char* const kMaxHits = "**/##Max hits_input";
 
 // Owns a real server for the length of one case.
@@ -193,13 +194,13 @@ void RegisterSceneControlTests(ImGuiTestEngine* engine) {
       IM_CHECK(!gui::g_state.sim.infinite);
       IM_CHECK(!IsDisabled(ctx->ItemInfo(kRays)));
 
-      // The declared domain, as literals.
+      // The declared domain (gui/ray_num_domain.hpp), as literals: 0.1 M to 100 000 M (1e11 rays).
       ctx->ItemInputValue(kRays, 0.1f);
       ctx->Yield();
       IM_CHECK_EQ(gui::g_state.sim.ray_num_millions, 0.1f);
-      ctx->ItemInputValue(kRays, 100.0f);
+      ctx->ItemInputValue(kRays, 100000.0f);
       ctx->Yield();
-      IM_CHECK_EQ(gui::g_state.sim.ray_num_millions, 100.0f);
+      IM_CHECK_EQ(gui::g_state.sim.ray_num_millions, 100000.0f);
 
       gui::g_state.sim.infinite = true;
       ctx->Yield(3);
@@ -209,6 +210,46 @@ void RegisterSceneControlTests(ImGuiTestEngine* engine) {
       gui::g_state.sim.infinite = false;
       ctx->Yield(3);
       IM_CHECK(!IsDisabled(ctx->ItemInfo(kRays)));
+    };
+  }
+
+  // The same two bounds reached by the SLIDER rather than the input box. The input path above
+  // never touches the mapping: it writes the number and the trailing clamp keeps it. The slider
+  // is a kLog track over six decades, and a stop on it is only the bound because the widget hands
+  // the extreme back through LogNormToValueSnapped — the mapping is unit-tested, what needs a live
+  // frame is that the real widget path reaches the snap (the Range slider's sqrt twin in
+  // test_edit_modal.cpp is the precedent). A drag far past either end clamps at that end whatever
+  // the slider's on-screen width. The start value is mid-travel and NOT a bound, so an ImGui that
+  // ignored the drag would read as a miss rather than as a pass.
+  {
+    ImGuiTest* t =
+        IM_REGISTER_TEST(engine, "scene_controls", "dragging_the_ray_total_to_a_stop_stores_the_exact_bound");
+    t->TestFunc = [](ImGuiTestContext* ctx) {
+      ResetTestState();
+      gui::g_state.sim.infinite = false;
+      gui::g_state.sim.ray_num_millions = 5.0f;
+      ctx->Yield(2);
+      IM_CHECK(ctx->ItemExists(kRaysSlider));
+
+      ctx->ItemDragWithDelta(kRaysSlider, ImVec2(2000.0f, 0.0f));
+      ctx->Yield(2);
+      IM_CHECK_EQ(gui::g_state.sim.ray_num_millions, 100000.0f);
+
+      ctx->ItemDragWithDelta(kRaysSlider, ImVec2(-2000.0f, 0.0f));
+      ctx->Yield(2);
+      IM_CHECK_EQ(gui::g_state.sim.ray_num_millions, 0.1f);
+
+      // And the law between the stops, from the live widget rather than the mapping's own unit
+      // test. ItemDragWithDelta presses at the item's CENTRE (norm 0.5 — ImGui jumps the grab to
+      // the press), then drags a quarter of the track: norm ~0.75, which is ~3 000 M under kLog
+      // (0.1 x 1e6^0.75) and ~75 000 M under kLinear. A decade either side of the kLog figure is
+      // asked for, so this reads which law runs and not ImGui's grab geometry.
+      const float track_w = ctx->ItemInfo(kRaysSlider).RectFull.GetWidth();
+      IM_CHECK_GT(track_w, 40.0f);
+      ctx->ItemDragWithDelta(kRaysSlider, ImVec2(track_w * 0.25f, 0.0f));
+      ctx->Yield(2);
+      IM_CHECK_GT(gui::g_state.sim.ray_num_millions, 300.0f);
+      IM_CHECK_LT(gui::g_state.sim.ray_num_millions, 30000.0f);
     };
   }
 

--- a/test/gui/references/_thresholds.json
+++ b/test/gui/references/_thresholds.json
@@ -1,7 +1,7 @@
 {
   "groups": {
     "capture_harness": {
-      "generated_at": "2026-09-13T03:24:12",
+      "generated_at": "2026-09-13T05:22:18",
       "n_ref_runs": 1,
       "n_calib_runs": 1,
       "scenes": {

--- a/test/gui/references/smoke_fullframe.png
+++ b/test/gui/references/smoke_fullframe.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6cf43584eb802f67b49e51485a2b1e4dff9464c6e8e1e4b3ce620621d901d2f5
-size 110384
+oid sha256:db88be8fc8df2e56e41aee477cdf7923e59477229eeb92fb0831d41341492d24
+size 110100

--- a/test/unit-correctness/config/test_json.cpp
+++ b/test/unit-correctness/config/test_json.cpp
@@ -698,6 +698,17 @@ TEST_F(V3TestJson, Filter_Complex) {
 
 
 // =============== Scene ===============
+// `ray_num` at the GUI slider's ceiling (gui/ray_num_domain.hpp: 100 000 M = 1e11 rays) parses
+// whole. The golden fixture below carries ray_num = 2, so nothing else here exercises a value
+// outside 32 bits; a reader that went through an int on the way to size_t would pass every other
+// case in this file and truncate exactly the document the GUI now exports at its top stop.
+TEST_F(V3TestJson, Scene_RayNumAtTheGuiCeilingParsesWhole) {
+  auto j = config_json_;
+  j.at("scene").at("ray_num") = 100000000000ULL;
+  auto manager = j.get<ConfigManager>();
+  ASSERT_EQ(manager.scene_.ray_num_, static_cast<size_t>(100000000000ULL));
+}
+
 TEST_F(V3TestJson, Scene_SingleScattering) {
   auto manager = config_json_.get<ConfigManager>();
   const auto& s = manager.scene_;

--- a/test/unit-correctness/gui/test_gui_widget_rules.cpp
+++ b/test/unit-correctness/gui/test_gui_widget_rules.cpp
@@ -776,6 +776,10 @@ TEST(ShapeScalarDomain, EveryPairedRowChangesItsReadoutWithinTheToleratedDrag) {
     { "Amplitude", 0.0f, 90.0f, "%.3g", SliderScale::kSqrt },
     { "Scale", 0.0f, 90.0f, "%.3g", SliderScale::kSqrt },
     { "sun.diameter", 0.1f, 5.0f, "%.2f", SliderScale::kLinear },
+    // The ray budget: six decades on one track, hence kLog and a relative format. Its production
+    // spelling is gui/ray_num_domain.hpp, the one definition both the document row and the
+    // analysis panel's row read; written out here for the same reason as the rows above.
+    { "Rays(M)", 0.1f, 100000.0f, "%.6g", SliderScale::kLog },
   };
 
   for (const NonlinearRow& row : kRows) {
@@ -872,7 +876,7 @@ TEST(SliderFormatGate, NothingTheBoundAcceptsMeasuresFrozen) {
     { "Upper H", 0.0f, 1.0f, "", SliderScale::kLinear },
     { "Face", 0.0f, 2.0f, "", SliderScale::kLinear },
     { "sun.diameter", 0.1f, 5.0f, "", SliderScale::kLinear },
-    { "ray_num_millions", 0.1f, 100.0f, "", SliderScale::kLinear },
+    { "ray_num_millions", 0.1f, 100000.0f, "", SliderScale::kLog },
     { "Std", 0.0f, 180.0f, "", SliderScale::kSqrt },
     { "Range", 0.0f, 360.0f, "", SliderScale::kSqrt },
     { "Amplitude", 0.0f, 90.0f, "", SliderScale::kSqrt },


### PR DESCRIPTION
## Summary

Owner request: the GUI ray budget should reach ≥ 1e11 rays. The `Rays(M)` slider (Simulation panel and the raypath-analysis panel) now spans **0.1 … 100 000 M** on a `kLog` track (the existing `SliderScale` infrastructure), so the low end still resolves to 0.1 M while the top reaches 1e11; the input box accepts any value directly.

- New `src/gui/ray_num_domain.hpp` holds the `(min, max, fmt, scale)` quadruple as the single authority; both rows reference the symbols with zero literals, and the self-described duplicate `kAnalysisRayNumMin/MaxMillions` constants are deleted.
- Display format `"%.1f"` → `"%.6g"` (no scientific notation anywhere in range), gated by the `slider_format::FormatIsFineEnough` `static_assert` next to the quadruple — `"%.1f"` / `"%.2g"` fail to compile, `"%.3g"` / `"%.6g"` pass, matching the hand calculation. The assert only pins format-vs-mapping coarseness; the `kLog` choice itself is pinned by a drag-law test (a quarter-track drag must read within `(300, 30000)`; `kLinear` would read ≈ 75 000).
- Serialization field names/types unchanged (`ray_num_millions: float` / `ray_num: <int>`); no C API or core schema change. The float → `LUMICE_RayCount` → `size_t` chain was audited for 1e11.
- `doc/gui-guide.md` / `_zh.md` describe the range.

Reference images: only `capture_harness` changed (the Rays(M) row's displayed text); reshot **once** per the owner's rule — `defaults_panel_layout` / `modal_layout` / `lens_proj` verified unchanged. LFS object pushed.

## Verification

- gui_test `dragging_the_ray_total_to_a_stop_stores_the_exact_bound`: real drags through `RenderNonlinearSlider`'s `kLog` branch land exactly on `100000.0f` / `0.1f`; quarter-track drag law test excludes `kLinear`.
- Round-trip tests at `100000.0f` and `0.1f` across `.lmc`, JSON export/import, the commit chain (`ray_num == 100000000000ULL`) and core JSON parsing — all `EXPECT_FLOAT_EQ`.
- `./scripts/test.sh quick` → `RESULT: PASS`; four diff-scoped gates + `format.sh --check` green.
- Independent code review: APPROVE, 0 Critical / 0 Major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BcEZUvJP2JfKBYVcwhbYat