### PR TITLE
fix(config): equidistant lens f→fov conversion was half the documented value

### DIFF
--- a/src/util/lens_focal.hpp
+++ b/src/util/lens_focal.hpp
@@ -49,10 +49,8 @@ namespace lumice {
 enum class LensFocalFormula {
   kLinear,                // `fov = 2 · atan(d / f)`; also `globe`, whose on-image scale is linear's
   kFisheyeEqualArea,      // `fov = 4 · asin(d / 2f)`; no solution when `d / 2f > 1`
-  kFisheyeEquidistant,    // `fov = d / f` (radians), as core has always computed it — note that
-                          // doc/configuration.md states `2d / f`, which is also what the forward
-                          // projection's edge implies; reconciling the two changes the CLI's
-                          // output for such configs and is a decision of its own, not a move.
+  kFisheyeEquidistant,    // `fov = 2d / f` (radians): r = f · theta, so the frame edge r = d sits
+                          // at theta = d / f and the full angle is twice that
   kFisheyeStereographic,  // `fov = 4 · atan(d / 2f)`
   kFisheyeOrthographic,   // `fov = 2 · asin(d / f)`; no solution when `d / f > 1`
   kRectangular,           // always full-sky; `f` is ignored and `fov` is 0 by convention
@@ -72,7 +70,7 @@ inline std::optional<float> LensFocalLengthToFovDegrees(LensFocalFormula formula
       }
       return std::asin(d / (2 * f)) * 4 * kRadToDegree;
     case LensFocalFormula::kFisheyeEquidistant:
-      return (d / f) * kRadToDegree;
+      return (2 * d / f) * kRadToDegree;
     case LensFocalFormula::kFisheyeStereographic:
       return std::atan(d / (2 * f)) * 4 * kRadToDegree;
     case LensFocalFormula::kFisheyeOrthographic:

--- a/test/unit-correctness/config/test_json.cpp
+++ b/test/unit-correctness/config/test_json.cpp
@@ -833,6 +833,26 @@ TEST_F(V3TestJson, Scene_GeomClockRoundTrip) {
   EXPECT_EQ(j_on.at("geom_clock").get<size_t>(), kGeomClockMax);
 }
 
+// =============== Lens Equidistant ===============
+
+TEST(LensConfigEquidistant, FCalcMidRange) {
+  // Equidistant: r = f * theta, frame edge r = d = 12mm -> fov = 2 * d / f rad.
+  // f = 12 -> 2 rad = 114.5916 deg (the same row the GUI import contract test pins to core).
+  nlohmann::json j = { { "type", "fisheye_equidistant" }, { "f", 12.0f } };
+  auto l = j.get<LensParam>();
+  EXPECT_EQ(l.type_, LensParam::kFisheyeEquidistant);
+  EXPECT_NEAR(l.fov_, 114.5916f, 1e-3f);
+}
+
+TEST(LensConfigEquidistant, DualFCalcMatchesSingle) {
+  // Both equidistant lens types route to the one formula family; the dual variant must decode
+  // the same f to the same fov.
+  nlohmann::json j = { { "type", "dual_fisheye_equidistant" }, { "f", 24.0f } };
+  auto l = j.get<LensParam>();
+  EXPECT_EQ(l.type_, LensParam::kDualFisheyeEquidistant);
+  EXPECT_NEAR(l.fov_, 57.2958f, 1e-3f);
+}
+
 // =============== Lens Orthographic ===============
 
 TEST(LensConfigOrthographic, MaxFovIs180) {

--- a/test/unit-correctness/util/test_lens_focal.cpp
+++ b/test/unit-correctness/util/test_lens_focal.cpp
@@ -40,10 +40,19 @@ TEST(LensFocal, EqualAreaBelowSixMmHasNoSolution) {
   EXPECT_NEAR(*edge, 360.0f, kTol);
 }
 
-// equidistant: fov = d / f radians. f = 12 → 1 rad = 57.2958°.
-TEST(LensFocal, EquidistantAtTwelveMmIsOneRadian) {
+// equidistant: fov = 2d / f radians. f = 12 → 2 rad = 114.5916°.
+TEST(LensFocal, EquidistantAtTwelveMmIsTwoRadians) {
   const std::optional<float> fov =
       lumice::LensFocalLengthToFovDegrees(lumice::LensFocalFormula::kFisheyeEquidistant, 12.0f);
+  ASSERT_TRUE(fov.has_value());
+  EXPECT_NEAR(*fov, 114.5916f, kTol);
+}
+
+// equidistant, second point: f = 24 → 1 rad = 57.2958°. Together with the f = 12 row this pins the
+// factor 2 itself, not one absolute value — an offset instead of a doubling passes at most one.
+TEST(LensFocal, EquidistantAtTwentyFourMmIsOneRadian) {
+  const std::optional<float> fov =
+      lumice::LensFocalLengthToFovDegrees(lumice::LensFocalFormula::kFisheyeEquidistant, 24.0f);
   ASSERT_TRUE(fov.has_value());
   EXPECT_NEAR(*fov, 57.2958f, kTol);
 }


### PR DESCRIPTION
## Summary

`src/util/lens_focal.hpp`'s `kFisheyeEquidistant` branch computed `fov = d / f`, while `doc/configuration.md` states `fov = 2d / f`, the forward projection (`r = r_scale·θ/(π/2)`, `r_scale = short_pix·(π/2)/fov_rad`) puts `θ_edge = fov/2` at the short edge, and the other five families (linear `2·atan(d/f)`, equal-area `4·asin(d/2f)`, stereographic `4·atan(d/2f)`, orthographic `2·asin(d/f)`, globe = linear) all carry the `fov = 2·θ_edge` factor. Only this row lacked it — code was the odd one out among three sources, so it is the one that changes (owner ruling, 2026-09-13).

Consequence: a config stating `f` for an equidistant lens now renders at the documented field of view (`f = 12 mm` → 114.59°, previously 57.30°). Core and the GUI importer share the one function since #355, so both sides move together. ⚠️ CLI behavior change for such configs — CHANGELOG line drafted in the task notes for the release chore.

- The enum comment no longer hedges ("a decision of its own") — it states the formula.
- `test_lens_focal.cpp`: the current-behavior literal (57.2958°) becomes `f=12 → 114.59°`, plus `f=24 → 57.30°` so the factor is pinned at two points.
- `test_json.cpp`: an equidistant `FCalc` case through config parsing.

## Verification

- Red state: reverting the formula to `d / f` turns all four assertions red; restored.
- GUI-side cross-check (import of the same config) passes unchanged — it reads the same function.
- `./scripts/test.sh quick` → `RESULT: PASS`; four diff-scoped gates + `format.sh --check` green; e2e reference images: 0 changes (no e2e config states `f` for an equidistant lens).
- Independent code review: APPROVE, 0 Critical / 0 Major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BcEZUvJP2JfKBYVcwhbYat