### PR TITLE
feat(server): standing CPU analysis pool on the GPU route, woken by session kind

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -687,7 +687,9 @@ Valuable design/architecture docs live in `doc/` (tracked). Consult the relevant
     取代「一次运行既渲染又按像素存分解」，拆开 N×W×H 的两处耦合各消解一处：专用运行拆掉与渲染的耦合，
     统计量而非图拆掉像素维度，内存降为 O(不同光路数)，是路线 E「不存、需要时算回来」的泛化。
     四条 owner 裁决均已落地：v1 只走 CPU 路且显式（`SessionMode::kAnalysis` 强制
-    `ResolveGpuRoute`/`CreateBackend` 走 CPU，GUI 不禁用/不提示）/ 完整链（跨 MS 层）= per-ray 链 id
+    `ResolveGpuRoute`/`CreateBackend` 走 CPU，GUI 不禁用/不提示；⭐2026-09-13 起 GPU 偏好 server
+    也是**多 worker**——构造期常备一组 CPU 偏好的分析池 `analysis_pool_simulators_`，`Start()` 按
+    `SessionKind` 只唤醒对应组，`num_workers` 由此对 GPU 路第一次生效=决定池大小）/ 完整链（跨 MS 层）= per-ray 链 id
     （`RayBuffer::chain_ids_`）interning（`ChainIdInterningTable`）前向携带，与 `components_` 同一套
     六个传播点（已用红态探针逐点验证）/ ROI = 方向空间锥形 + 分环 + 角半径滑杆 display-time 生效（GUI
     专测钉住）/ 总能量降序必有，密度排序（能量/立体角）v1 未做。顺带闭环：列表行 →「Exclude this

--- a/doc/c_api.md
+++ b/doc/c_api.md
@@ -219,15 +219,33 @@ Server configuration structure for `LUMICE_CreateServerEx()`.
 
 ```c
 typedef struct LUMICE_ServerConfig_ {
-  int num_workers;        // Number of simulator worker threads. 0 = default (hardware_concurrency - 2)
+  int num_workers;        // CPU worker count. 0 = automatic: min(physical core count, 10) —
+                          // kMaxDefaultWorkerCount in server.cpp is the cap and carries the
+                          // measurements behind it. A value > 0 is honoured verbatim, above
+                          // the cap included.
   unsigned int sim_seed;  // Deterministic seed for worker RNGs. 0 = random (default).
                           // Non-zero collapses to 1 worker for bit-stable results.
+  int preferred_backend;  // LUMICE_BACKEND_CPU / LUMICE_BACKEND_METAL / LUMICE_BACKEND_CUDA
 } LUMICE_ServerConfig;
 ```
 
 **Notes**:
-- Zero-initialized struct (`= {0}`) is equivalent to default behavior (auto worker count, random seed)
-- When `sim_seed != 0`, the server forces `num_workers = 1` to ensure deterministic ray tracing results.
+- Zero-initialized struct (`= {0}`) is equivalent to default behavior (auto worker count, random seed,
+  CPU backend)
+- `num_workers` sizes the server's CPU worker group on **both** routes. On the CPU route these are the
+  render workers, which also run an analysis. On the GPU route (Metal/CUDA) the render engine stays a
+  single `Simulator` whatever this says (N engines would contend one GPU — see
+  `doc/gpu-single-engine-implementation.md`), and the count sizes the server's **standing CPU analysis
+  pool**: the workers `LUMICE_StartRaypathAnalysis` runs on, built at construction and woken only by an
+  analysis session.
+  **⚠️ BEHAVIOUR CHANGE** (with the standing pool): before it existed the field was ignored on the GPU
+  route — an analysis there ran on the single engine with CPU forced, one core. A caller that passed a
+  non-zero `num_workers` to a GPU-preferred server now gets an analysis pool of that size; a caller that
+  left it 0 gets the automatic size. The render is unaffected either way.
+- When `sim_seed != 0`, the server forces `num_workers = 1` to ensure deterministic ray tracing results —
+  on the GPU route this collapses the analysis pool to one worker by the same rule, and that worker holds
+  `sim_seed` exactly as the CPU route's one worker does, so a seeded analysis reproduces across the
+  backend toggle, not only across sessions of one server.
   The determinism is per run, for EVERY run of the server's life: each `LUMICE_CommitScene` /
   `LUMICE_StartRaypathAnalysis` session re-seeds the worker from `sim_seed` at its start, so the tenth
   session of one server reproduces the first bit for bit (the worker's RNG used to be seeded at

--- a/doc/raypath-analysis-panel.md
+++ b/doc/raypath-analysis-panel.md
@@ -113,6 +113,16 @@ owner 在 2026-09-11 提出第三种形态，不再试图同时满足「渲染�
    （`src/include/lumice.h:2448`，`src/server/c_api.cpp:3320`）把它读出来给调用方核对「强制是否生效」。
    GUI 侧**没有**为这条加任何可见提示或按钮禁用——Analyze 在 GPU 偏好会话下一样可点，只是内部
    静默走 CPU、可能比渲染慢；这是子任务 5 范围内的非目标（GUI 的 GPU 路径体验留给未来子任务）。
+   **多 worker（as-built，2026-09-13 起）**：CPU 路的分析本来就跑在多 worker 上；GPU 偏好的
+   server 现在亦然——`ServerImpl` 构造期在单引擎之外额外建一组 CPU 偏好的**常备分析池**
+   （`analysis_pool_simulators_`，`num_workers > 0 ? num_workers : min(PhysicalCoreCount(), kMaxDefaultWorkerCount)`
+   个 `Simulator`，`sim_seed != 0` 时与 CPU 路同规则坍缩为 1），`Start()` 按 `SessionKind` 只
+   唤醒对应的那一组（`RunPersistentLoop` 的 `required_mode` 等待谓词：渲染唤醒引擎，分析唤醒池，
+   另一组在 `Start()`/`Stop()` 间沉睡），`Stop()` 的 `active_workers_ → 0` 等待因此只计醒着的组。
+   在此之前 GPU 偏好 server 上的分析是「对唯一那个引擎 simulator 强制 CPU」——单核。
+   `AnalysisWorkers()` 是「分析会话属性下发到哪一组」的唯一权威（CPU 路 = `simulators_` 本身，
+   GPU 路 = 池）；`LUMICE_ServerConfig.num_workers` 由此对 GPU 偏好 server 第一次产生效果
+   （决定池大小，此前被忽略），`doc/c_api.md` 有行为变化标记。
 2. **「光路」= 从光源到相机的完整链，不是单晶体内的一段。**
    例如 `crystal1(1-3-5)-crystal2(3-2)`；单晶体 MS 或单层退化为链长 1，不特判成另一种数据形状。
    理由（机制约束）：现有数据结构拿不到全链——`ExitRayRecord::path` 只装最后一层的面序列，
@@ -466,9 +476,12 @@ entry 共享）/ 多个 Out 槽位 / 还有未筛选子组分别措辞。实施�
   `SimData` 携带本批新增的表增量，consumer 按 `ChainIdMerger` 合并（见 §3.2）；未采用「强制
   `worker_count=1`」的备选方案，多 worker 吞吐未被牺牲。诚实边界：这条合并逻辑只有合成数据 +
   白盒单测覆盖（`test_chain_id_merger.cpp`），真实多线程并发场景的端到端验证由子任务 4 的
-  `test_server_analysis_run.cpp` 补齐（互斥/强制 CPU 场景），但**没有**一个测试是「多 worker
-  并发跑分析会话，断言合并结果与已知答案一致」这种端到端形状——仍然是合成/白盒覆盖，
-  没有再往上升级。
+  `test_server_analysis_run.cpp` 补齐（互斥/强制 CPU 场景）。2026-09-13 起补上了端到端形状：
+  `ServerAnalysisRunMultiWorker.FourWorkersMergeIntoTheSameHistogramAsOne`（同文件）在 CPU 路上
+  对同一场景跑 1-worker 与 4-worker 两次分析，精确断言预算被全额追踪、每条链只占一行（跨 worker
+  合并失败的形状是同一条链被拆到多行），并在该场景实测噪声（总能量 ±7%、主链份额相对 ≤11%、
+  计数 0.14%）给出的容差内断言总能量、计数与每条主链的份额双向一致。仍是统计比对，不是
+  「与已知答案一致」——随机 seed 下没有已知答案可比。
 - **ROI 圈随视角错位**（2026-09-12 前的已知限制，仅记在 `GuiState::analysis` 的代码注释与
   `doc/user-manual/06-raypath-analysis{,_zh}.md` 的「已知限制」小节里，本设计文档从未记录这条限制——
   全部历史版本无此措辞，可用 `git log --all -p -- doc/raypath-analysis-panel.md` 核实）——**已修复**：
@@ -553,7 +566,9 @@ B——2026-09-12 更新把 symmetry 搬到读取侧而结构性消失，完整�
 
 - **GPU 直方图 kernel**（对应 §2 第 1 条的「GPU 不覆盖」）：触发条件——用户反馈 CPU-only 的
   分析等待时间在大 `ray_num` / 多晶体场景下不可接受，且 Metal/CUDA 补上 per-ray 记录回传
-  （当前 `ReadbackExitRays` 直接返回空）的工程代价被证明值得投入。
+  （当前 `ReadbackExitRays` 直接返回空）的工程代价被证明值得投入。⚠️ GPU 偏好 server 上的分析
+  在 2026-09-13 之前是单核的（见 §2 第 1 条「多 worker」段），那个时代测得的等待时间数字不构成
+  触发证据，须以常备分析池落地后的实测数字重判。
 - **密度排序（能量 / 覆盖立体角）**（对应 §2 第 4 条）：触发条件——用户明确反馈「总能量降序」
   把弥散但总量大的链排到了他们认为不重要的位置靠前。需要给每个链 key 配一张粗天球栅格才能算出
   覆盖立体角，存储与实现复杂度上升一个量级，不是加一个排序 comparator 就能做到。

--- a/src/gui/app.cpp
+++ b/src/gui/app.cpp
@@ -1098,8 +1098,9 @@ bool MaybeReconstructServerForConstructionProperties() {
   LUMICE_DestroyServer(g_server);
 
   LUMICE_ServerConfig cfg{};
-  // The user's personal default (Settings §app), 0 = PhysicalCoreCount (CPU). Ignored on the GPU
-  // single engine, which is always one worker whatever this says.
+  // The user's personal default (Settings §app), 0 = PhysicalCoreCount (capped). On the GPU route
+  // the render engine is one worker whatever this says; the value sizes that server's standing CPU
+  // analysis pool instead.
   cfg.num_workers = want_workers;
   cfg.sim_seed = 0;  // 0 = random — matches LUMICE_CreateServer() startup default
   cfg.preferred_backend = want_gpu ? ResolveGpuBackend() : LUMICE_BACKEND_CPU;

--- a/src/gui/gui_state.hpp
+++ b/src/gui/gui_state.hpp
@@ -1478,9 +1478,10 @@ struct GuiState {
   // physical core, capped (LUMICE_ServerConfig::num_workers's own meaning for 0, server.cpp —
   // deliberately the same convention rather than a second answer to "what does 0 mean here"). Like use_gpu_backend this
   // is a construction-time property, so changing it reconstructs the server on the next DoRun via
-  // MaybeReconstructServerForConstructionProperties; the GPU route is a single engine and ignores
-  // it. UI-only: not serialized into a document (.lmc) and not in the Revert baseline
-  // (ConfigSnapshot).
+  // MaybeReconstructServerForConstructionProperties. On the GPU route the render engine is a single
+  // Simulator whatever this says; there the value sizes the server's standing CPU analysis pool
+  // instead (the workers a raypath analysis runs on), so it is not ignored on that route either.
+  // UI-only: not serialized into a document (.lmc) and not in the Revert baseline (ConfigSnapshot).
   //
   // WHY IT IS AN app PREFERENCE AND NOT A DOCUMENT FIELD. A worker count is a property of the
   // MACHINE, not of the halo being simulated: the same document opened on a laptop and on a

--- a/src/include/lumice.h
+++ b/src/include/lumice.h
@@ -653,11 +653,18 @@ typedef struct LUMICE_StatsResult_ {
 
 // =============== Server Configuration ===============
 typedef struct LUMICE_ServerConfig_ {
-  int num_workers;        // CPU route only: worker count (0 = automatic: the physical core
-                          // count, capped — see kMaxDefaultWorkerCount in server.cpp for the
-                          // value and the measurements behind it). A value > 0 is honoured
-                          // verbatim and is NOT subject to that cap.
-                          // Ignored on the GPU/Metal route (always one engine, task-268.7).
+  int num_workers;        // CPU worker count (0 = automatic: the physical core count, capped —
+                          // see kMaxDefaultWorkerCount in server.cpp for the value and the
+                          // measurements behind it). A value > 0 is honoured verbatim and is
+                          // NOT subject to that cap. On the CPU route these are the render
+                          // workers (which also run an analysis). On the GPU/Metal/CUDA route
+                          // the render engine stays a single Simulator (N engines would contend
+                          // one GPU; see doc/gpu-single-engine-implementation.md) and this
+                          // count sizes the server's standing CPU ANALYSIS POOL — the workers
+                          // LUMICE_StartRaypathAnalysis runs on. BEHAVIOUR CHANGE: before that
+                          // pool existed the field was ignored on the GPU route; a caller that
+                          // passed a non-zero value there now gets an analysis pool of that
+                          // size (the render is unaffected either way).
   unsigned int sim_seed;  // Deterministic seed for the worker RNG. 0 = random (default).
   int preferred_backend;  // LUMICE_BACKEND_CPU (0, multi-worker), LUMICE_BACKEND_METAL
                           // (1, single engine on Apple) or LUMICE_BACKEND_CUDA (2, future).

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -1,6 +1,7 @@
 #include "server/server.hpp"
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -180,10 +181,11 @@ class ServerImpl {
   Error ParseConfigManager(const nlohmann::json& config_json, const char* caller,
                            const std::function<void(const ConfigManager&)>& validate, ConfigManager* out);
 
-  // task-268.7: single-engine orchestration — server now runs exactly one
+  // Single-engine orchestration — the GPU route's render group is exactly one
   // Simulator. The legacy kDefaultSimulatorCnt = PhysicalCoreCount() was removed
-  // along with the 12-worker queue-per-Simulator pattern; num_workers is reserved
-  // and ignored. See doc/gpu-single-engine-implementation.md §6.
+  // along with the 12-worker queue-per-Simulator pattern. num_workers sizes the CPU
+  // group on both routes: the render workers on the CPU route, the standing analysis
+  // pool on the GPU route (see the ctor). See doc/gpu-single-engine-implementation.md §6.
   static constexpr int kMaxSceneCnt = 128;
   static constexpr size_t kDefaultRayNum = 128;
   // scrum-268.6: Metal single-engine needs a large GPU dispatch to saturate the
@@ -250,8 +252,15 @@ class ServerImpl {
   void PublishEmptyFrame();
 
   // Persistent thread loop: wait for Start(), run work_fn, repeat until kTerminating.
+  // `required_mode` is the group-selection half of Start(): a thread that carries one
+  // only leaves the wait when the session being started is of that kind (mode_), and
+  // otherwise stays parked — it consumes no batch and is not counted in active_workers_,
+  // exactly as if the notify had been spurious. nullopt = wake for every session (the
+  // two control threads, and every worker of a CPU-route server, whose one group serves
+  // both kinds). Start() itself stays a plain notify_all(): the selection lives in the
+  // wait predicate, so there is no second wake-up path to keep in step with the first.
   template <typename F>
-  void RunPersistentLoop(F work_fn);
+  void RunPersistentLoop(F work_fn, std::optional<SessionKind> required_mode = std::nullopt);
 
   ConfigManager config_manager_;
 
@@ -310,7 +319,22 @@ class ServerImpl {
   QueuePtrS<SimBatch> scene_queue_;
   QueuePtrS<SimData> data_queue_;
 
+  // The server's principal worker group: the single GPU engine on the GPU route, the
+  // legacy multi-worker set on the CPU route. Every "is this the single-engine route"
+  // question in this file (ReadBackendActive's size()==1, GetActiveBackend's [0]) is
+  // asked of THIS vector, which is why the analysis pool below is a second vector and
+  // not more members of this one — merged in, `size() != 1` would read true on every
+  // GPU-route server and silently switch the whole fallback detection off.
   std::vector<Simulator> simulators_;
+  // The standing analysis pool: CPU-preferred Simulators that only an analysis session
+  // wakes (RunPersistentLoop's required_mode = kAnalysis). Non-empty only when
+  // gpu_route_ is true — on the CPU route the analysis runs on simulators_ itself, which
+  // is already the multi-worker set. Built once in the ctor next to simulators_, its
+  // threads live in the same simulator_threads_ and stop at the same start_cv_ wait;
+  // there is no second lifecycle for it. The two groups never run in the same session:
+  // the render wakes simulators_ (required_mode = kRender on the GPU route), the
+  // analysis wakes this pool, and the other group sleeps through Start()/Stop().
+  std::vector<Simulator> analysis_pool_simulators_;
   std::vector<ConsumerPtrS> consumers_;
   mutable TicketMutex consumer_mutex_;  // FIFO lock: prevents Poller starvation on Windows
   bool snapshot_dirty_{ false };        // Set by ConsumeData, cleared by DoSnapshot
@@ -507,6 +531,34 @@ class ServerImpl {
     return simulators_[0].BackendActive();
   }
 
+  // The one owner of "which group an analysis session runs on, and so which group its
+  // three per-Simulator session properties (chain ids, forced CPU) are set on and
+  // withdrawn from". StartRaypathAnalysis and CommitConfig's was_analysis reset both
+  // iterate this and nothing else, so the two cannot drift apart. The two routes are not
+  // symmetric in what this names: on the GPU route it is the standing pool, physically
+  // apart from the render engine; on the CPU route it is simulators_ — the render group
+  // ITSELF, which serves both session kinds. A new CPU-route consumer of this helper is
+  // therefore touching the render workers, not a separate object.
+  std::vector<Simulator>& AnalysisWorkers() { return gpu_route_ ? analysis_pool_simulators_ : simulators_; }
+  const std::vector<Simulator>& AnalysisWorkers() const { return gpu_route_ ? analysis_pool_simulators_ : simulators_; }
+
+  // The group the CURRENT session wakes — the one whose Simulators are running or can
+  // run, and so the only one whose IsIdle() says anything about this session. The
+  // dormant group is not merely uninteresting but misleading to poll: Simulator::Stop()
+  // (which Stop() and the dtor send to every Simulator, both groups) leaves stop_ set,
+  // and only the next Run() clears it, so a group that sat out the session after a
+  // Stop() reads !IsIdle() until it is next woken. Scanning it would hold GetStatus() at
+  // kRunning for the whole of every later session of the other kind.
+  const std::vector<Simulator>& ActiveWorkers() const {
+    return mode_.load(std::memory_order_acquire) == SessionKind::kAnalysis ? AnalysisWorkers() : simulators_;
+  }
+
+  // Both groups, for the broadcasts that address every Simulator this server owns
+  // whatever the session (Stop(), the dtor, SetLogLevel). On the CPU route the pool is
+  // empty and its loop is a no-op; the shape is the same on both routes so a new
+  // broadcast site has one thing to call instead of a second vector to remember.
+  std::array<std::vector<Simulator>*, 2> AllWorkerGroups() { return { &simulators_, &analysis_pool_simulators_ }; }
+
   std::atomic_int sim_scene_cnt_;
   std::mutex scene_mutex_;
   std::condition_variable scene_cv_;
@@ -525,14 +577,22 @@ class ServerImpl {
 };
 
 template <typename F>
-void ServerImpl::RunPersistentLoop(F work_fn) {
+void ServerImpl::RunPersistentLoop(F work_fn, std::optional<SessionKind> required_mode) {
   uint64_t my_gen = 0;
   while (true) {
     {
       std::unique_lock<std::mutex> lk(start_mutex_);
-      start_cv_.wait(lk, [this, &my_gen] {
-        return state_.load() == ServerState::kTerminating ||
-               (state_.load() == ServerState::kRunning && start_generation_.load() != my_gen);
+      // Termination FIRST and on its own: a thread whose group is not the session's must
+      // still leave on kTerminating, or the dtor's join would wait on it forever. The
+      // mode filter only qualifies the running-state clause — "is this Start() for my
+      // group" — never the exit. A thread turned away here keeps its my_gen, so the next
+      // Start() of its own kind still reads as a new generation to it.
+      start_cv_.wait(lk, [this, &my_gen, &required_mode] {
+        if (state_.load() == ServerState::kTerminating) {
+          return true;
+        }
+        return state_.load() == ServerState::kRunning && start_generation_.load() != my_gen &&
+               (!required_mode.has_value() || mode_.load(std::memory_order_acquire) == *required_mode);
       });
       if (state_.load() == ServerState::kTerminating) {
         return;
@@ -642,26 +702,51 @@ ServerImpl::ServerImpl(int num_workers, uint32_t sim_seed, BackendKind preferred
   StorePublished(std::make_shared<const ResultFrame>());
   preferred_backend_.store(preferred_backend, std::memory_order_release);
   gpu_route_ = ResolveGpuRoute(preferred_backend, logger_);
+  // The CPU worker count, by the one rule both routes size their CPU group with: the
+  // caller's explicit number verbatim, else the capped physical core count; and a fixed
+  // seed collapses it to a single worker — the deterministic CPU contract, which is also
+  // what keeps SimData::producer_effective_seed_ distinct per worker (a fixed seed is
+  // returned verbatim as the effective seed): relaxing this needs every worker's seed
+  // made distinct, or ChainIdMerger fuses chains across workers silently. The per-index
+  // seed offset below is that guard, dead today.
+  const int cpu_worker_count =
+      sim_seed != 0 ? 1 : (num_workers > 0 ? num_workers : std::min(PhysicalCoreCount(), kMaxDefaultWorkerCount));
   int worker_count = 1;
+  int analysis_pool_worker_count = 0;
   if (gpu_route_) {
     worker_count = 1;  // GPU route: single engine (task-268.7; CUDA joined 296.6)
+    // The analysis always traces on the CPU path (it is the only one that carries chain
+    // ids), and a single CPU worker is not what "analysis" should cost on a machine that
+    // was given a GPU precisely because it has cores to spare. So the GPU route ALSO
+    // stands up the CPU group the CPU route would have built, as a second vector that
+    // only an analysis session wakes. num_workers, which the single engine has no use
+    // for, sizes it — the one place the field has an effect on this route.
+    analysis_pool_worker_count = cpu_worker_count;
   } else {
-    worker_count = num_workers > 0 ? num_workers : std::min(PhysicalCoreCount(), kMaxDefaultWorkerCount);
-    if (sim_seed != 0) {
-      worker_count = 1;  // deterministic CPU contract: fixed seed → single worker
-      // Also what keeps SimData::producer_effective_seed_ distinct per worker
-      // (a fixed seed is returned verbatim as the effective seed): relaxing
-      // this needs every worker's seed made distinct, or ChainIdMerger fuses
-      // chains across workers silently. The per-index offset below is that
-      // guard, dead today.
-    }
+    worker_count = cpu_worker_count;  // the CPU route's one group serves both session kinds
   }
-  // AC1 observability (296.6): the GPU single-engine route must run worker_count==1.
-  ILOG_INFO(logger_, "ServerImpl: gpu_route={} worker_count={} (preferred_backend={})", gpu_route_, worker_count,
-            static_cast<int>(preferred_backend));
+  // AC1 observability (296.6): the GPU single-engine route must run worker_count==1;
+  // analysis_pool_worker_count is the standing analysis pool's size (0 = no second group).
+  ILOG_INFO(logger_, "ServerImpl: gpu_route={} worker_count={} analysis_pool_worker_count={} (preferred_backend={})",
+            gpu_route_, worker_count, analysis_pool_worker_count, static_cast<int>(preferred_backend));
   for (int i = 0; i < worker_count; i++) {
     uint32_t worker_seed = sim_seed != 0 ? sim_seed + static_cast<uint32_t>(i) : 0u;
     simulators_.emplace_back(scene_queue_, data_queue_, worker_seed);
+  }
+  // The pool is seeded by the SAME per-index rule as the principal group, from the same
+  // base, on purpose: the two groups never run in the same session, so overlapping seeds
+  // cannot pair two concurrent producers, and a fixed-seed analysis then traces the same
+  // stream whether the server was built CPU- or GPU-preferred (the single pool worker and
+  // the single CPU-route worker both hold sim_seed) — reproducibility across the backend
+  // toggle, not only across sessions of one server.
+  for (int i = 0; i < analysis_pool_worker_count; i++) {
+    uint32_t worker_seed = sim_seed != 0 ? sim_seed + static_cast<uint32_t>(i) : 0u;
+    analysis_pool_simulators_.emplace_back(scene_queue_, data_queue_, worker_seed);
+    // Pinned to CPU for life: not by SetPreferredBackend below or later (which
+    // deliberately addresses simulators_ only), nor by the env override — the analysis
+    // session's SetAnalysisForceCpu makes even that moot, but the pool's own preference
+    // says what it is for without depending on the session flag.
+    analysis_pool_simulators_.back().SetPreferredBackend(BackendKind::kCpu);
   }
 
   // Propagate the construction-time backend into every simulator. The server-level
@@ -677,10 +762,17 @@ ServerImpl::ServerImpl(int num_workers, uint32_t sim_seed, BackendKind preferred
   }
 
   // Spawn persistent threads — they start in cv.wait(), not working. All
-  // simulators_ are emplaced above first, so the &s references stay valid (no
-  // further vector reallocation).
+  // simulators_ / analysis_pool_simulators_ are emplaced above first, so the &s
+  // references stay valid (no further vector reallocation). Group selection: on the GPU
+  // route the engine wakes for renders only and the pool for analyses only; on the CPU
+  // route the one group wakes for both (nullopt), and the pool loop is empty.
+  const std::optional<SessionKind> engine_mode =
+      gpu_route_ ? std::optional<SessionKind>(SessionKind::kRender) : std::nullopt;
   for (auto& s : simulators_) {
-    simulator_threads_.emplace_back([this, &s]() { RunPersistentLoop([&s] { s.Run(); }); });
+    simulator_threads_.emplace_back([this, &s, engine_mode]() { RunPersistentLoop([&s] { s.Run(); }, engine_mode); });
+  }
+  for (auto& s : analysis_pool_simulators_) {
+    simulator_threads_.emplace_back([this, &s]() { RunPersistentLoop([&s] { s.Run(); }, SessionKind::kAnalysis); });
   }
   consume_data_thread_ = std::thread([this]() { RunPersistentLoop([this]() { ConsumeData(); }); });
   generate_scene_thread_ = std::thread([this]() { RunPersistentLoop([this]() { GenerateScene(); }); });
@@ -703,9 +795,13 @@ ServerImpl::~ServerImpl() {
   start_cv_.notify_all();
   scene_cv_.notify_one();
 
-  // Stop simulators to break their inner Run() loops
-  for (auto& s : simulators_) {
-    s.Stop();
+  // Stop simulators to break their inner Run() loops — both groups: the dormant one has
+  // nothing to break, and is told anyway, so that the broadcast and the join below
+  // address the same set of threads.
+  for (auto* group : AllWorkerGroups()) {
+    for (auto& s : *group) {
+      s.Stop();
+    }
   }
 
   // Join all persistent threads
@@ -978,7 +1074,7 @@ Error ServerImpl::CommitConfig(const nlohmann::json& config_json, bool* out_reus
   if (was_analysis) {
     {
       std::lock_guard<std::mutex> lock(prod_mutex_);
-      for (auto& s : simulators_) {
+      for (auto& s : AnalysisWorkers()) {
         s.SetAnalysisChainId(false, 0);
         s.SetAnalysisForceCpu(false);
       }
@@ -1208,7 +1304,12 @@ Error ServerImpl::StartRaypathAnalysis(const nlohmann::json& scene_json, const R
   }
   {
     std::lock_guard<std::mutex> lock(prod_mutex_);
-    for (auto& s : simulators_) {
+    // The group this session wakes (CPU route: the workers themselves; GPU route: the
+    // standing pool). SetAnalysisForceCpu is redundant on the pool, whose preference is
+    // already CPU, and is set all the same: the session property is what ResolveGpuRoute /
+    // CreateBackend read and log, and the declaration of "this run is CPU by request"
+    // must not depend on which group happens to carry it.
+    for (auto& s : AnalysisWorkers()) {
       // Finest, always: the reader reduces (RaypathAnalysisRequest says why).
       s.SetAnalysisChainId(true, FilterConfig::kSymNone);
       s.SetAnalysisForceCpu(true);
@@ -1219,9 +1320,10 @@ Error ServerImpl::StartRaypathAnalysis(const nlohmann::json& scene_json, const R
   // and the preference itself is untouched (GetActiveBackend is the readable form).
   ILOG_INFO(logger_,
             "StartRaypathAnalysis: forcing CPU route (analysis run session property; overrides "
-            "preferred_backend={} and LUMICE_TRACE_BACKEND, neither is modified); roi_mode={} (chains recorded "
-            "unreduced; symmetry is applied when the result is read)",
-            static_cast<int>(preferred_backend_.load(std::memory_order_acquire)), static_cast<int>(request.roi_.mode_));
+            "preferred_backend={} and LUMICE_TRACE_BACKEND, neither is modified) on {} worker(s){}; roi_mode={} "
+            "(chains recorded unreduced; symmetry is applied when the result is read)",
+            static_cast<int>(preferred_backend_.load(std::memory_order_acquire)), AnalysisWorkers().size(),
+            gpu_route_ ? " (standing analysis pool)" : "", static_cast<int>(request.roi_.mode_));
   // Bind the scene this session traces — the same three writes, under the same lock, on
   // the same reset action as CommitConfig's bind (see the fields' declarations for why an
   // analysis advances the epoch: it is a submission of its own scene, and a reader's "is
@@ -1569,13 +1671,18 @@ void ServerImpl::Stop() {
   data_queue_->Shutdown();
   scene_cv_.notify_one();
 
-  // Stop simulators to break their inner Run() loops
-  for (auto& s : simulators_) {
-    s.Stop();
+  // Stop simulators to break their inner Run() loops. Both groups, though only the
+  // session's group is running: Stop() on a dormant Simulator is a flag it will clear at
+  // its next Run() entry, and the queue shutdowns are idempotent.
+  for (auto* group : AllWorkerGroups()) {
+    for (auto& s : *group) {
+      s.Stop();
+    }
   }
 
   // Wait for all workers to finish their current work cycle.
-  // Workers notify start_cv_ when active_workers_ reaches 0.
+  // Workers notify start_cv_ when active_workers_ reaches 0. Only the woken group ever
+  // counted itself in, so this waits on exactly the session's workers.
   {
     std::unique_lock<std::mutex> lk(start_mutex_);
     start_cv_.wait(lk, [this] { return active_workers_.load() == 0; });
@@ -1661,7 +1768,9 @@ ServerStatus ServerImpl::GetStatus() const {
   bool any_busy = false;
   {
     std::lock_guard<std::mutex> lock(prod_mutex_);
-    for (const auto& s : simulators_) {
+    // The session's own group only — see ActiveWorkers() for why the dormant group must
+    // not be polled (its stop_ flag outlives the Stop() that set it).
+    for (const auto& s : ActiveWorkers()) {
       if (!s.IsIdle()) {
         any_busy = true;
         break;
@@ -2199,8 +2308,8 @@ void ServerImpl::GenerateScene() {
   // cannot disagree today; say so out loud if they ever do, rather than letting one
   // silently size the batches while the other decides whether a fallback happened.
   if (kGpuRoute != gpu_route_ && !kAnalysis) {
-    // (An analysis session on a GPU-built server differs by design, not by drift: it is
-    // still sized single-worker, and the forced CPU route is exactly the point.)
+    // (An analysis session on a GPU-built server differs by design, not by drift: it
+    // runs on the standing CPU pool, and the forced CPU route is exactly the point.)
     ILOG_WARN(logger_,
               "GenerateScene: live gpu_route ({}) disagrees with the construction-time route ({}); this server was "
               "sized for the latter, so dispatch grain and the fallback signal are now keyed off different routes",
@@ -2355,6 +2464,8 @@ void ServerImpl::GenerateScene() {
 void ServerImpl::SetPreferredBackend(BackendKind backend) {
   preferred_backend_.store(backend, std::memory_order_release);
   std::lock_guard<std::mutex> lock(prod_mutex_);
+  // simulators_ only, deliberately: the standing analysis pool is CPU for life (its
+  // declaration says why), and a render-backend toggle has no business reaching it.
   for (auto& s : simulators_) {
     s.SetPreferredBackend(backend);
   }
@@ -2493,8 +2604,10 @@ Error ServerImpl::GetColorClassSignals(uint8_t* out_flags, int class_count) {
 void ServerImpl::SetLogLevel(LogLevel level) {
   logger_.SetLevel(level);
   std::lock_guard<std::mutex> lock(prod_mutex_);
-  for (auto& s : simulators_) {
-    s.SetLogLevel(level);
+  for (auto* group : AllWorkerGroups()) {
+    for (auto& s : *group) {
+      s.SetLogLevel(level);
+    }
   }
 }
 

--- a/src/server/server.hpp
+++ b/src/server/server.hpp
@@ -541,12 +541,16 @@ class Server {
 
   /**
    * @brief Construct a new Server
-   * @param num_workers CPU route only: worker count (0 = automatic: the physical core count,
-   *        capped — see kMaxDefaultWorkerCount in server.cpp). A value > 0 is honoured verbatim,
-   *        above that cap included.
-   *        Ignored on the GPU/Metal route, which is always a single engine
-   *        (task-268.7). The route is fixed at construction (see preferred_backend).
-   * @param sim_seed Deterministic RNG seed. 0 = random; non-zero clamps CPU route to 1 worker.
+   * @param num_workers CPU worker count (0 = automatic: the physical core count, capped — see
+   *        kMaxDefaultWorkerCount in server.cpp). A value > 0 is honoured verbatim, above that
+   *        cap included. On the CPU route these are the render workers, which also run an
+   *        analysis. On the GPU/Metal/CUDA route the render engine is always a single
+   *        Simulator (doc/gpu-single-engine-implementation.md) and this count sizes the standing
+   *        CPU analysis pool instead —
+   *        the workers a StartRaypathAnalysis session runs on. The route is fixed at
+   *        construction (see preferred_backend).
+   * @param sim_seed Deterministic RNG seed. 0 = random; non-zero clamps the CPU group (render
+   *        workers on the CPU route, the analysis pool on the GPU route) to 1 worker.
    * @param preferred_backend BackendKind::kCpu (multi-worker), kMetal (single engine)
    *        or kCuda (future). An env LUMICE_TRACE_BACKEND override takes precedence.
    *        The GUI reconstructs the server when the backend selection changes.

--- a/test/unit-correctness/server/test_server_analysis_run.cpp
+++ b/test/unit-correctness/server/test_server_analysis_run.cpp
@@ -29,12 +29,22 @@
 //        holds for every session of one server, not only its first — a later analysis
 //        (after a render + Stop(), or after another analysis) reproduces the first row
 //        for row.
+//   FourWorkersMergeIntoTheSameHistogramAsOne: an N-worker analysis is the same
+//        histogram as a 1-worker one, up to the scene's measured noise — the worker
+//        count is a merge-correctness axis of its own now that a server sizes it.
+//   ServerAnalysisRunGpuPool.*: the GPU-preferred server's standing CPU analysis pool —
+//        that it runs (a rate no single worker reaches), that a fixed seed collapses it,
+//        that render and analysis alternate without deadlock or leaked results, and
+//        that the dtor returns with an analysis in flight.
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <chrono>
 #include <cmath>
+#include <memory>
 #include <nlohmann/json.hpp>
+#include <set>
 #include <string>
 #include <thread>
 #include <tuple>
@@ -42,6 +52,7 @@
 
 #include "core/math.hpp"
 #include "server/server.hpp"
+#include "util/cpu_info.hpp"
 
 namespace lumice {
 namespace {
@@ -628,6 +639,356 @@ TEST(ServerAnalysisRunGpu, AnalysisForcesCpuUnderGpuPreference) {
   server.Stop();
 #else
   GTEST_SKIP() << "no GPU backend in this build; the CPU-route half is covered by the fixture above";
+#endif
+}
+
+
+// ---------------------------------------------------------------------------
+// Multi-worker analysis correctness (the standing-pool change made the worker count of an
+// analysis a first-class property, so "N workers merge into the same histogram as one"
+// needs a proposition of its own; until now no test compared an N>1 analysis to anything).
+// Same scene, same ROI, same budget on a 1-worker and a 4-worker CPU-route server. The two
+// runs are different random draws, so the comparison is statistical wherever it can be and
+// exact only where the mechanism makes it so:
+//   exact   — sim_ray_num equals the budget on both (the batch schedule sums to it);
+//             no two rows carry the same chain (ChainIdMerger keyed the four producers'
+//             tables into one id space: a merge failure shows as one chain split across
+//             per-producer rows, which the 1-worker run cannot produce).
+//   bounded — every major chain (>= kMajorFrac of the energy) of either run is a row of
+//             the other with at least half that share (hysteresis, so a chain sitting on
+//             the threshold cannot flip the verdict), and its energy share agrees within
+//             kShareTol; the total counted rays and the total energy agree within a
+//             tolerance set by the noise measured on this scene, not chosen.
+// The tolerances come from measured noise, 5 + 5 runs at 200k rays on this scene
+// (2026-09-13): the total energy spreads 4.89M-5.57M (about +-7% around a mean that is
+// the same for N=1 and N=4, 5.16M vs 5.20M — the legacy grain draws one wavelength per
+// 128-ray batch, so 1563 draws of Y(wl) set that spread), the eight ~3% chains' shares
+// move 0.0296-0.0329 (up to ~11% relative between two runs), the ~2% chains 0.0196-0.0212,
+// and the counted-ray total 962949-964260 (0.14%). A merge defect is not a few percent:
+// a chain split across workers loses 75% of its share, a chain double-counted doubles it.
+// ---------------------------------------------------------------------------
+struct ChainShare {
+  std::string display;
+  double frac;
+  size_t count;
+};
+
+std::vector<ChainShare> SharesOf(const AnalysisFingerprint& fp, double total) {
+  std::vector<ChainShare> out;
+  out.reserve(fp.rows.size());
+  for (const auto& row : fp.rows) {
+    out.push_back({ std::get<0>(row), std::get<1>(row) / total, std::get<2>(row) });
+  }
+  return out;
+}
+
+const ChainShare* FindShare(const std::vector<ChainShare>& shares, const std::string& display) {
+  for (const auto& s : shares) {
+    if (s.display == display) {
+      return &s;
+    }
+  }
+  return nullptr;
+}
+
+TEST(ServerAnalysisRunMultiWorker, FourWorkersMergeIntoTheSameHistogramAsOne) {
+  constexpr size_t kRays = 200000;
+  constexpr double kMajorFrac = 0.015;  // a chain worth >= 1.5% of the energy is "major"
+  constexpr double kShareTol = 0.25;    // relative, on a major chain's energy share
+  constexpr double kTotalTol = 0.25;    // relative, on the total energy (4% noise per run)
+  constexpr double kCountTol = 0.02;    // relative, on the counted-ray total (0.2% noise)
+  const nlohmann::json scene = Halo22Config(kRays);
+
+  AnalysisFingerprint one;
+  AnalysisFingerprint four;
+  {
+    Server server(1, 0, BackendKind::kCpu);
+    one = RunAnalysisAndFingerprint(server, scene);
+    server.Stop();
+  }
+  {
+    Server server(4, 0, BackendKind::kCpu);
+    four = RunAnalysisAndFingerprint(server, scene);
+    server.Stop();
+  }
+  ASSERT_FALSE(one.rows.empty());
+  ASSERT_FALSE(four.rows.empty());
+
+  // Exact: the budget is traced in full on both, whatever the worker count.
+  EXPECT_EQ(one.sim_ray_num, kRays);
+  EXPECT_EQ(four.sim_ray_num, kRays);
+
+  // Exact: one row per chain. Keyed on the display text, which is the chain's own
+  // formatting (a per-producer split would show as the same text on several rows).
+  {
+    std::set<std::string> seen;
+    for (const auto& row : four.rows) {
+      EXPECT_TRUE(seen.insert(std::get<0>(row)).second) << "duplicate chain row: " << std::get<0>(row);
+    }
+  }
+
+  const double total_one = TotalEnergy(one);
+  const double total_four = TotalEnergy(four);
+  ASSERT_GT(total_one, 0.0);
+  ASSERT_GT(total_four, 0.0);
+  EXPECT_NEAR(total_four / total_one, 1.0, kTotalTol)
+      << "total energy: 1 worker " << total_one << ", 4 workers " << total_four;
+  size_t count_one = one.other_count;
+  size_t count_four = four.other_count;
+  for (const auto& row : one.rows) {
+    count_one += std::get<2>(row);
+  }
+  for (const auto& row : four.rows) {
+    count_four += std::get<2>(row);
+  }
+  EXPECT_NEAR(static_cast<double>(count_four) / static_cast<double>(count_one), 1.0, kCountTol)
+      << "counted rays: 1 worker " << count_one << ", 4 workers " << count_four;
+
+  // Bounded: the major chains are the same set with the same shares, both directions.
+  const std::vector<ChainShare> shares_one = SharesOf(one, total_one);
+  const std::vector<ChainShare> shares_four = SharesOf(four, total_four);
+  size_t major_checked = 0;
+  const auto check_direction = [&](const std::vector<ChainShare>& a, const std::vector<ChainShare>& b,
+                                   const char* a_name, const char* b_name) {
+    for (const auto& sa : a) {
+      if (sa.frac < kMajorFrac) {
+        continue;  // rows are energy-descending, but the tail is what we skip, so keep scanning cheap
+      }
+      const ChainShare* sb = FindShare(b, sa.display);
+      if (sb == nullptr) {
+        ADD_FAILURE() << "chain " << sa.display << " holds " << sa.frac << " of the energy on " << a_name
+                      << " and has no row on " << b_name;
+        continue;
+      }
+      EXPECT_GE(sb->frac, sa.frac * 0.5) << "chain " << sa.display << ": " << a_name << " " << sa.frac << ", " << b_name
+                                         << " " << sb->frac;
+      EXPECT_NEAR(sb->frac / sa.frac, 1.0, kShareTol) << "chain " << sa.display << ": share " << sa.frac << " ("
+                                                      << a_name << ") vs " << sb->frac << " (" << b_name << ")";
+      major_checked++;
+    }
+  };
+  check_direction(shares_one, shares_four, "1 worker", "4 workers");
+  check_direction(shares_four, shares_one, "4 workers", "1 worker");
+  // The 22-degree scene has eight ~3% chains and a dozen ~2% ones; a scene that yielded
+  // no major chain at all would make the checks above vacuous.
+  EXPECT_GE(major_checked, 8u) << "too few major chains to compare: " << major_checked;
+}
+
+// ---------------------------------------------------------------------------
+// The standing analysis pool of a GPU-preferred server — four propositions, all
+// GPU-gated the way AnalysisForcesCpuUnderGpuPreference is (the pool only exists on the
+// GPU route, and the route only resolves where a GPU backend does):
+//   PoolIsUsedUnderGpuPreference — existence: with num_workers=4 the analysis advances
+//        its ray count at least twice as fast as with num_workers=1 over the same window,
+//        which a single engine Simulator with CPU forced (the shape before the pool) could
+//        not do; while it runs the lifecycle reads kRunning (GetStatus polls the pool, not
+//        the idle engine); and the render after it is GPU again (the reset reached the
+//        group that carried the analysis properties).
+//   FixedSeedCollapsesThePoolToOneWorker — the deterministic contract: num_workers=4 with
+//        a seed still reproduces bit for bit across sessions, and equals the CPU-route
+//        server's own fixed-seed analysis of the same scene (both trace on one worker
+//        seeded sim_seed), so the backend toggle does not change a seeded analysis.
+//   AlternatingRenderAndAnalysisNeitherDeadlocksNorLeaks — the wake-up selection under the
+//        two switch shapes that matter, five times over, every wait bounded: a render
+//        submitted over a running analysis is refused and the analysis keeps running; a
+//        render Stop()ped and an analysis started at once reaches its first rays; and no
+//        frame of either session kind carries the other kind's result.
+//   DestructionDuringAnalysisTerminates — the dormant engine thread and the busy pool
+//        threads both leave on kTerminating: the wait predicate checks termination ahead
+//        of the group filter, and a mistake there would hang the dtor's join.
+// ---------------------------------------------------------------------------
+#if defined(__APPLE__) || defined(LUMICE_CUDA_ENABLED)
+#if defined(__APPLE__)
+constexpr BackendKind kGpuBackend = BackendKind::kMetal;
+#else
+constexpr BackendKind kGpuBackend = BackendKind::kCuda;
+#endif
+
+bool GpuRouteAvailable() {
+  Logger probe{ "ServerAnalysisRunGpuPool" };
+  return ResolveGpuRoute(kGpuBackend, probe);
+}
+
+// Rays traced by an unbounded analysis over `window` after its first rays arrive.
+size_t AnalysisRaysOverWindow(Server& server, const nlohmann::json& scene, std::chrono::milliseconds window) {
+  EXPECT_FALSE(server.StartRaypathAnalysis(scene, FullSkyRequest()));
+  EXPECT_TRUE(WaitForFirstRays(server, 10000));
+  EXPECT_EQ(server.GetSimLifecycle(), SimLifecycle::kRunning) << "an analysis in flight must read as running";
+  const size_t before = server.GetLiveSimRayCount();
+  std::this_thread::sleep_for(window);
+  const size_t after = server.GetLiveSimRayCount();
+  server.Stop();
+  return after - before;
+}
+#endif
+
+TEST(ServerAnalysisRunGpuPool, PoolIsUsedUnderGpuPreference) {
+#if defined(__APPLE__) || defined(LUMICE_CUDA_ENABLED)
+  if (!GpuRouteAvailable()) {
+    GTEST_SKIP() << "GPU route unavailable on this machine (or overridden by LUMICE_TRACE_BACKEND)";
+  }
+  if (PhysicalCoreCount() < 4) {
+    GTEST_SKIP() << "fewer than 4 physical cores; a 4-worker pool cannot show a rate gain here";
+  }
+  const nlohmann::json scene = Halo22Config("infinite");
+  constexpr auto kWindow = std::chrono::milliseconds(1500);
+  // One worker first, then four, on separate servers: the pool is a construction-time
+  // property. An existence threshold, not a performance figure: four pool workers measured
+  // 3.4x, 4.3x and 5.0x one over this window on a 12-core development machine (2026-09-13);
+  // 2x is what separates "the pool ran" from "one worker ran" with room for a loaded box.
+  size_t rays_one = 0;
+  {
+    Server server(1, 0, kGpuBackend);
+    rays_one = AnalysisRaysOverWindow(server, scene, kWindow);
+  }
+  ASSERT_GT(rays_one, 0u);
+  Server server(4, 0, kGpuBackend);
+  const size_t rays_four = AnalysisRaysOverWindow(server, scene, kWindow);
+  EXPECT_GE(rays_four, rays_one * 2) << "1 worker traced " << rays_one << " rays over the window, 4 workers "
+                                     << rays_four << ": the pool did not run";
+
+  // The withdrawal of the analysis properties reached the pool: the render after it is
+  // GPU, and its frame carries no histogram.
+  ASSERT_FALSE(server.CommitConfig(Halo22Config(20000)));
+  ASSERT_EQ(WaitForRunToEnd(server, 30000), SimLifecycle::kCompleted);
+  EXPECT_EQ(server.GetActiveBackend(), kGpuBackend);
+  EXPECT_FALSE(server.BackendFellBack());
+  EXPECT_FALSE(server.AcquireResultFrame()->raypath_histogram_result_.has_value());
+  server.Stop();
+#else
+  GTEST_SKIP() << "no GPU backend in this build; there is no standing pool on the CPU route";
+#endif
+}
+
+TEST(ServerAnalysisRunGpuPool, FixedSeedCollapsesThePoolToOneWorker) {
+#if defined(__APPLE__) || defined(LUMICE_CUDA_ENABLED)
+  if (!GpuRouteAvailable()) {
+    GTEST_SKIP() << "GPU route unavailable on this machine (or overridden by LUMICE_TRACE_BACKEND)";
+  }
+  constexpr uint32_t kSeed = 1;
+  const nlohmann::json scene = Halo22Config(20000);
+  // num_workers=4 asks for a four-worker pool; the seed must win (one worker), or the
+  // sessions below diverge — the merge order of four producers is not deterministic.
+  Server server(4, kSeed, kGpuBackend);
+  const AnalysisFingerprint first = RunAnalysisAndFingerprint(server, scene);
+  ASSERT_FALSE(first.rows.empty());
+  ASSERT_EQ(first.sim_ray_num, 20000u);
+  ASSERT_FALSE(server.CommitConfig(scene));  // a GPU render in between, then Stop()
+  ASSERT_EQ(WaitForRunToEnd(server, 30000), SimLifecycle::kCompleted);
+  server.Stop();
+  const AnalysisFingerprint after_render = RunAnalysisAndFingerprint(server, scene);
+  const AnalysisFingerprint after_analysis = RunAnalysisAndFingerprint(server, scene);
+  EXPECT_TRUE(after_render == first) << "session 2 (after a GPU render + Stop) differs from session 1";
+  EXPECT_TRUE(after_analysis == first) << "session 3 (after an analysis) differs from session 1";
+  server.Stop();
+
+  // And the same as the CPU-route server's: the pool's one worker and the CPU route's one
+  // worker both hold sim_seed, so a seeded analysis does not depend on the backend toggle.
+  Server cpu_server(0, kSeed, BackendKind::kCpu);
+  const AnalysisFingerprint cpu = RunAnalysisAndFingerprint(cpu_server, scene);
+  EXPECT_TRUE(cpu == first) << "the GPU-preferred server's seeded analysis differs from the CPU-preferred server's";
+  cpu_server.Stop();
+#else
+  GTEST_SKIP() << "no GPU backend in this build";
+#endif
+}
+
+TEST(ServerAnalysisRunGpuPool, AlternatingRenderAndAnalysisNeitherDeadlocksNorLeaks) {
+#if defined(__APPLE__) || defined(LUMICE_CUDA_ENABLED)
+  if (!GpuRouteAvailable()) {
+    GTEST_SKIP() << "GPU route unavailable on this machine (or overridden by LUMICE_TRACE_BACKEND)";
+  }
+  const nlohmann::json unbounded = Halo22Config("infinite");
+  Server server(4, 0, kGpuBackend);
+  // One round, as a callable: every step's precondition is the step before it, so a
+  // fatal assert must end the round (it returns from this lambda) — and the rounds are
+  // not independent rows either, each starts from the Stop()ped state the last one left,
+  // so a failed round ends the loop below explicitly rather than driving four more rounds
+  // off a state that is not their precondition.
+  const auto run_round = [&](int round) {
+    SCOPED_TRACE("round " + std::to_string(round));
+    // Shape 1: a render submitted over a running analysis. Refused, and the analysis is
+    // untouched — still running, still counting.
+    ASSERT_FALSE(server.StartRaypathAnalysis(unbounded, FullSkyRequest()));
+    ASSERT_TRUE(WaitForFirstRays(server, 10000)) << "the analysis never reached its first rays";
+    ASSERT_EQ(server.GetSimLifecycle(), SimLifecycle::kRunning);
+    ASSERT_EQ(server.GetSessionKind(), SessionKind::kAnalysis);
+    EXPECT_TRUE(server.CommitConfig(unbounded)) << "a commit over a running analysis must be refused";
+    ASSERT_EQ(server.GetSessionKind(), SessionKind::kAnalysis);
+    const size_t before = server.GetLiveSimRayCount();
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    EXPECT_GT(server.GetLiveSimRayCount(), before) << "the refused commit stalled the analysis";
+    EXPECT_EQ(server.GetActiveBackend(), BackendKind::kCpu);
+    {
+      auto frame = server.AcquireResultFrame();
+      EXPECT_TRUE(frame->raypath_histogram_result_.has_value());
+      EXPECT_TRUE(frame->render_results_.empty()) << "a render result inside an analysis session";
+    }
+    server.Stop();
+    ASSERT_NE(server.GetSimLifecycle(), SimLifecycle::kRunning) << "Stop() returned with the analysis running";
+
+    // Shape 2: a render, Stop()ped mid-flight, and an analysis started at once. The
+    // engine must let go and the pool must take over, with no batch of the render in
+    // the analysis's frame.
+    ASSERT_FALSE(server.CommitConfig(unbounded));
+    ASSERT_TRUE(WaitForFirstRays(server, 10000)) << "the render never reached its first rays";
+    ASSERT_EQ(server.GetSessionKind(), SessionKind::kRender);
+    EXPECT_EQ(server.GetActiveBackend(), kGpuBackend);
+    {
+      auto frame = server.AcquireResultFrame();
+      EXPECT_FALSE(frame->raypath_histogram_result_.has_value()) << "a histogram inside a render session";
+    }
+    server.Stop();
+    ASSERT_NE(server.GetSimLifecycle(), SimLifecycle::kRunning) << "Stop() returned with the render running";
+    ASSERT_FALSE(server.StartRaypathAnalysis(unbounded, FullSkyRequest()));
+    ASSERT_TRUE(WaitForFirstRays(server, 10000)) << "the analysis after a stopped render never started";
+    {
+      auto frame = server.AcquireResultFrame();
+      EXPECT_TRUE(frame->raypath_histogram_result_.has_value());
+      EXPECT_TRUE(frame->render_results_.empty()) << "the stopped render's result leaked into the analysis";
+    }
+    server.Stop();
+    ASSERT_NE(server.GetSimLifecycle(), SimLifecycle::kRunning);
+  };
+  for (int round = 0; round < 5; round++) {
+    run_round(round);
+    if (::testing::Test::HasFailure()) {
+      break;
+    }
+  }
+#else
+  GTEST_SKIP() << "no GPU backend in this build";
+#endif
+}
+
+TEST(ServerAnalysisRunGpuPool, DestructionDuringAnalysisTerminates) {
+#if defined(__APPLE__) || defined(LUMICE_CUDA_ENABLED)
+  if (!GpuRouteAvailable()) {
+    GTEST_SKIP() << "GPU route unavailable on this machine (or overridden by LUMICE_TRACE_BACKEND)";
+  }
+  auto server = std::make_unique<Server>(4, 0, kGpuBackend);
+  ASSERT_FALSE(server->StartRaypathAnalysis(Halo22Config("infinite"), FullSkyRequest()));
+  ASSERT_TRUE(WaitForFirstRays(*server, 10000));
+  // Destroy from another thread so a hang is a bounded failure here, not a silent one at
+  // the process's exit. A dtor that never returns leaves that thread blocked; the test
+  // reports it and the process-level timeout finishes the job.
+  std::atomic_bool destroyed{ false };
+  std::thread destroyer([&] {
+    server.reset();
+    destroyed.store(true);
+  });
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(20);
+  while (!destroyed.load() && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  EXPECT_TRUE(destroyed.load()) << "~Server() did not return within 20 s with an analysis in flight";
+  if (destroyed.load()) {
+    destroyer.join();
+  } else {
+    destroyer.detach();
+  }
+#else
+  GTEST_SKIP() << "no GPU backend in this build";
 #endif
 }
 


### PR DESCRIPTION
## Summary

Raypath analysis on a GPU-preferred server ran on a single core: the GPU route builds one engine simulator, and the analysis session forced that one simulator to CPU. This lands the owner's chosen shape — a **standing CPU worker pool owned by the server** (not a GUI-side server rebuild), so it applies equally to CLI / C API consumers and costs nothing while idle.

- **Pool** (`ServerImpl::analysis_pool_simulators_`): a GPU-route server additionally builds `min(PhysicalCoreCount(), kMaxDefaultWorkerCount)` CPU-preferred simulators at construction; a CPU-route server builds no second group (analysis reuses its workers). Threads share `simulator_threads_` — spawned at construction, joined at destruction, parked on `start_cv_`; no new lifecycle surface. Startup log gains `analysis_pool_worker_count=`.
- **Selective wake** (`RunPersistentLoop(work_fn, required_mode)`): the wait predicate checks `kTerminating` first and alone, then `kRunning && new generation && mode matches`. Engine threads wake for `kRender`, pool threads for `kAnalysis`, CPU-route workers for either. `Start()`/`Stop()` bodies unchanged.
- **Consumers**: `AnalysisWorkers()` (analysis attribute fan-out / reset), `ActiveWorkers()` (`GetStatus()` busy scan — the *awake* group only; scanning both would read the parked group as busy forever after any `Stop()`, since `Simulator::stop_` clears only on the next `Run()`), `AllWorkerGroups()` (`Stop` / dtor / `SetLogLevel` broadcast).
- **Fixed seed**: `sim_seed != 0` collapses the pool to one worker (the `ChainIdMerger` cross-worker red line). Pool seeds share the engine group's base (`sim_seed + i`) — the two groups never run concurrently — which makes a fixed-seed analysis fingerprint reproducible across `preferred_backend`, pinned by test.
- **Behaviour change**: `num_workers` on a GPU-route server now sizes the analysis pool instead of being ignored (`lumice.h` marked; `doc/c_api.md` `LUMICE_ServerConfig` block realigned).
- **Tests** (`test_server_analysis_run.cpp`, six new cases): N=1 vs N=4 chain set / energy share / count conservation; GPU-pool existence evidence (3.4–5.0× progress vs 1 worker); fixed-seed cross-backend fingerprint; 5 rounds render↔analysis alternation without deadlock; bounded termination mid-analysis at destruction. Red-state probe: making the mode filter always-true turns exactly one of 1672 unit cases red.
- Docs: `doc/raypath-analysis-panel.md` §2/§8 as-built (single-core wait times no longer count as GPU-histogram trigger evidence).

Not touched: `Simulator` trace semantics, exit seam, GPU kernels. Idle-memory check: 10-worker pool ≤ +0.3 MB RSS.

## Test plan

- [x] `./scripts/test.sh pr` PASS on the original base (incl. shared-lib + slow e2e); `./scripts/test.sh quick` PASS on the rebased tree (`b10d1bbc`)
- [x] Metal parity rows green (pool is invisible to the render path)
- [x] Five diff gates + `format.sh --check` green over the PR range
- [x] Independent code review APPROVE (0 Critical / 0 Major)
- [ ] Owner: on a Metal-preferred GUI, Analyze a multi-crystal scene and confirm multi-core occupancy / shorter wait (AC5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dy77Edn5Dnx2EdER4W5p6X